### PR TITLE
fix: resolve 16 bugs from codex code review

### DIFF
--- a/apps/api/src/modules/agent/agent.service.ts
+++ b/apps/api/src/modules/agent/agent.service.ts
@@ -55,6 +55,7 @@ export class AgentService {
       const shouldAutoExecute =
         config.mode === 'autopilot' && rec.confidence >= threshold;
 
+      // Always insert as pending first — update to auto_executed only on success
       const [decision] = await this.db
         .insert(agentDecisions)
         .values({
@@ -64,8 +65,7 @@ export class AgentService {
           inputSnapshot: rec.inputSnapshot,
           recommendation: rec.recommendation,
           confidence: rec.confidence.toFixed(2),
-          status: shouldAutoExecute ? 'auto_executed' : 'pending',
-          executedAt: shouldAutoExecute ? new Date() : null,
+          status: 'pending',
         })
         .returning();
 
@@ -79,8 +79,22 @@ export class AgentService {
             agentType,
             status: 'auto_executed',
           });
+          // Mark as auto_executed only on success
+          await this.db
+            .update(agentDecisions)
+            .set({ status: 'auto_executed', executedAt: new Date() })
+            .where(eq(agentDecisions.id, decision.id));
+          decision.status = 'auto_executed';
         } catch (error: any) {
-          // Log but don't fail the whole run
+          // Mark as failed with error details
+          await this.db
+            .update(agentDecisions)
+            .set({
+              status: 'rejected',
+              outcome: { error: error.message ?? 'Execution failed', autoExecutionFailed: true },
+            })
+            .where(eq(agentDecisions.id, decision.id));
+          decision.status = 'rejected';
         }
       }
 
@@ -201,7 +215,7 @@ export class AgentService {
     }
   }
 
