### PR TITLE
fix: resolve 9 bugs from second codex review

### DIFF
--- a/apps/api/src/modules/agent/cancellation/cancellation-predictor.agent.ts
+++ b/apps/api/src/modules/agent/cancellation/cancellation-predictor.agent.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
 import { eq, and, gte, not, inArray } from 'drizzle-orm';
-import { reservations, guests, folios, payments } from '@haip/database';
+import { reservations, guests, folios, payments, bookings } from '@haip/database';
 import { DRIZZLE } from '../../../database/database.module';
 import { AgentService } from '../agent.service';
 import type {
@@ -36,10 +36,16 @@ export class CancellationPredictorAgent implements HaipAgent, OnModuleInit {
   async analyze(propertyId: string, _context?: AgentContext): Promise<AgentAnalysis> {
     const today = new Date().toISOString().split('T')[0]!;
 
-    // Get active reservations (confirmed, pending)
-    const activeRes = await this.db
-      .select()
+    // Get active reservations (confirmed, pending) joined with their booking so we can
+    // see the real booking source. `source` lives on `bookings`, not on `reservations`.
+    const activeResRaw = await this.db
+      .select({
+        reservation: reservations,
+        bookingSource: bookings.source,
+        bookingChannelCode: bookings.channelCode,
+      })
       .from(reservations)
+      .leftJoin(bookings, eq(reservations.bookingId, bookings.id))
       .where(
         and(
           eq(reservations.propertyId, propertyId),
@@ -47,6 +53,12 @@ export class CancellationPredictorAgent implements HaipAgent, OnModuleInit {
           not(inArray(reservations.status, ['cancelled', 'checked_out', 'no_show'] as any)),
         ),
       );
+
+    const activeRes = activeResRaw.map((row: any) => ({
+      ...row.reservation,
+      source: row.bookingSource ?? null,
+      channelCode: row.bookingChannelCode ?? null,
+    }));
 
     // Get guest data for VIP/repeat detection
     const guestIds = [...new Set(activeRes.map((r: any) => r.guestId).filter(Boolean))];

--- a/apps/api/src/modules/agent/night-audit/night-audit-anomaly.agent.ts
+++ b/apps/api/src/modules/agent/night-audit/night-audit-anomaly.agent.ts
@@ -37,14 +37,17 @@ export class NightAuditAnomalyAgent implements HaipAgent, OnModuleInit {
   async analyze(propertyId: string, _context?: AgentContext): Promise<AgentAnalysis> {
     const today = new Date().toISOString().split('T')[0]!;
 
-    // Get checked-in reservations (should have charges posted)
+    // Get in-house + recently checked-out reservations (should have charges posted).
+    // Include checked_out so payment-mismatch detection has a reachable trigger —
+    // previously the mismatch rule required status === 'checked_out' but the query
+    // only selected in-house statuses, making the rule dead code.
     const checkedIn = await this.db
       .select()
       .from(reservations)
       .where(
         and(
           eq(reservations.propertyId, propertyId),
-          inArray(reservations.status, ['checked_in', 'stayover', 'due_out'] as any),
+          inArray(reservations.status, ['checked_in', 'stayover', 'due_out', 'checked_out'] as any),
         ),
       );
 
@@ -176,7 +179,10 @@ export class NightAuditAnomalyAgent implements HaipAgent, OnModuleInit {
           const totalChargesAmt = parseFloat(folio.totalCharges ?? '0');
           const totalPaymentsAmt = parseFloat(folio.totalPayments ?? '0');
           const balance = Math.abs(totalChargesAmt - totalPaymentsAmt);
-          if (totalChargesAmt > 0 && balance > 0.01 && res.status === 'checked_out') {
+          // Payment mismatch is an anomaly when the stay has ended (due_out / checked_out)
+          // but the folio is still open with a non-zero balance.
+          const mismatchStatuses = ['due_out', 'checked_out'];
+          if (totalChargesAmt > 0 && balance > 0.01 && mismatchStatuses.includes(res.status)) {
             anomalies.push({
               anomalyType: 'payment_mismatch',
               severity: getSeverity('payment_mismatch'),

--- a/apps/api/src/modules/agent/overbooking/overbooking.agent.ts
+++ b/apps/api/src/modules/agent/overbooking/overbooking.agent.ts
@@ -51,25 +51,40 @@ export class OverbookingAgent implements HaipAgent, OnModuleInit {
     futureEnd.setDate(futureEnd.getDate() + 14);
     const futureEndStr = futureEnd.toISOString().split('T')[0]!;
 
+    // Pull any reservation whose stay overlaps the next-14-day window.
+    // A reservation arriving day -3 and departing day +1 occupies the target dates from day 0 to day 0.
     const futureRes = await this.db
       .select({
         arrivalDate: reservations.arrivalDate,
+        departureDate: reservations.departureDate,
         status: reservations.status,
       })
       .from(reservations)
       .where(
         and(
           eq(reservations.propertyId, propertyId),
-          gte(reservations.arrivalDate, today),
           lte(reservations.arrivalDate, futureEndStr),
+          gte(reservations.departureDate, today),
           not(inArray(reservations.status, ['cancelled'] as any)),
         ),
       );
 
+    // Expand each reservation across every occupied night [arrivalDate, departureDate)
+    // so counts reflect all stayovers, not just arrivals.
     const otb = new Map<string, number>();
+    const windowStart = new Date(today);
+    const windowEnd = new Date(futureEndStr);
     for (const r of futureRes) {
-      const date = r.arrivalDate as string;
-      otb.set(date, (otb.get(date) ?? 0) + 1);
+      const arrival = new Date(r.arrivalDate as string);
+      const departure = r.departureDate ? new Date(r.departureDate as string) : new Date(arrival.getTime() + 86400000);
+      const nights = Math.max(1, Math.ceil((departure.getTime() - arrival.getTime()) / 86400000));
+      for (let n = 0; n < nights; n++) {
+        const d = new Date(arrival);
+        d.setDate(d.getDate() + n);
+        if (d < windowStart || d > windowEnd) continue;
+        const dateStr = d.toISOString().split('T')[0]!;
+        otb.set(dateStr, (otb.get(dateStr) ?? 0) + 1);
+      }
     }
 
     // Historical no-show rate

--- a/apps/api/src/modules/auth/auth.guard.ts
+++ b/apps/api/src/modules/auth/auth.guard.ts
@@ -26,9 +26,10 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   }
 
   override canActivate(context: ExecutionContext) {
-    // If auth is disabled (dev/testing), allow all requests
-    const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'false');
-    if (authEnabled !== 'true') {
+    // Secure-by-default: auth is ON unless AUTH_ENABLED is explicitly set to 'false'.
+    // Previously this defaulted to 'false' and skipped auth whenever unset — a fail-open bug.
+    const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'true');
+    if (authEnabled === 'false') {
       return true;
     }
 

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com.adapter.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com.adapter.ts
@@ -30,7 +30,7 @@ export class BookingComAdapter implements ChannelAdapter {
   constructor(private readonly configService: ConfigService) {}
 
   async pushAvailability(params: AvailabilityPushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = mapAvailabilityToOta(config.hotelId, params.items);
     const xml = buildOtaXml('OTA_HotelAvailNotifRQ', payload);
 
@@ -48,7 +48,7 @@ export class BookingComAdapter implements ChannelAdapter {
   }
 
   async pushRates(params: RatePushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = mapRatesToOta(config.hotelId, params.items);
     const xml = buildOtaXml('OTA_HotelRateAmountNotifRQ', payload);
 
@@ -66,7 +66,7 @@ export class BookingComAdapter implements ChannelAdapter {
   }
 
   async pushRestrictions(params: RestrictionPushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = mapRestrictionsToOta(config.hotelId, params.items);
     const xml = buildOtaXml('OTA_HotelRateAmountNotifRQ', payload);
 
@@ -84,7 +84,7 @@ export class BookingComAdapter implements ChannelAdapter {
   }
 
   async pullReservations(params: ReservationPullParams): Promise<ChannelReservationResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
 
     const payload: Record<string, unknown> = {
       ReadRequests: {
@@ -126,7 +126,7 @@ export class BookingComAdapter implements ChannelAdapter {
   }
 
   async confirmReservation(params: ConfirmReservationParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = buildReservationConfirmation(
       params.externalConfirmation,
       params.pmsConfirmationNumber,
@@ -143,7 +143,7 @@ export class BookingComAdapter implements ChannelAdapter {
   }
 
   async cancelReservation(params: CancelReservationParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig(params.channelConnectionId);
+    const config = this.resolveConfig(params.connectionConfig);
 
     const payload = {
       UniqueID: {
@@ -253,32 +253,31 @@ export class BookingComAdapter implements ChannelAdapter {
 
   /**
    * Resolve config for a channel connection.
-   * In production, config would come from the channel connection record.
-   * Falls back to env vars for simple setup.
+   * Prefers per-connection credentials from channelConnections.config (passed via params.connectionConfig);
+   * falls back to env vars only when a value is missing from the connection record.
    */
-  private resolveConfig(_channelConnectionId: string): BookingComConfig {
-    return {
-      hotelId: this.configService.get<string>('BOOKING_COM_HOTEL_ID', 'MOCK_HOTEL_1'),
-      username: this.configService.get<string>('BOOKING_COM_USERNAME', 'haip_test'),
-      password: this.configService.get<string>('BOOKING_COM_PASSWORD', 'test_password'),
-      baseUrl: this.configService.get<string>(
-        'BOOKING_COM_BASE_URL',
-        DEFAULT_BOOKING_COM_CONFIG.baseUrl!,
-      ),
-      timeoutMs: DEFAULT_BOOKING_COM_CONFIG.timeoutMs,
-      maxRetries: DEFAULT_BOOKING_COM_CONFIG.maxRetries,
-    };
+  private resolveConfig(connectionConfig?: Record<string, unknown>): BookingComConfig {
+    return this.buildConfig(connectionConfig ?? {});
   }
 
   private buildConfig(config: Record<string, unknown>): BookingComConfig {
+    const hotelId = config['hotelId'];
+    const username = config['username'];
+    const password = config['password'];
+    const baseUrl = config['baseUrl'];
     return {
-      hotelId: String(config['hotelId'] ?? this.configService.get<string>('BOOKING_COM_HOTEL_ID', 'MOCK_HOTEL_1')),
-      username: String(config['username'] ?? this.configService.get<string>('BOOKING_COM_USERNAME', 'haip_test')),
-      password: String(config['password'] ?? this.configService.get<string>('BOOKING_COM_PASSWORD', 'test_password')),
-      baseUrl: String(
-        config['baseUrl'] ??
-          this.configService.get<string>('BOOKING_COM_BASE_URL', DEFAULT_BOOKING_COM_CONFIG.baseUrl!),
-      ),
+      hotelId: hotelId != null && hotelId !== ''
+        ? String(hotelId)
+        : this.configService.get<string>('BOOKING_COM_HOTEL_ID', 'MOCK_HOTEL_1'),
+      username: username != null && username !== ''
+        ? String(username)
+        : this.configService.get<string>('BOOKING_COM_USERNAME', 'haip_test'),
+      password: password != null && password !== ''
+        ? String(password)
+        : this.configService.get<string>('BOOKING_COM_PASSWORD', 'test_password'),
+      baseUrl: baseUrl != null && baseUrl !== ''
+        ? String(baseUrl)
+        : this.configService.get<string>('BOOKING_COM_BASE_URL', DEFAULT_BOOKING_COM_CONFIG.baseUrl!),
       timeoutMs: DEFAULT_BOOKING_COM_CONFIG.timeoutMs,
       maxRetries: DEFAULT_BOOKING_COM_CONFIG.maxRetries,
     };

--- a/apps/api/src/modules/channel/adapters/siteminder/siteminder.adapter.ts
+++ b/apps/api/src/modules/channel/adapters/siteminder/siteminder.adapter.ts
@@ -32,7 +32,7 @@ export class SiteMinderAdapter implements ChannelAdapter {
    * Push availability + restrictions combined (SiteMinder convention).
    */
   async pushAvailability(params: AvailabilityPushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig();
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = mapAvailabilityToOta(config.hotelCode, params.items);
     const soap = buildSoapEnvelope(
       'OTA_HotelAvailNotifRQ',
@@ -58,7 +58,7 @@ export class SiteMinderAdapter implements ChannelAdapter {
   }
 
   async pushRates(params: RatePushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig();
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = mapRatesToOta(config.hotelCode, params.items);
     const soap = buildSoapEnvelope(
       'OTA_HotelRateAmountNotifRQ',
@@ -88,7 +88,7 @@ export class SiteMinderAdapter implements ChannelAdapter {
    * This method is a passthrough that builds a combined availability+restriction push.
    */
   async pushRestrictions(params: RestrictionPushParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig();
+    const config = this.resolveConfig(params.connectionConfig);
     // Build availability items from restriction items (zero availability = stop sell)
     const availItems = params.items.map((item) => ({
       channelRoomCode: item.channelRoomCode,
@@ -125,7 +125,7 @@ export class SiteMinderAdapter implements ChannelAdapter {
    * Pull reservations via ReadRQ (SiteMinder is pull-only, no webhook push).
    */
   async pullReservations(params: ReservationPullParams): Promise<ChannelReservationResult> {
-    const config = this.resolveConfig();
+    const config = this.resolveConfig(params.connectionConfig);
 
     const readBody: Record<string, unknown> = {
       ReadRequests: {
@@ -167,7 +167,7 @@ export class SiteMinderAdapter implements ChannelAdapter {
    * SiteMinder re-sends unconfirmed reservations on next poll.
    */
   async confirmReservation(params: ConfirmReservationParams): Promise<ChannelSyncResult> {
-    const config = this.resolveConfig();
+    const config = this.resolveConfig(params.connectionConfig);
     const payload = buildNotifConfirmation(config.hotelCode, [
       {
         externalConfirmation: params.externalConfirmation,
@@ -293,29 +293,33 @@ export class SiteMinderAdapter implements ChannelAdapter {
     };
   }
 
-  private resolveConfig(): SiteMinderConfig {
-    return {
-      hotelCode: this.configService.get<string>('SITEMINDER_HOTEL_CODE', 'MOCK_SM_HOTEL'),
-      username: this.configService.get<string>('SITEMINDER_USERNAME', 'haip_test'),
-      password: this.configService.get<string>('SITEMINDER_PASSWORD', 'test_password'),
-      baseUrl: this.configService.get<string>(
-        'SITEMINDER_BASE_URL',
-        DEFAULT_SITEMINDER_CONFIG.baseUrl!,
-      ),
-      timeoutMs: DEFAULT_SITEMINDER_CONFIG.timeoutMs,
-      maxRetries: DEFAULT_SITEMINDER_CONFIG.maxRetries,
-    };
+  /**
+   * Resolve SiteMinder config.
+   * Prefers per-connection credentials from channelConnections.config (passed via params.connectionConfig);
+   * falls back to env vars only when a value is missing from the connection record.
+   */
+  private resolveConfig(connectionConfig?: Record<string, unknown>): SiteMinderConfig {
+    return this.buildConfig(connectionConfig ?? {});
   }
 
   private buildConfig(config: Record<string, unknown>): SiteMinderConfig {
+    const hotelCode = config['hotelCode'];
+    const username = config['username'];
+    const password = config['password'];
+    const baseUrl = config['baseUrl'];
     return {
-      hotelCode: String(config['hotelCode'] ?? this.configService.get<string>('SITEMINDER_HOTEL_CODE', 'MOCK_SM_HOTEL')),
-      username: String(config['username'] ?? this.configService.get<string>('SITEMINDER_USERNAME', 'haip_test')),
-      password: String(config['password'] ?? this.configService.get<string>('SITEMINDER_PASSWORD', 'test_password')),
-      baseUrl: String(
-        config['baseUrl'] ??
-          this.configService.get<string>('SITEMINDER_BASE_URL', DEFAULT_SITEMINDER_CONFIG.baseUrl!),
-      ),
+      hotelCode: hotelCode != null && hotelCode !== ''
+        ? String(hotelCode)
+        : this.configService.get<string>('SITEMINDER_HOTEL_CODE', 'MOCK_SM_HOTEL'),
+      username: username != null && username !== ''
+        ? String(username)
+        : this.configService.get<string>('SITEMINDER_USERNAME', 'haip_test'),
+      password: password != null && password !== ''
+        ? String(password)
+        : this.configService.get<string>('SITEMINDER_PASSWORD', 'test_password'),
+      baseUrl: baseUrl != null && baseUrl !== ''
+        ? String(baseUrl)
+        : this.configService.get<string>('SITEMINDER_BASE_URL', DEFAULT_SITEMINDER_CONFIG.baseUrl!),
       timeoutMs: DEFAULT_SITEMINDER_CONFIG.timeoutMs,
       maxRetries: DEFAULT_SITEMINDER_CONFIG.maxRetries,
     };

--- a/apps/api/src/modules/channel/ari.service.ts
+++ b/apps/api/src/modules/channel/ari.service.ts
@@ -89,6 +89,7 @@ export class AriService {
       const result = await adapter.pushAvailability({
         propertyId,
         channelConnectionId: conn.id,
+        connectionConfig: (conn.config ?? {}) as Record<string, unknown>,
         items,
       });
 
@@ -190,12 +191,13 @@ export class AriService {
 
       const adapter = this.adapterFactory.getAdapter(conn.adapterType);
 
+      const connectionConfig = (conn.config ?? {}) as Record<string, unknown>;
       const rateResult = rateItems.length > 0
-        ? await adapter.pushRates({ propertyId, channelConnectionId: conn.id, items: rateItems })
+        ? await adapter.pushRates({ propertyId, channelConnectionId: conn.id, connectionConfig, items: rateItems })
         : { success: true, itemsSynced: 0, errors: [] };
 
       const restrictionResult = restrictionItems.length > 0
-        ? await adapter.pushRestrictions({ propertyId, channelConnectionId: conn.id, items: restrictionItems })
+        ? await adapter.pushRestrictions({ propertyId, channelConnectionId: conn.id, connectionConfig, items: restrictionItems })
         : { success: true, itemsSynced: 0, errors: [] };
 
       // Log syncs
@@ -282,6 +284,7 @@ export class AriService {
     const result = await adapter.pushAvailability({
       propertyId,
       channelConnectionId,
+      connectionConfig: (conn.config ?? {}) as Record<string, unknown>,
       items,
     });
 
@@ -305,6 +308,27 @@ export class AriService {
       }
     } catch {
       // Fire-and-forget: don't crash on push failure
+    }
+  }
+
+  @OnEvent('reservation.modified')
+  async handleReservationModified(payload: WebhookPayload) {
+    if (!payload.propertyId) return;
+    try {
+      const data = payload.data as Record<string, unknown>;
+      // Push availability for both old and new windows so channels see the freed + taken inventory.
+      const arrivalDate = data['arrivalDate'] as string | undefined;
+      const departureDate = data['departureDate'] as string | undefined;
+      const prevArrival = data['previousArrivalDate'] as string | undefined;
+      const prevDeparture = data['previousDepartureDate'] as string | undefined;
+      if (arrivalDate && departureDate) {
+        await this.pushAvailability(payload.propertyId, arrivalDate, departureDate);
+      }
+      if (prevArrival && prevDeparture && (prevArrival !== arrivalDate || prevDeparture !== departureDate)) {
+        await this.pushAvailability(payload.propertyId, prevArrival, prevDeparture);
+      }
+    } catch {
+      // Fire-and-forget
     }
   }
 

--- a/apps/api/src/modules/channel/channel-adapter.interface.ts
+++ b/apps/api/src/modules/channel/channel-adapter.interface.ts
@@ -20,6 +20,11 @@ export interface ChannelAdapter {
 export interface AvailabilityPushParams {
   propertyId: string;
   channelConnectionId: string;
+  /**
+   * Per-connection credentials/config from channelConnections.config.
+   * Adapters use this when set; fall back to env vars only when missing.
+   */
+  connectionConfig?: Record<string, unknown>;
   items: Array<{
     channelRoomCode: string;
     date: string;
@@ -31,6 +36,7 @@ export interface AvailabilityPushParams {
 export interface RatePushParams {
   propertyId: string;
   channelConnectionId: string;
+  connectionConfig?: Record<string, unknown>;
   items: Array<{
     channelRoomCode: string;
     channelRateCode: string;
@@ -46,6 +52,7 @@ export interface RatePushParams {
 export interface RestrictionPushParams {
   propertyId: string;
   channelConnectionId: string;
+  connectionConfig?: Record<string, unknown>;
   items: Array<{
     channelRoomCode: string;
     channelRateCode: string;
@@ -61,6 +68,7 @@ export interface RestrictionPushParams {
 export interface ReservationPullParams {
   propertyId: string;
   channelConnectionId: string;
+  connectionConfig?: Record<string, unknown>;
   since?: Date;
 }
 
@@ -87,12 +95,14 @@ export interface ChannelReservation {
 
 export interface ConfirmReservationParams {
   channelConnectionId: string;
+  connectionConfig?: Record<string, unknown>;
   externalConfirmation: string;
   pmsConfirmationNumber: string;
 }
 
 export interface CancelReservationParams {
   channelConnectionId: string;
+  connectionConfig?: Record<string, unknown>;
   externalConfirmation: string;
   reason?: string;
 }

--- a/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
@@ -73,6 +73,9 @@ describe('InboundReservationService', () => {
         }),
       }),
     };
+    // Transactions just run the callback with the same mock — the tx-scoped insert/select
+    // queries still hit the shared mocks configured above.
+    mockDb.transaction = vi.fn().mockImplementation((cb: any) => cb(mockDb));
 
     mockChannelService = {
       findById: vi.fn().mockResolvedValue(mockConnection),

--- a/apps/api/src/modules/channel/inbound-reservation.service.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.ts
@@ -68,6 +68,7 @@ export class InboundReservationService {
     const result = await adapter.pullReservations({
       propertyId,
       channelConnectionId,
+      connectionConfig: (conn.config ?? {}) as Record<string, unknown>,
       since,
     });
 
@@ -98,12 +99,9 @@ export class InboundReservationService {
   private async handleNewReservation(conn: any, reservation: ChannelReservation) {
     const propertyId = conn.propertyId;
 
-    // Resolve channel codes to PMS IDs
+    // Resolve channel codes to PMS IDs (outside tx — pure lookups)
     const roomTypeId = this.resolveRoomTypeId(conn, reservation.channelRoomCode);
     const ratePlanId = this.resolveRatePlanId(conn, reservation.channelRateCode);
-
-    // Find or create guest
-    const guest = await this.findOrCreateGuest(reservation);
 
     // Calculate nights
     const arrival = new Date(reservation.arrivalDate);
@@ -113,45 +111,51 @@ export class InboundReservationService {
     // Generate confirmation number
     const confirmationNumber = this.generateConfirmationNumber();
 
-    // Create booking
-    const [booking] = await this.db
-      .insert(bookings)
-      .values({
-        propertyId,
-        guestId: guest.id,
-        confirmationNumber,
-        externalConfirmation: reservation.externalConfirmation,
-        source: 'ota',
-        channelCode: reservation.channelCode,
-      })
-      .returning();
+    // Atomically create guest + booking + reservation so we never end up with a half-written record.
+    const { guest, booking, pmsReservation } = await this.db.transaction(async (tx: any) => {
+      const guest = await this.findOrCreateGuestTx(tx, reservation);
 
-    // Create reservation
-    const [pmsReservation] = await this.db
-      .insert(reservations)
-      .values({
-        propertyId,
-        bookingId: booking.id,
-        guestId: guest.id,
-        arrivalDate: reservation.arrivalDate,
-        departureDate: reservation.departureDate,
-        nights,
-        roomTypeId,
-        ratePlanId,
-        totalAmount: reservation.totalAmount.toString(),
-        currencyCode: reservation.currencyCode,
-        adults: reservation.adults,
-        children: reservation.children ?? 0,
-        specialRequests: reservation.specialRequests,
-        status: 'confirmed',
-      })
-      .returning();
+      const [booking] = await tx
+        .insert(bookings)
+        .values({
+          propertyId,
+          guestId: guest.id,
+          confirmationNumber,
+          externalConfirmation: reservation.externalConfirmation,
+          source: 'ota',
+          channelCode: reservation.channelCode,
+        })
+        .returning();
+
+      const [pmsReservation] = await tx
+        .insert(reservations)
+        .values({
+          propertyId,
+          bookingId: booking.id,
+          guestId: guest.id,
+          arrivalDate: reservation.arrivalDate,
+          departureDate: reservation.departureDate,
+          nights,
+          roomTypeId,
+          ratePlanId,
+          totalAmount: reservation.totalAmount.toString(),
+          currencyCode: reservation.currencyCode,
+          adults: reservation.adults,
+          children: reservation.children ?? 0,
+          specialRequests: reservation.specialRequests,
+          status: 'confirmed',
+        })
+        .returning();
+
+      return { guest, booking, pmsReservation };
+    });
 
     // Confirm back to channel
     try {
       const adapter = this.adapterFactory.getAdapter(conn.adapterType);
       await adapter.confirmReservation({
         channelConnectionId: conn.id,
+        connectionConfig: (conn.config ?? {}) as Record<string, unknown>,
         externalConfirmation: reservation.externalConfirmation,
         pmsConfirmationNumber: confirmationNumber,
       });
@@ -352,6 +356,26 @@ export class InboundReservationService {
         ),
       );
     return existing ?? null;
+  }
+
+  private async findOrCreateGuestTx(tx: any, reservation: ChannelReservation) {
+    if (reservation.guestEmail) {
+      const [existing] = await tx
+        .select()
+        .from(guests)
+        .where(eq(guests.email, reservation.guestEmail));
+      if (existing) return existing;
+    }
+    const [guest] = await tx
+      .insert(guests)
+      .values({
+        firstName: reservation.guestFirstName,
+        lastName: reservation.guestLastName,
+        email: reservation.guestEmail ?? null,
+        phone: reservation.guestPhone ?? null,
+      })
+      .returning();
+    return guest;
   }
 
   private async findOrCreateGuest(reservation: ChannelReservation) {

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   forwardRef,
 } from '@nestjs/common';
 import { eq, and, sql, gte, lte } from 'drizzle-orm';
@@ -114,6 +115,20 @@ export class ReservationService {
       return { ...reservation, booking };
     });
 
+    // Emit reservation.created so channel manager / ARI can push updated availability.
+    await this.webhookService.emit(
+      'reservation.created',
+      'reservation',
+      result.id,
+      {
+        reservationId: result.id,
+        arrivalDate: result.arrivalDate,
+        departureDate: result.departureDate,
+        roomTypeId: result.roomTypeId,
+      },
+      dto.propertyId,
+    );
+
     return result;
   }
 
@@ -176,6 +191,22 @@ export class ReservationService {
       })
       .where(eq(reservations.id, id))
       .returning();
+
+    // Emit reservation.cancelled so channel manager / ARI can push updated availability.
+    await this.webhookService.emit(
+      'reservation.cancelled',
+      'reservation',
+      updated.id,
+      {
+        reservationId: updated.id,
+        arrivalDate: updated.arrivalDate,
+        departureDate: updated.departureDate,
+        roomTypeId: updated.roomTypeId,
+        cancellationReason: dto.cancellationReason,
+      },
+      updated.propertyId,
+    );
+
     return updated;
   }
 
@@ -583,6 +614,10 @@ export class ReservationService {
 
     const updates: Record<string, unknown> = { updatedAt: new Date() };
 
+    const arrivalChanged = dto.arrivalDate && dto.arrivalDate !== reservation.arrivalDate;
+    const departureChanged = dto.departureDate && dto.departureDate !== reservation.departureDate;
+    const roomTypeChanged = dto.roomTypeId && dto.roomTypeId !== reservation.roomTypeId;
+
     if (dto.arrivalDate || dto.departureDate) {
       const arrival = dto.arrivalDate ?? reservation.arrivalDate;
       const departure = dto.departureDate ?? reservation.departureDate;
@@ -606,11 +641,69 @@ export class ReservationService {
     if (dto.specialRequests !== undefined)
       updates['specialRequests'] = dto.specialRequests;
 
+    // If dates or room type change, re-check availability on the new window.
+    // The existing reservation still occupies its old window (and room type) in searchAvailability,
+    // so if roomType is unchanged we must exclude it from the count to avoid blocking itself on overlap.
+    if (arrivalChanged || departureChanged || roomTypeChanged) {
+      const newArrival = (dto.arrivalDate ?? reservation.arrivalDate) as string;
+      const newDeparture = (dto.departureDate ?? reservation.departureDate) as string;
+      const newRoomTypeId = (dto.roomTypeId ?? reservation.roomTypeId) as string;
+
+      const availability = await this.availabilityService.searchAvailability(
+        reservation.propertyId,
+        newArrival,
+        newDeparture,
+        newRoomTypeId,
+      );
+
+      // Check each night in the requested window has availability.
+      // If the reservation currently occupies the same room type and overlaps the new window,
+      // it was counted as "sold" — give it back one unit when evaluating.
+      const currentCountsItself = !roomTypeChanged &&
+        reservation.arrivalDate < newDeparture &&
+        reservation.departureDate > newArrival;
+
+      const nightsOk = availability
+        .filter((a: any) => a.roomTypeId === newRoomTypeId)
+        .every((a: any) => {
+          const existingOccupiesThisNight =
+            currentCountsItself &&
+            (reservation.arrivalDate as string) <= a.date &&
+            (reservation.departureDate as string) > a.date;
+          const effectiveAvailable = a.available + (existingOccupiesThisNight ? 1 : 0);
+          return effectiveAvailable > 0;
+        });
+
+      if (!nightsOk) {
+        throw new ConflictException(
+          `No availability for room type ${newRoomTypeId} on ${newArrival} → ${newDeparture}`,
+        );
+      }
+    }
+
     const [updated] = await this.db
       .update(reservations)
       .set(updates)
       .where(eq(reservations.id, id))
       .returning();
+
+    // Emit reservation.modified so channel manager / ARI can push updated availability.
+    await this.webhookService.emit(
+      'reservation.modified',
+      'reservation',
+      updated.id,
+      {
+        reservationId: updated.id,
+        arrivalDate: updated.arrivalDate,
+        departureDate: updated.departureDate,
+        roomTypeId: updated.roomTypeId,
+        previousArrivalDate: reservation.arrivalDate,
+        previousDepartureDate: reservation.departureDate,
+        previousRoomTypeId: reservation.roomTypeId,
+      },
+      updated.propertyId,
+    );
+
     return updated;
   }
 

--- a/apps/api/src/modules/room/room.controller.ts
+++ b/apps/api/src/modules/room/room.controller.ts
@@ -97,10 +97,14 @@ export class RoomController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get room by ID' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Room found' })
   @ApiResponse({ status: 404, description: 'Room not found' })
-  getRoomById(@Param('id', ParseUUIDPipe) id: string) {
-    return this.roomService.findRoomById(id);
+  getRoomById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.roomService.findRoomById(id, propertyId);
   }
 
   @Patch(':id/status')
@@ -120,12 +124,14 @@ export class RoomController {
   @Patch(':id')
   @Roles('admin', 'front_desk', 'housekeeping_manager')
   @ApiOperation({ summary: 'Update room' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Room updated' })
   @ApiResponse({ status: 404, description: 'Room not found' })
   updateRoom(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateRoomDto,
   ) {
-    return this.roomService.updateRoom(id, dto);
+    return this.roomService.updateRoom(id, propertyId, dto);
   }
 }

--- a/apps/api/src/modules/room/room.service.ts
+++ b/apps/api/src/modules/room/room.service.ts
@@ -61,22 +61,22 @@ export class RoomService {
       .where(and(...conditions));
   }
 
-  async findRoomById(id: string) {
+  async findRoomById(id: string, propertyId: string) {
     const [room] = await this.db
       .select()
       .from(rooms)
-      .where(eq(rooms.id, id));
+      .where(and(eq(rooms.id, id), eq(rooms.propertyId, propertyId)));
     if (!room) {
       throw new NotFoundException(`Room ${id} not found`);
     }
     return room;
   }
 
-  async updateRoom(id: string, dto: UpdateRoomDto) {
+  async updateRoom(id: string, propertyId: string, dto: UpdateRoomDto) {
     const [room] = await this.db
       .update(rooms)
       .set({ ...dto, updatedAt: new Date() })
-      .where(eq(rooms.id, id))
+      .where(and(eq(rooms.id, id), eq(rooms.propertyId, propertyId)))
       .returning();
     if (!room) {
       throw new NotFoundException(`Room ${id} not found`);


### PR DESCRIPTION
## Summary

Second round of codex review fixes. All 15 fixes from round 1 (PR #75) confirmed applied; this PR addresses 9 new bugs found on re-review.

## Bugs fixed

| # | Severity | Bug |
|---|----------|-----|
| 1 | CRITICAL | Channel adapters now read per-connection credentials (env fallback only) |
| 2 | HIGH | `modifyReservation()` checks availability on date/roomType change |
| 3 | HIGH | PMS `reservation.created/cancelled/modified` events emitted → ARI sync |
| 4 | HIGH | Inbound reservation creation wrapped in `db.transaction()` |
| 5 | HIGH | `GET/PATCH /rooms/:id` now require `propertyId` scoping |
| 6 | HIGH | Auth guard fails closed when `AUTH_ENABLED` is unset |
| 7 | MEDIUM | Overbooking agent expands reservations across all occupied nights |
| 8 | MEDIUM | Cancellation predictor joins `bookings` for real `source`/`channelCode` |
| 9 | MEDIUM | Night-audit payment-mismatch rule now reachable (`due_out`/`checked_out`) |

## Test plan
- [x] `pnpm build` — green
- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 551/551 api + 39/39 dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)