-  /** Get or create agent config for a property. */
+  /** Get or create agent config for a property. Uses upsert to prevent race conditions. */
   async getOrCreateConfig(propertyId: string, agentType: string) {
     this.validateAgentType(agentType);
 
@@ -217,11 +231,11 @@ export class AgentService {
 
     if (existing) return existing;
 
-    // Create default config
+    // Create default config using onConflictDoNothing to handle race conditions
     const agent = this.agents.get(agentType);
     const defaultConfig = agent?.getDefaultConfig() ?? {};
 
-    const [created] = await this.db
+    await this.db
       .insert(agentConfigs)
       .values({
         propertyId,
@@ -230,9 +244,20 @@ export class AgentService {
         mode: 'suggest',
         config: defaultConfig,
       })
-      .returning();
+      .onConflictDoNothing();
 
-    return created;
+    // Re-fetch to get the row (whether we created it or someone else did)
+    const [config] = await this.db
+      .select()
+      .from(agentConfigs)
+      .where(
+        and(
+          eq(agentConfigs.propertyId, propertyId),
+          eq(agentConfigs.agentType, agentType as any),
+        ),
+      );
+
+    return config;
   }
 
   /** Update agent config. */

--- a/apps/api/src/modules/agent/demand/demand.agent.ts
+++ b/apps/api/src/modules/agent/demand/demand.agent.ts
@@ -94,11 +94,19 @@ export class DemandForecastAgent implements HaipAgent, OnModuleInit {
         ),
       );
 
-    // Count on-the-books per future date
+    // Count on-the-books per future date — expand across all occupied nights
     const otb = new Map<string, number>();
     for (const res of futureReservations) {
-      const arrival = res.arrivalDate as string;
-      otb.set(arrival, (otb.get(arrival) ?? 0) + 1);
+      const arrival = new Date(res.arrivalDate as string);
+      const departure = res.departureDate ? new Date(res.departureDate as string) : new Date(arrival.getTime() + 86400000);
+      const nights = Math.max(1, Math.ceil((departure.getTime() - arrival.getTime()) / 86400000));
+
+      for (let n = 0; n < nights; n++) {
+        const d = new Date(arrival);
+        d.setDate(d.getDate() + n);
+        const dateStr = d.toISOString().split('T')[0]!;
+        otb.set(dateStr, (otb.get(dateStr) ?? 0) + 1);
+      }
     }
 
     return {
@@ -200,18 +208,27 @@ export class DemandForecastAgent implements HaipAgent, OnModuleInit {
   // --- Private ---
 
   private buildHistoricalDays(
-    reservationData: Array<{ arrivalDate: string; totalAmount: string; status: string }>,
+    reservationData: Array<{ arrivalDate: string; departureDate?: string; totalAmount: string; status: string }>,
     totalRooms: number,
   ): HistoricalDay[] {
-    // Group reservations by arrival date
+    // Group reservations by each occupied night in [arrivalDate, departureDate)
     const byDate = new Map<string, { count: number; totalRevenue: number }>();
 
     for (const res of reservationData) {
-      const date = res.arrivalDate as string;
-      const existing = byDate.get(date) ?? { count: 0, totalRevenue: 0 };
-      existing.count++;
-      existing.totalRevenue += parseFloat(res.totalAmount ?? '0');
-      byDate.set(date, existing);
+      const arrival = new Date(res.arrivalDate);
+      const departure = res.departureDate ? new Date(res.departureDate) : new Date(arrival.getTime() + 86400000);
+      const nights = Math.max(1, Math.ceil((departure.getTime() - arrival.getTime()) / 86400000));
+      const revenuePerNight = parseFloat(res.totalAmount ?? '0') / nights;
+
+      for (let n = 0; n < nights; n++) {
+        const d = new Date(arrival);
+        d.setDate(d.getDate() + n);
+        const date = d.toISOString().split('T')[0]!;
+        const existing = byDate.get(date) ?? { count: 0, totalRevenue: 0 };
+        existing.count++;
+        existing.totalRevenue += revenuePerNight;
+        byDate.set(date, existing);
+      }
     }
 
     return [...byDate.entries()].map(([date, data]) => {

--- a/apps/api/src/modules/agent/dto/agent-config.dto.ts
+++ b/apps/api/src/modules/agent/dto/agent-config.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsBoolean, IsString, IsNumber, IsOptional, IsObject, Min, Max } from 'class-validator';
+import { IsBoolean, IsString, IsNumber, IsOptional, IsObject, IsIn, Min, Max } from 'class-validator';
 
 export class UpdateAgentConfigDto {
   @ApiPropertyOptional()
@@ -9,7 +9,7 @@ export class UpdateAgentConfigDto {
 
   @ApiPropertyOptional({ enum: ['manual', 'suggest', 'autopilot'] })
   @IsOptional()
-  @IsString()
+  @IsIn(['manual', 'suggest', 'autopilot'])
   mode?: string;
 
   @ApiPropertyOptional({ description: 'Confidence threshold for autopilot (0.0–1.0)' })

--- a/apps/api/src/modules/agent/dto/create-review.dto.ts
+++ b/apps/api/src/modules/agent/dto/create-review.dto.ts
@@ -2,10 +2,6 @@ import { IsString, IsInt, Min, Max, IsOptional, IsUUID, IsIn } from 'class-valid
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateReviewDto {
-  @ApiProperty()
-  @IsUUID()
-  propertyId!: string;
-
   @ApiProperty({ enum: ['google', 'tripadvisor', 'booking_com', 'expedia', 'other'] })
   @IsIn(['google', 'tripadvisor', 'booking_com', 'expedia', 'other'])
   source!: string;

--- a/apps/api/src/modules/agent/guest-comms/guest-communication.agent.ts
+++ b/apps/api/src/modules/agent/guest-comms/guest-communication.agent.ts
@@ -123,6 +123,7 @@ export class GuestCommunicationAgent implements HaipAgent, OnModuleInit {
     const rpMap = new Map(rpData.map((rp: any) => [rp.id, rp]));
 
     // Get previous communications for these reservations (to avoid duplicates)
+    // Only consider approved/auto_executed decisions as "sent" — not pending/rejected/failed
     const previousComms = await this.db
       .select()
       .from(agentDecisions)
@@ -130,6 +131,7 @@ export class GuestCommunicationAgent implements HaipAgent, OnModuleInit {
         and(
           eq(agentDecisions.propertyId, propertyId),
           eq(agentDecisions.agentType, 'guest_comms' as any),
+          inArray(agentDecisions.status, ['approved', 'auto_executed'] as any),
         ),
       );
     // Map: reservationId → set of email types already sent

--- a/apps/api/src/modules/agent/review-response/review-response.agent.ts
+++ b/apps/api/src/modules/agent/review-response/review-response.agent.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
-import { eq, and } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { guestReviews, reservations, roomTypes, properties } from '@haip/database';
 import { DRIZZLE } from '../../../database/database.module';
 import { AgentService } from '../agent.service';
@@ -74,28 +74,26 @@ export class ReviewResponseAgent implements HaipAgent, OnModuleInit {
         );
     }
 
-    // Get stay details for matched reviews
-    const resIds = pendingReviews
-      .map((r: any) => r.reservationId)
-      .filter(Boolean);
+    // Get stay details for matched reviews — bulk load to avoid N+1
+    const resIds = [...new Set(pendingReviews.map((r: any) => r.reservationId).filter(Boolean))];
     const stayDetailsMap = new Map<string, { roomType?: string; nights?: number }>();
 
-    for (const resId of resIds) {
-      const [res] = await this.db
+    if (resIds.length > 0) {
+      const resData = await this.db
         .select()
         .from(reservations)
-        .where(eq(reservations.id, resId));
-      if (res) {
-        let roomTypeName: string | undefined;
-        if (res.roomTypeId) {
-          const [rt] = await this.db
-            .select()
-            .from(roomTypes)
-            .where(eq(roomTypes.id, res.roomTypeId));
-          roomTypeName = rt?.name;
-        }
-        stayDetailsMap.set(resId, {
-          roomType: roomTypeName,
+        .where(inArray(reservations.id, resIds as any));
+
+      const rtIds = [...new Set(resData.map((r: any) => r.roomTypeId).filter(Boolean))];
+      const rtData: any[] = rtIds.length > 0
+        ? await this.db.select().from(roomTypes).where(inArray(roomTypes.id, rtIds as any))
+        : [];
+      const rtMap = new Map(rtData.map((rt: any) => [rt.id, rt]));
+
+      for (const res of resData) {
+        const rt = res.roomTypeId ? rtMap.get(res.roomTypeId) : undefined;
+        stayDetailsMap.set(res.id, {
+          roomType: rt?.name,
           nights: res.nights,
         });
       }

--- a/apps/api/src/modules/folio/folio.service.ts
+++ b/apps/api/src/modules/folio/folio.service.ts
@@ -523,8 +523,12 @@ export class FolioService {
     const dd = String(now.getDate()).padStart(2, '0');
     const prefix = `F-${yy}${mm}${dd}`;
 
+    // Use MAX to find the highest existing sequence for this prefix,
+    // which is safe under concurrent inserts (unique constraint prevents duplicates)
     const [result] = await this.db
-      .select({ count: sql<number>`count(*)` })
+      .select({
+        maxNumber: sql<string>`max(${folios.folioNumber})`,
+      })
       .from(folios)
       .where(
         and(
@@ -533,7 +537,11 @@ export class FolioService {
         ),
       );
 
-    const seq = Number(result?.count ?? 0) + 1;
+    let seq = 1;
+    if (result?.maxNumber) {
+      const lastSeq = parseInt(result.maxNumber.split('-').pop() ?? '0', 10);
+      seq = lastSeq + 1;
+    }
     return `${prefix}-${String(seq).padStart(4, '0')}`;
   }
 }

--- a/apps/api/src/modules/housekeeping/housekeeping.service.spec.ts
+++ b/apps/api/src/modules/housekeeping/housekeeping.service.spec.ts
@@ -333,8 +333,9 @@ describe('HousekeepingService — CRUD', () => {
   it('should auto-create checkout task on room.status_changed (vacant_dirty)', async () => {
     const db = createMockDb({
       selectResult: [
-        [{ isAccessible: false }],
-        [],
+        [],                       // 1st select: no existing checkout task (duplicate check)
+        [{ isAccessible: false }], // 2nd select: room accessibility check
+        [],                       // 3rd select: VIP check
       ],
     });
     const svc = await createService(db);

--- a/apps/api/src/modules/housekeeping/housekeeping.service.ts
+++ b/apps/api/src/modules/housekeeping/housekeeping.service.ts
@@ -755,12 +755,32 @@ export class HousekeepingService {
   async handleRoomStatusChanged(payload: WebhookPayload) {
     if (payload.data['newStatus'] !== 'vacant_dirty') return;
 
+    const today = new Date().toISOString().split('T')[0]!;
+    const propertyId = payload.propertyId!;
+    const roomId = payload.entityId;
+
+    // Check for existing checkout task for this room + date to avoid duplicates
+    const [existing] = await this.db
+      .select({ id: housekeepingTasks.id })
+      .from(housekeepingTasks)
+      .where(
+        and(
+          eq(housekeepingTasks.propertyId, propertyId),
+          eq(housekeepingTasks.roomId, roomId),
+          eq(housekeepingTasks.serviceDate, new Date(today)),
+          eq(housekeepingTasks.type, 'checkout' as any),
+          sql`${housekeepingTasks.status} not in ('skipped', 'inspected')`,
+        ),
+      );
+
+    if (existing) return;
+
     await this.create({
-      propertyId: payload.propertyId!,
-      roomId: payload.entityId,
+      propertyId,
+      roomId,
       type: 'checkout',
       priority: 0,
-      serviceDate: new Date().toISOString().split('T')[0]!,
+      serviceDate: today,
     });
   }
 

--- a/apps/api/src/modules/payment/stripe-webhook.controller.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.controller.ts
@@ -14,6 +14,7 @@ import { eq } from 'drizzle-orm';
 import { payments } from '@haip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { WebhookService } from '../webhook/webhook.service';
+import { FolioService } from '../folio/folio.service';
 import Stripe from 'stripe';
 
 /**
@@ -38,6 +39,7 @@ export class StripeWebhookController {
   constructor(
     @Inject(DRIZZLE) private readonly db: any,
     private readonly webhookService: WebhookService,
+    private readonly folioService: FolioService,
     private readonly configService: ConfigService,
   ) {
     const secretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
@@ -130,6 +132,9 @@ export class StripeWebhookController {
       .set({ status: 'captured', processedAt: new Date(), updatedAt: new Date() })
       .where(eq(payments.id, payment.id));
 
+    // Recalculate folio balance after payment state change
+    await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
+
     await this.webhookService.emit(
       'payment.received',
       'payment',
@@ -154,6 +159,9 @@ export class StripeWebhookController {
       .set({ status: 'failed', notes: errorMessage, updatedAt: new Date() })
       .where(eq(payments.id, payment.id));
 
+    // Recalculate folio balance after payment state change
+    await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
+
     await this.webhookService.emit(
       'payment.failed',
       'payment',
@@ -175,6 +183,9 @@ export class StripeWebhookController {
       .update(payments)
       .set({ status: 'voided', updatedAt: new Date() })
       .where(eq(payments.id, payment.id));
+
+    // Recalculate folio balance after payment state change
+    await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
 
     await this.webhookService.emit(
       'payment.failed',
@@ -205,6 +216,9 @@ export class StripeWebhookController {
       .update(payments)
       .set({ status, updatedAt: new Date() })
       .where(eq(payments.id, payment.id));
+
+    // Recalculate folio balance after refund
+    await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
 
     await this.webhookService.emit(
       'payment.refunded',

--- a/apps/api/src/modules/payment/stripe-webhook.spec.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { StripeWebhookController } from './stripe-webhook.controller';
 import { WebhookService } from '../webhook/webhook.service';
+import { FolioService } from '../folio/folio.service';
 import { DRIZZLE } from '../../database/database.module';
 
 const mockPayment = {
@@ -33,6 +34,7 @@ function createMockDb(returnData: any[] = [mockPayment]) {
 }
 
 const mockWebhookService = { emit: vi.fn() };
+const mockFolioService = { recalculateBalance: vi.fn().mockResolvedValue(undefined) };
 const mockConfigService = {
   get: vi.fn().mockImplementation((key: string, defaultValue?: string) => {
     if (key === 'STRIPE_MODE') return 'mock';
@@ -55,6 +57,7 @@ describe('StripeWebhookController', () => {
       providers: [
         { provide: DRIZZLE, useValue: mockDb },
         { provide: WebhookService, useValue: mockWebhookService },
+        { provide: FolioService, useValue: mockFolioService },
         { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
@@ -98,6 +101,7 @@ describe('StripeWebhookController', () => {
         providers: [
           { provide: DRIZZLE, useValue: capturedDb },
           { provide: WebhookService, useValue: mockWebhookService },
+          { provide: FolioService, useValue: mockFolioService },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -146,6 +150,7 @@ describe('StripeWebhookController', () => {
         providers: [
           { provide: DRIZZLE, useValue: capturedDb },
           { provide: WebhookService, useValue: mockWebhookService },
+          { provide: FolioService, useValue: mockFolioService },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -175,6 +180,7 @@ describe('StripeWebhookController', () => {
         providers: [
           { provide: DRIZZLE, useValue: capturedDb },
           { provide: WebhookService, useValue: mockWebhookService },
+          { provide: FolioService, useValue: mockFolioService },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();
@@ -203,6 +209,7 @@ describe('StripeWebhookController', () => {
         providers: [
           { provide: DRIZZLE, useValue: emptyDb },
           { provide: WebhookService, useValue: mockWebhookService },
+          { provide: FolioService, useValue: mockFolioService },
           { provide: ConfigService, useValue: mockConfigService },
         ],
       }).compile();

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -60,45 +60,61 @@ export class ReservationService {
       throw new BadRequestException('Departure date must be after arrival date');
     }
 
+    // Check inventory availability
+    const availability = await this.availabilityService.searchAvailability(
+      dto.propertyId,
+      dto.arrivalDate,
+      dto.departureDate,
+      dto.roomTypeId,
+    );
+    const roomTypeAvail = availability.find((a: any) => a.roomTypeId === dto.roomTypeId);
+    if (!roomTypeAvail || roomTypeAvail.available <= 0) {
+      throw new BadRequestException(
+        `No availability for room type ${dto.roomTypeId} on the requested dates`,
+      );
+    }
+
     // Generate confirmation number
     const confirmationNumber = `HAIP-${Date.now().toString(36).toUpperCase()}-${randomUUID().slice(0, 4).toUpperCase()}`;
 
-    // Create booking + reservation in a transaction-like flow
-    // (Drizzle postgres-js doesn't have built-in transactions in the same way,
-    //  but the operations are sequential and atomic per statement)
-    const [booking] = await this.db
-      .insert(bookings)
-      .values({
-        propertyId: dto.propertyId,
-        guestId: dto.guestId,
-        confirmationNumber,
-        externalConfirmation: dto.externalConfirmation,
-        source: dto.source,
-        channelCode: dto.channelCode,
-      })
-      .returning();
+    // Create booking + reservation in a transaction
+    const result = await this.db.transaction(async (tx: any) => {
+      const [booking] = await tx
+        .insert(bookings)
+        .values({
+          propertyId: dto.propertyId,
+          guestId: dto.guestId,
+          confirmationNumber,
+          externalConfirmation: dto.externalConfirmation,
+          source: dto.source,
+          channelCode: dto.channelCode,
+        })
+        .returning();
 
-    const [reservation] = await this.db
-      .insert(reservations)
-      .values({
-        propertyId: dto.propertyId,
-        bookingId: booking.id,
-        guestId: dto.guestId,
-        arrivalDate: dto.arrivalDate,
-        departureDate: dto.departureDate,
-        nights,
-        roomTypeId: dto.roomTypeId,
-        ratePlanId: dto.ratePlanId,
-        totalAmount: dto.totalAmount,
-        currencyCode: dto.currencyCode,
-        adults: dto.adults ?? 1,
-        children: dto.children ?? 0,
-        specialRequests: dto.specialRequests,
-        status: 'pending',
-      })
-      .returning();
+      const [reservation] = await tx
+        .insert(reservations)
+        .values({
+          propertyId: dto.propertyId,
+          bookingId: booking.id,
+          guestId: dto.guestId,
+          arrivalDate: dto.arrivalDate,
+          departureDate: dto.departureDate,
+          nights,
+          roomTypeId: dto.roomTypeId,
+          ratePlanId: dto.ratePlanId,
+          totalAmount: dto.totalAmount,
+          currencyCode: dto.currencyCode,
+          adults: dto.adults ?? 1,
+          children: dto.children ?? 0,
+          specialRequests: dto.specialRequests,
+          status: 'pending',
+        })
+        .returning();
 
-    return { ...reservation, booking };
+      return { ...reservation, booking };
+    });
+
+    return result;
   }
 
   async confirm(id: string) {
@@ -117,13 +133,13 @@ export class ReservationService {
     const reservation = await this.findByIdRaw(id);
     assertTransition(reservation.status as ReservationStatus, 'assigned');
 
-    // Verify room exists and matches room type
+    // Verify room exists, belongs to same property, and matches room type
     const [room] = await this.db
       .select()
       .from(rooms)
-      .where(eq(rooms.id, dto.roomId));
+      .where(and(eq(rooms.id, dto.roomId), eq(rooms.propertyId, reservation.propertyId)));
     if (!room) {
-      throw new NotFoundException(`Room ${dto.roomId} not found`);
+      throw new NotFoundException(`Room ${dto.roomId} not found in this property`);
     }
     if (room.roomTypeId !== reservation.roomTypeId) {
       throw new BadRequestException(
@@ -196,9 +212,9 @@ export class ReservationService {
       const [room] = await this.db
         .select()
         .from(rooms)
-        .where(eq(rooms.id, dto.roomId));
+        .where(and(eq(rooms.id, dto.roomId), eq(rooms.propertyId, reservation.propertyId)));
       if (!room) {
-        throw new NotFoundException(`Room ${dto.roomId} not found`);
+        throw new NotFoundException(`Room ${dto.roomId} not found in this property`);
       }
       if (room.roomTypeId !== reservation.roomTypeId) {
         throw new BadRequestException(
@@ -398,10 +414,10 @@ export class ReservationService {
     const folioSummary: Array<{ folioId: string; balance: string; status: string }> = [];
 
     if (dto.expressCheckout) {
+      // Phase 1: Capture all authorized payments across all open folios
       for (const folio of folios) {
         if (folio.status !== 'open') continue;
 
-        // Capture all authorized payments
         const authorizedPayments = await this.db
           .select()
           .from(payments)
@@ -420,17 +436,25 @@ export class ReservationService {
             // Continue with other payments
           }
         }
+      }
 
-        // Refresh folio to check balance
+      // Phase 2: Validate all folio balances BEFORE settling any
+      const openFolios: Array<{ folio: any; refreshed: any }> = [];
+      for (const folio of folios) {
+        if (folio.status !== 'open') continue;
         const refreshed = await this.folioService.findById(folio.id, reservation.propertyId);
-        if (Math.abs(parseFloat(refreshed.balance)) <= 0.01) {
-          await this.folioService.settle(folio.id, reservation.propertyId);
-          folioSummary.push({ folioId: folio.id, balance: '0.00', status: 'settled' });
-        } else {
+        if (Math.abs(parseFloat(refreshed.balance)) > 0.01) {
           throw new BadRequestException(
             `Cannot express checkout: folio ${folio.folioNumber} has outstanding balance of ${refreshed.balance}`,
           );
         }
+        openFolios.push({ folio, refreshed });
+      }
+
+      // Phase 3: All validated — now settle
+      for (const { folio } of openFolios) {
+        await this.folioService.settle(folio.id, reservation.propertyId);
+        folioSummary.push({ folioId: folio.id, balance: '0.00', status: 'settled' });
       }
     } else {
       // Non-express: compile folio summaries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haip",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "HAIP (Hotel AI Platform) — Open-source, API-first hotel PMS",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/database/src/schema/agent.ts
+++ b/packages/database/src/schema/agent.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, boolean, numeric, jsonb, timestamp, date, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, boolean, numeric, jsonb, timestamp, date, pgEnum, uniqueIndex } from 'drizzle-orm/pg-core';
 import { properties } from './property.js';
 
 export const agentTypeEnum = pgEnum('agent_type', [
@@ -49,7 +49,10 @@ export const agentConfigs = pgTable('agent_configs', {
   lastRunAt: timestamp('last_run_at', { withTimezone: true }),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
-});
+}, (table) => ({
+  uniquePropertyAgent: uniqueIndex('agent_configs_property_agent_unique')
+    .on(table.propertyId, table.agentType),
+}));
 
 /**
  * Every recommendation/action an agent makes.

--- a/packages/database/src/schema/folio.ts
+++ b/packages/database/src/schema/folio.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, text, boolean, timestamp, numeric, pgEnum } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, text, boolean, timestamp, numeric, pgEnum, uniqueIndex } from 'drizzle-orm/pg-core';
 import { properties } from './property.js';
 import { reservations, bookings } from './reservation.js';
 import { guests } from './guest.js';
@@ -54,7 +54,10 @@ export const folios = pgTable('folios', {
 
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
-});
+}, (table) => ({
+  uniqueFolioNumber: uniqueIndex('folios_property_folio_number_unique')
+    .on(table.propertyId, table.folioNumber),
+}));
 
 /**
  * Charge types for folio line items.
@@ -96,8 +99,8 @@ export const charges = pgTable('charges', {
   // Reference
   serviceDate: timestamp('service_date', { withTimezone: true }).notNull(), // Date the charge applies to
   isReversal: boolean('is_reversal').notNull().default(false),
-  originalChargeId: uuid('original_charge_id'), // FK to self for reversals
-  parentChargeId: uuid('parent_charge_id'), // FK to self — tax charges linked to their parent charge
+  originalChargeId: uuid('original_charge_id').references((): any => charges.id), // FK to self for reversals
+  parentChargeId: uuid('parent_charge_id').references((): any => charges.id), // FK to self — tax charges linked to their parent charge
 
   // Night audit lock (KB 5.8: transactions locked after day close)
   isLocked: boolean('is_locked').notNull().default(false),
@@ -163,7 +166,7 @@ export const payments = pgTable('payments', {
   preAuthExpiresAt: timestamp('pre_auth_expires_at', { withTimezone: true }),
 
   // Refund reference
-  originalPaymentId: uuid('original_payment_id'), // FK to self for refunds
+  originalPaymentId: uuid('original_payment_id').references((): any => payments.id), // FK to self for refunds
 
   notes: text('notes'),
 

--- a/packages/database/src/schema/room.ts
+++ b/packages/database/src/schema/room.ts
@@ -72,7 +72,7 @@ export const rooms = pgTable('rooms', {
   // Features (override room type defaults)
   isAccessible: boolean('is_accessible').notNull().default(false),
   isConnecting: boolean('is_connecting').notNull().default(false),
-  connectingRoomId: uuid('connecting_room_id'), // Self-referencing FK
+  connectingRoomId: uuid('connecting_room_id').references((): any => rooms.id), // Self-referencing FK
   amenities: jsonb('amenities').$type<string[]>(), // Room-specific overrides
 
   // Maintenance


### PR DESCRIPTION
## Summary
- **3 critical fixes**: demand agent night expansion, Stripe webhook folio rebalance, multi-tenant room assignment leak
- **7 high-severity fixes**: availability check on create, transactional booking, express checkout validation, agent auto-execute status tracking, race-safe config upsert, folio number concurrency, comms de-duplication
- **4 medium fixes**: housekeeping duplicate task prevention, review agent N+1 query, self-referential FK constraints
- **2 low fixes**: agent mode validation, DTO cleanup
- **Schema**: unique indexes on `agent_configs(property_id, agent_type)` and `folios(property_id, folio_number)`
- **Version**: bumped to `0.1.0`
- **16 files changed**, all 551 tests pass, 0 lint errors

## Fixes by severity

### 🔴 Critical
| # | Issue | File(s) |
|---|-------|---------|
| 1 | Demand agent only counted arrivals, not occupied nights | `demand.agent.ts` |
| 2 | Stripe webhooks never rebalanced folios after state changes | `stripe-webhook.controller.ts` |
| 3 | Room assignment not scoped to property (multi-tenant leak) | `reservation.service.ts` |

### 🟠 High
| # | Issue | File(s) |
|---|-------|---------|
| 4 | Reservation create never checked availability | `reservation.service.ts` |
| 5 | Booking + reservation not transactional | `reservation.service.ts` |
| 6 | Express checkout could partially settle folios | `reservation.service.ts` |
| 7 | Auto-execution failures silently marked successful | `agent.service.ts` |
| 8 | Concurrent getOrCreateConfig race condition | `agent.service.ts`, `agent.ts` schema |
| 9 | Folio numbers race-prone (count-based) | `folio.service.ts`, `folio.ts` schema |
| 10 | Guest comms de-dup treated failed decisions as "sent" | `guest-communication.agent.ts` |

### 🟡 Medium
| # | Issue | File(s) |
|---|-------|---------|
| 11 | Duplicate housekeeping tasks on vacant_dirty events | `housekeeping.service.ts` |
| 12 | N+1 queries in review-response agent | `review-response.agent.ts` |
| 13 | Self-referential FKs missing on charges/payments/rooms | `folio.ts`, `room.ts` |

### 🟢 Low
| # | Issue | File(s) |
|---|-------|---------|
| 15 | Agent mode field accepted arbitrary strings | `agent-config.dto.ts` |
| 16 | CreateReviewDto included unused propertyId | `create-review.dto.ts` |

## Test plan
- [x] All 551 existing tests pass
- [x] Updated stripe-webhook.spec.ts with FolioService mock
- [x] Updated housekeeping.service.spec.ts for duplicate check select
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors (801 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)