### PR TITLE
fix: round 3 codex review + full tenant-scoping audit

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -26,17 +26,20 @@ import { RolesGuard } from './roles.guard';
     ConfigModule,
   ],
   providers: [
-    // Only register JWT strategy when auth might be enabled
-    // The strategy itself is lazy — only connects to JWKS when a token is actually validated
+    // Register JWT strategy unless auth is explicitly disabled.
+    // The guards (JwtAuthGuard / RolesGuard) are secure-by-default — they enforce
+    // auth unless AUTH_ENABLED === 'false' — so the strategy must be registered
+    // to match. The strategy is lazy — it only connects to JWKS when a token is
+    // actually validated, so no runtime cost when auth is off.
     {
       provide: JwtStrategy,
       useFactory: (configService: ConfigService) => {
-        const authEnabled = configService.get<string>('AUTH_ENABLED', 'false');
-        if (authEnabled === 'true') {
-          return new JwtStrategy(configService);
+        const authEnabled = configService.get<string>('AUTH_ENABLED', 'true');
+        if (authEnabled === 'false') {
+          // Return a no-op strategy when auth is explicitly disabled
+          return {} as JwtStrategy;
         }
-        // Return a no-op strategy when auth is disabled
-        return {} as JwtStrategy;
+        return new JwtStrategy(configService);
       },
       inject: [ConfigService],
     },

--- a/apps/api/src/modules/auth/roles.guard.ts
+++ b/apps/api/src/modules/auth/roles.guard.ts
@@ -25,9 +25,10 @@ export class RolesGuard implements CanActivate {
   ) {}
 
   canActivate(context: ExecutionContext): boolean {
-    // If auth is disabled, skip role checks
-    const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'false');
-    if (authEnabled !== 'true') {
+    // Secure-by-default: role checks are ON unless AUTH_ENABLED is explicitly 'false'.
+    // Matches JwtAuthGuard's default-on behavior.
+    const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'true');
+    if (authEnabled === 'false') {
       return true;
     }
 

--- a/apps/api/src/modules/channel/ari.service.ts
+++ b/apps/api/src/modules/channel/ari.service.ts
@@ -131,11 +131,16 @@ export class AriService {
       const restrictionItems: RestrictionPushParams['items'] = [];
 
       for (const rateMapping of ratePlanMapping) {
-        // Get rate plan details
+        // Get rate plan details — scoped to the connection's property
         const [ratePlan] = await this.db
           .select()
           .from(ratePlans)
-          .where(eq(ratePlans.id, rateMapping.ratePlanId));
+          .where(
+            and(
+              eq(ratePlans.id, rateMapping.ratePlanId),
+              eq(ratePlans.propertyId, propertyId),
+            ),
+          );
 
         if (!ratePlan) continue;
 

--- a/apps/api/src/modules/channel/inbound-reservation.service.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.ts
@@ -31,10 +31,12 @@ export class InboundReservationService {
     const conn = await this.findConnectionForInbound(channelConnectionId);
     const propertyId = conn.propertyId;
 
-    // Check deduplication
+    // Check deduplication — scoped to the connection's property to prevent
+    // cross-tenant collisions on externalConfirmation + channelCode.
     const existing = await this.findByExternalConfirmation(
       reservation.externalConfirmation,
       reservation.channelCode,
+      propertyId,
     );
 
     if (reservation.status === 'cancelled') {
@@ -199,11 +201,16 @@ export class InboundReservationService {
   private async handleModification(conn: any, reservation: ChannelReservation, existing: any) {
     const propertyId = conn.propertyId;
 
-    // Find the existing reservation linked to this booking
+    // Find the existing reservation linked to this booking — scoped to property.
     const [existingReservation] = await this.db
       .select()
       .from(reservations)
-      .where(eq(reservations.bookingId, existing.id));
+      .where(
+        and(
+          eq(reservations.bookingId, existing.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      );
 
     if (!existingReservation) {
       throw new NotFoundException('Existing reservation not found for modification');
@@ -233,7 +240,12 @@ export class InboundReservationService {
         specialRequests: reservation.specialRequests,
         updatedAt: new Date(),
       })
-      .where(eq(reservations.id, existingReservation.id))
+      .where(
+        and(
+          eq(reservations.id, existingReservation.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      )
       .returning();
 
     // Push updated availability
@@ -277,11 +289,16 @@ export class InboundReservationService {
 
     const propertyId = conn.propertyId;
 
-    // Find the reservation
+    // Find the reservation — scoped to property.
     const [existingReservation] = await this.db
       .select()
       .from(reservations)
-      .where(eq(reservations.bookingId, existing.id));
+      .where(
+        and(
+          eq(reservations.bookingId, existing.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      );
 
     if (!existingReservation) {
       throw new NotFoundException('Existing reservation not found for cancellation');
@@ -296,7 +313,12 @@ export class InboundReservationService {
         cancellationReason: `Cancelled via channel: ${reservation.channelCode}`,
         updatedAt: new Date(),
       })
-      .where(eq(reservations.id, existingReservation.id));
+      .where(
+        and(
+          eq(reservations.id, existingReservation.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      );
 
     // Push updated availability
     try {
@@ -345,12 +367,17 @@ export class InboundReservationService {
     return conn;
   }
 
-  private async findByExternalConfirmation(externalConfirmation: string, channelCode: string) {
+  private async findByExternalConfirmation(
+    externalConfirmation: string,
+    channelCode: string,
+    propertyId: string,
+  ) {
     const [existing] = await this.db
       .select()
       .from(bookings)
       .where(
         and(
+          eq(bookings.propertyId, propertyId),
           eq(bookings.externalConfirmation, externalConfirmation),
           eq(bookings.channelCode, channelCode),
         ),

--- a/apps/api/src/modules/channel/rate-parity.service.ts
+++ b/apps/api/src/modules/channel/rate-parity.service.ts
@@ -135,7 +135,7 @@ export class RateParityService {
     const [plan] = await this.db
       .select()
       .from(ratePlans)
-      .where(eq(ratePlans.id, ratePlanId));
+      .where(and(eq(ratePlans.id, ratePlanId), eq(ratePlans.propertyId, propertyId)));
 
     if (!plan) {
       return { baseAmount: 0, effectiveRate: 0, hasOverride: false };
@@ -144,7 +144,12 @@ export class RateParityService {
     const [conn] = await this.db
       .select()
       .from(channelConnections)
-      .where(eq(channelConnections.id, channelConnectionId));
+      .where(
+        and(
+          eq(channelConnections.id, channelConnectionId),
+          eq(channelConnections.propertyId, propertyId),
+        ),
+      );
 
     if (!conn) {
       return { baseAmount: parseFloat(plan.baseAmount), effectiveRate: parseFloat(plan.baseAmount), hasOverride: false };

--- a/apps/api/src/modules/connect/connect-events.service.spec.ts
+++ b/apps/api/src/modules/connect/connect-events.service.spec.ts
@@ -80,7 +80,7 @@ describe('ConnectEventsService', () => {
         }),
       }));
 
-      const result = await service.deleteSubscription('sub-1');
+      const result = await service.deleteSubscription('sub-1', 'prop-1');
 
       expect(result.deleted).toBe(true);
       expect(mockDb.update).toHaveBeenCalled();
@@ -93,7 +93,7 @@ describe('ConnectEventsService', () => {
         }),
       }));
 
-      await expect(service.deleteSubscription('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(service.deleteSubscription('nonexistent', 'prop-1')).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -105,7 +105,7 @@ describe('ConnectEventsService', () => {
         }),
       }));
 
-      const result = await service.testSubscription('sub-1');
+      const result = await service.testSubscription('sub-1', 'prop-1');
 
       expect(result.testSent).toBe(true);
       expect(result.callbackUrl).toBe('https://otaip.example.com/webhooks');

--- a/apps/api/src/modules/connect/connect-events.service.ts
+++ b/apps/api/src/modules/connect/connect-events.service.ts
@@ -46,11 +46,16 @@ export class ConnectEventsService {
   /**
    * Delete (deactivate) a subscription.
    */
-  async deleteSubscription(id: string) {
+  async deleteSubscription(id: string, propertyId: string) {
     const [subscription] = await this.db
       .select()
       .from(agentWebhookSubscriptions)
-      .where(eq(agentWebhookSubscriptions.id, id));
+      .where(
+        and(
+          eq(agentWebhookSubscriptions.id, id),
+          eq(agentWebhookSubscriptions.propertyId, propertyId),
+        ),
+      );
 
     if (!subscription) {
       throw new NotFoundException(`Subscription ${id} not found`);
@@ -59,7 +64,12 @@ export class ConnectEventsService {
     await this.db
       .update(agentWebhookSubscriptions)
       .set({ isActive: false, updatedAt: new Date() })
-      .where(eq(agentWebhookSubscriptions.id, id));
+      .where(
+        and(
+          eq(agentWebhookSubscriptions.id, id),
+          eq(agentWebhookSubscriptions.propertyId, propertyId),
+        ),
+      );
 
     return { deleted: true, id };
   }
@@ -67,11 +77,16 @@ export class ConnectEventsService {
   /**
    * Send a test event to verify a subscription's callback URL.
    */
-  async testSubscription(id: string) {
+  async testSubscription(id: string, propertyId: string) {
     const [subscription] = await this.db
       .select()
       .from(agentWebhookSubscriptions)
-      .where(eq(agentWebhookSubscriptions.id, id));
+      .where(
+        and(
+          eq(agentWebhookSubscriptions.id, id),
+          eq(agentWebhookSubscriptions.propertyId, propertyId),
+        ),
+      );
 
     if (!subscription) {
       throw new NotFoundException(`Subscription ${id} not found`);
@@ -85,7 +100,12 @@ export class ConnectEventsService {
         lastDeliveryStatus: 'test_logged',
         updatedAt: new Date(),
       })
-      .where(eq(agentWebhookSubscriptions.id, id));
+      .where(
+        and(
+          eq(agentWebhookSubscriptions.id, id),
+          eq(agentWebhookSubscriptions.propertyId, propertyId),
+        ),
+      );
 
     return {
       testSent: true,

--- a/apps/api/src/modules/connect/connect.controller.ts
+++ b/apps/api/src/modules/connect/connect.controller.ts
@@ -104,14 +104,22 @@ export class ConnectController {
 
   @Delete('subscriptions/:id')
   @ApiOperation({ summary: 'Unsubscribe from events' })
-  async deleteSubscription(@Param('id', ParseUUIDPipe) id: string) {
-    return this.eventsService.deleteSubscription(id);
+  @ApiQuery({ name: 'propertyId', required: true })
+  async deleteSubscription(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.eventsService.deleteSubscription(id, propertyId);
   }
 
   @Post('subscriptions/:id/test')
   @ApiOperation({ summary: 'Send a test event to verify callback URL' })
-  async testSubscription(@Param('id', ParseUUIDPipe) id: string) {
-    return this.eventsService.testSubscription(id);
+  @ApiQuery({ name: 'propertyId', required: true })
+  async testSubscription(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.eventsService.testSubscription(id, propertyId);
   }
 
   // --- Event Polling ---

--- a/apps/api/src/modules/night-audit/night-audit.service.spec.ts
+++ b/apps/api/src/modules/night-audit/night-audit.service.spec.ts
@@ -374,7 +374,7 @@ describe('NightAuditService', () => {
     const result = await service.processNoShows('prop-001', '2026-04-06');
     expect(result.count).toBe(1);
     expect(result.reservationIds).toContain('res-001');
-    expect(mockReservationService.markNoShow).toHaveBeenCalledWith('res-001');
+    expect(mockReservationService.markNoShow).toHaveBeenCalledWith('res-001', 'prop-001');
   });
 
   it('should post no-show fee if configured', async () => {

--- a/apps/api/src/modules/night-audit/night-audit.service.ts
+++ b/apps/api/src/modules/night-audit/night-audit.service.ts
@@ -249,7 +249,7 @@ export class NightAuditService {
     for (const reservation of noShowCandidates) {
       try {
         // Mark as no-show
-        await this.reservationService.markNoShow(reservation.id);
+        await this.reservationService.markNoShow(reservation.id, propertyId);
         reservationIds.push(reservation.id);
         count++;
 

--- a/apps/api/src/modules/rate-plan/rate-plan.controller.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.controller.ts
@@ -40,38 +40,52 @@ export class RatePlanController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get rate plan by ID' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Rate plan found' })
   @ApiResponse({ status: 404, description: 'Rate plan not found' })
-  getRatePlanById(@Param('id', ParseUUIDPipe) id: string) {
-    return this.ratePlanService.findById(id);
+  getRatePlanById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.ratePlanService.findById(id, propertyId);
   }
 
   @Get(':id/effective-rate')
   @ApiOperation({ summary: 'Calculate effective rate (resolves derived rate chain)' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Effective rate calculated' })
-  getEffectiveRate(@Param('id', ParseUUIDPipe) id: string) {
-    return this.ratePlanService.calculateDerivedRate(id);
+  getEffectiveRate(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.ratePlanService.calculateDerivedRate(id, propertyId);
   }
 
   @Patch(':id')
   @Roles('admin')
   @ApiOperation({ summary: 'Update rate plan' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Rate plan updated' })
   @ApiResponse({ status: 404, description: 'Rate plan not found' })
   updateRatePlan(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateRatePlanDto,
   ) {
-    return this.ratePlanService.update(id, dto);
+    return this.ratePlanService.update(id, propertyId, dto);
   }
 
   // --- Restrictions sub-resource ---
 
   @Get(':id/restrictions')
   @ApiOperation({ summary: 'Get restrictions for a rate plan' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'List of restrictions' })
-  getRestrictions(@Param('id', ParseUUIDPipe) id: string) {
-    return this.ratePlanService.findRestrictions(id);
+  getRestrictions(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.ratePlanService.findRestrictions(id, propertyId);
   }
 
   @Post(':id/restrictions')
@@ -82,31 +96,35 @@ export class RatePlanController {
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: CreateRateRestrictionDto,
   ) {
-    return this.ratePlanService.createRestriction(id, dto);
+    return this.ratePlanService.createRestriction(id, dto.propertyId, dto);
   }
 
   @Patch(':id/restrictions/:restrictionId')
   @Roles('admin')
   @ApiOperation({ summary: 'Update a rate restriction' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Restriction updated' })
   @ApiResponse({ status: 404, description: 'Restriction not found' })
   updateRestriction(
     @Param('id', ParseUUIDPipe) _id: string,
     @Param('restrictionId', ParseUUIDPipe) restrictionId: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateRateRestrictionDto,
   ) {
-    return this.ratePlanService.updateRestriction(restrictionId, dto);
+    return this.ratePlanService.updateRestriction(restrictionId, propertyId, dto);
   }
 
   @Delete(':id/restrictions/:restrictionId')
   @Roles('admin')
   @ApiOperation({ summary: 'Delete a rate restriction' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Restriction deleted' })
   @ApiResponse({ status: 404, description: 'Restriction not found' })
   deleteRestriction(
     @Param('id', ParseUUIDPipe) _id: string,
     @Param('restrictionId', ParseUUIDPipe) restrictionId: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
   ) {
-    return this.ratePlanService.deleteRestriction(restrictionId);
+    return this.ratePlanService.deleteRestriction(restrictionId, propertyId);
   }
 }

--- a/apps/api/src/modules/rate-plan/rate-plan.service.spec.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.service.spec.ts
@@ -59,7 +59,7 @@ describe('RatePlanService', () => {
       }).compile();
       const service = module.get<RatePlanService>(RatePlanService);
 
-      const result = await service.calculateDerivedRate('rp-bar-001');
+      const result = await service.calculateDerivedRate('rp-bar-001', 'prop-001');
       expect(result.effectiveRate).toBe(200);
       expect(result.currency).toBe('USD');
     });
@@ -91,7 +91,7 @@ describe('RatePlanService', () => {
       }).compile();
       const service = module.get<RatePlanService>(RatePlanService);
 
-      const result = await service.calculateDerivedRate('rp-aaa-001');
+      const result = await service.calculateDerivedRate('rp-aaa-001', 'prop-001');
       // 200 * (1 + (-10/100)) = 200 * 0.9 = 180
       expect(result.effectiveRate).toBe(180);
       expect(result.currency).toBe('USD');
@@ -129,7 +129,7 @@ describe('RatePlanService', () => {
       }).compile();
       const service = module.get<RatePlanService>(RatePlanService);
 
-      const result = await service.calculateDerivedRate('rp-fixed-001');
+      const result = await service.calculateDerivedRate('rp-fixed-001', 'prop-001');
       // 200 + (-25) = 175
       expect(result.effectiveRate).toBe(175);
     });
@@ -166,7 +166,7 @@ describe('RatePlanService', () => {
       }).compile();
       const service = module.get<RatePlanService>(RatePlanService);
 
-      const result = await service.calculateDerivedRate('rp-big-001');
+      const result = await service.calculateDerivedRate('rp-big-001', 'prop-001');
       expect(result.effectiveRate).toBe(0);
     });
   });

--- a/apps/api/src/modules/rate-plan/rate-plan.service.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.service.ts
@@ -25,11 +25,16 @@ export class RatePlanService {
           'Derived rate plans require parentRatePlanId, derivedAdjustmentType, and derivedAdjustmentValue',
         );
       }
-      // Verify parent exists
+      // Verify parent exists — must be in same property
       const [parent] = await this.db
         .select()
         .from(ratePlans)
-        .where(eq(ratePlans.id, dto.parentRatePlanId));
+        .where(
+          and(
+            eq(ratePlans.id, dto.parentRatePlanId),
+            eq(ratePlans.propertyId, dto.propertyId),
+          ),
+        );
       if (!parent) {
         throw new NotFoundException(`Parent rate plan ${dto.parentRatePlanId} not found`);
       }
@@ -55,22 +60,22 @@ export class RatePlanService {
       );
   }
 
-  async findById(id: string) {
+  async findById(id: string, propertyId: string) {
     const [ratePlan] = await this.db
       .select()
       .from(ratePlans)
-      .where(eq(ratePlans.id, id));
+      .where(and(eq(ratePlans.id, id), eq(ratePlans.propertyId, propertyId)));
     if (!ratePlan) {
       throw new NotFoundException(`Rate plan ${id} not found`);
     }
     return ratePlan;
   }
 
-  async update(id: string, dto: UpdateRatePlanDto) {
+  async update(id: string, propertyId: string, dto: UpdateRatePlanDto) {
     const [ratePlan] = await this.db
       .update(ratePlans)
       .set({ ...dto, updatedAt: new Date() })
-      .where(eq(ratePlans.id, id))
+      .where(and(eq(ratePlans.id, id), eq(ratePlans.propertyId, propertyId)))
       .returning();
     if (!ratePlan) {
       throw new NotFoundException(`Rate plan ${id} not found`);
@@ -82,8 +87,11 @@ export class RatePlanService {
    * Calculate the effective rate for a derived rate plan.
    * Follows the parent chain to get the base amount, then applies the adjustment.
    */
-  async calculateDerivedRate(id: string): Promise<{ effectiveRate: number; currency: string }> {
-    const ratePlan = await this.findById(id);
+  async calculateDerivedRate(
+    id: string,
+    propertyId: string,
+  ): Promise<{ effectiveRate: number; currency: string }> {
+    const ratePlan = await this.findById(id, propertyId);
 
     if (ratePlan.type !== 'derived' || !ratePlan.parentRatePlanId) {
       return {
@@ -92,7 +100,7 @@ export class RatePlanService {
       };
     }
 
-    const parent = await this.findById(ratePlan.parentRatePlanId);
+    const parent = await this.findById(ratePlan.parentRatePlanId, propertyId);
     const parentAmount = Number(parent.baseAmount);
     const adjustmentValue = Number(ratePlan.derivedAdjustmentValue);
 
@@ -112,27 +120,46 @@ export class RatePlanService {
 
   // --- Rate Restrictions ---
 
-  async createRestriction(ratePlanId: string, dto: CreateRateRestrictionDto) {
-    await this.findById(ratePlanId); // Verify rate plan exists
+  async createRestriction(
+    ratePlanId: string,
+    propertyId: string,
+    dto: CreateRateRestrictionDto,
+  ) {
+    await this.findById(ratePlanId, propertyId); // Verify rate plan exists + tenant scope
     const [restriction] = await this.db
       .insert(rateRestrictions)
-      .values({ ...dto, ratePlanId })
+      .values({ ...dto, ratePlanId, propertyId })
       .returning();
     return restriction;
   }
 
-  async findRestrictions(ratePlanId: string) {
+  async findRestrictions(ratePlanId: string, propertyId: string) {
+    await this.findById(ratePlanId, propertyId); // Verify rate plan exists + tenant scope
     return this.db
       .select()
       .from(rateRestrictions)
-      .where(eq(rateRestrictions.ratePlanId, ratePlanId));
+      .where(
+        and(
+          eq(rateRestrictions.ratePlanId, ratePlanId),
+          eq(rateRestrictions.propertyId, propertyId),
+        ),
+      );
   }
 
-  async updateRestriction(id: string, dto: UpdateRateRestrictionDto) {
+  async updateRestriction(
+    id: string,
+    propertyId: string,
+    dto: UpdateRateRestrictionDto,
+  ) {
     const [restriction] = await this.db
       .update(rateRestrictions)
       .set({ ...dto, updatedAt: new Date() })
-      .where(eq(rateRestrictions.id, id))
+      .where(
+        and(
+          eq(rateRestrictions.id, id),
+          eq(rateRestrictions.propertyId, propertyId),
+        ),
+      )
       .returning();
     if (!restriction) {
       throw new NotFoundException(`Rate restriction ${id} not found`);
@@ -140,10 +167,15 @@ export class RatePlanService {
     return restriction;
   }
 
-  async deleteRestriction(id: string) {
+  async deleteRestriction(id: string, propertyId: string) {
     const [restriction] = await this.db
       .delete(rateRestrictions)
-      .where(eq(rateRestrictions.id, id))
+      .where(
+        and(
+          eq(rateRestrictions.id, id),
+          eq(rateRestrictions.propertyId, propertyId),
+        ),
+      )
       .returning();
     if (!restriction) {
       throw new NotFoundException(`Rate restriction ${id} not found`);

--- a/apps/api/src/modules/reservation/availability.service.ts
+++ b/apps/api/src/modules/reservation/availability.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { eq, and, notInArray, lte, gte, sql } from 'drizzle-orm';
-import { reservations, roomTypes, properties } from '@haip/database';
+import { reservations, roomTypes, properties, rooms } from '@haip/database';
 import { DRIZZLE } from '../../database/database.module';
 
 export interface AvailabilityResult {
@@ -69,6 +69,25 @@ export class AvailabilityService {
         ),
       );
 
+    // Single grouped query for room counts per room type (avoids N+1).
+    const roomCountRows = await this.db
+      .select({
+        roomTypeId: rooms.roomTypeId,
+        count: sql<number>`count(*)`,
+      })
+      .from(rooms)
+      .where(
+        and(
+          eq(rooms.propertyId, propertyId),
+          eq(rooms.isActive, true),
+        ),
+      )
+      .groupBy(rooms.roomTypeId);
+
+    const roomCountByType = new Map<string, number>(
+      roomCountRows.map((r: any) => [r.roomTypeId, Number(r.count ?? 0)]),
+    );
+
     // Generate date-level availability
     const results: AvailabilityResult[] = [];
     const startDate = new Date(checkIn);
@@ -76,7 +95,7 @@ export class AvailabilityService {
 
     for (const type of types) {
       const totalRooms = type.maxOccupancy
-        ? await this.countRoomsByType(propertyId, type.id)
+        ? (roomCountByType.get(type.id) ?? 0)
         : 0;
 
       for (
@@ -112,18 +131,4 @@ export class AvailabilityService {
     return results;
   }
 
-  private async countRoomsByType(propertyId: string, roomTypeId: string): Promise<number> {
-    const { rooms } = await import('@haip/database');
-    const [result] = await this.db
-      .select({ count: sql<number>`count(*)` })
-      .from(rooms)
-      .where(
-        and(
-          eq(rooms.propertyId, propertyId),
-          eq(rooms.roomTypeId, roomTypeId),
-          eq(rooms.isActive, true),
-        ),
-      );
-    return Number(result?.count ?? 0);
-  }
 }

--- a/apps/api/src/modules/reservation/check-in.spec.ts
+++ b/apps/api/src/modules/reservation/check-in.spec.ts
@@ -161,14 +161,14 @@ describe('ReservationService — checkIn', () => {
   it('should transition state to checked_in', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    const result = await svc.checkIn('res-001');
+    const result = await svc.checkIn('res-001', 'prop-001');
     expect(result.reservation.status).toBe('checked_in');
   });
 
   it('should set checkedInAt and actualArrivalTime', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    const result = await svc.checkIn('res-001');
+    const result = await svc.checkIn('res-001', 'prop-001');
     expect(result.reservation.checkedInAt).toBeDefined();
     expect(result.reservation.actualArrivalTime).toBeDefined();
   });
@@ -176,21 +176,21 @@ describe('ReservationService — checkIn', () => {
   it('should create auto-folio', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001');
+    await svc.checkIn('res-001', 'prop-001');
     expect(mockFolioService.createAutoFolio).toHaveBeenCalled();
   });
 
   it('should mark room occupied', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001');
+    await svc.checkIn('res-001', 'prop-001');
     expect(mockRoomStatusService.markOccupied).toHaveBeenCalledWith('room-001', 'prop-001');
   });
 
   it('should emit reservation.checked_in webhook', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001');
+    await svc.checkIn('res-001', 'prop-001');
     expect(mockWebhookService.emit).toHaveBeenCalledWith(
       'reservation.checked_in',
       'reservation',
@@ -203,7 +203,7 @@ describe('ReservationService — checkIn', () => {
   it('should store encrypted guestIdDocument when ID provided', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001', {
+    await svc.checkIn('res-001', 'prop-001', {
       idType: 'passport',
       idNumber: 'AB123456',
       idCountry: 'US',
@@ -245,7 +245,7 @@ describe('ReservationService — checkIn', () => {
       }),
     };
     const svc = await createService(db);
-    await expect(svc.checkIn('res-001', { roomId: 'room-002' })).rejects.toThrow(
+    await expect(svc.checkIn('res-001', 'prop-001', { roomId: 'room-002' })).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -276,7 +276,7 @@ describe('ReservationService — checkIn', () => {
       }),
     };
     const svc = await createService(db);
-    await expect(svc.checkIn('res-001', { roomId: 'room-002' })).rejects.toThrow(
+    await expect(svc.checkIn('res-001', 'prop-001', { roomId: 'room-002' })).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -307,20 +307,20 @@ describe('ReservationService — checkIn', () => {
       }),
     };
     const svc = await createService(db);
-    await expect(svc.checkIn('res-001')).rejects.toThrow(BadRequestException);
+    await expect(svc.checkIn('res-001', 'prop-001')).rejects.toThrow(BadRequestException);
   });
 
   it('should reject DNR guest', async () => {
     const dnrGuest = { ...mockGuest, isDnr: true };
     const db = createCheckInDb({ guest: dnrGuest });
     const svc = await createService(db);
-    await expect(svc.checkIn('res-001')).rejects.toThrow(BadRequestException);
+    await expect(svc.checkIn('res-001', 'prop-001')).rejects.toThrow(BadRequestException);
   });
 
   it('should call paymentService.authorizePayment when token provided', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001', {
+    await svc.checkIn('res-001', 'prop-001', {
       gatewayPaymentToken: 'tok_test_123',
       gatewayProvider: 'stripe',
     });
@@ -335,7 +335,7 @@ describe('ReservationService — checkIn', () => {
   it('should skip deposit auth when skipDepositAuth is true', async () => {
     const db = createCheckInDb();
     const svc = await createService(db);
-    await svc.checkIn('res-001', {
+    await svc.checkIn('res-001', 'prop-001', {
       skipDepositAuth: true,
       gatewayPaymentToken: 'tok_test_123',
     });
@@ -348,7 +348,7 @@ describe('ReservationService — checkIn', () => {
     );
     const db = createCheckInDb();
     const svc = await createService(db);
-    const result = await svc.checkIn('res-001', {
+    const result = await svc.checkIn('res-001', 'prop-001', {
       gatewayPaymentToken: 'tok_test_fail',
       gatewayProvider: 'stripe',
     });
@@ -361,7 +361,7 @@ describe('ReservationService — checkIn', () => {
     const earlyProperty = { ...mockProperty, checkInTime: '23:59', settings: { earlyCheckInFee: 50 } };
     const db = createCheckInDb({ property: earlyProperty });
     const svc = await createService(db);
-    const result = await svc.checkIn('res-001');
+    const result = await svc.checkIn('res-001', 'prop-001');
     const updateCall = db.update.mock.results[0].value.set.mock.calls[0][0];
     expect(updateCall.isEarlyCheckin).toBe(true);
   });
@@ -370,7 +370,7 @@ describe('ReservationService — checkIn', () => {
     const earlyProperty = { ...mockProperty, checkInTime: '23:59', settings: { earlyCheckInFee: 50 } };
     const db = createCheckInDb({ property: earlyProperty });
     const svc = await createService(db);
-    await svc.checkIn('res-001');
+    await svc.checkIn('res-001', 'prop-001');
     expect(mockFolioService.postCharge).toHaveBeenCalledWith(
       'folio-001',
       expect.objectContaining({

--- a/apps/api/src/modules/reservation/check-out.spec.ts
+++ b/apps/api/src/modules/reservation/check-out.spec.ts
@@ -136,14 +136,14 @@ describe('ReservationService — checkOut', () => {
   it('should transition state to checked_out', async () => {
     const db = createCheckOutDb();
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001');
+    const result = await svc.checkOut('res-001', 'prop-001');
     expect(result.reservation.status).toBe('checked_out');
   });
 
   it('should set checkedOutAt and actualDepartureTime', async () => {
     const db = createCheckOutDb();
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001');
+    const result = await svc.checkOut('res-001', 'prop-001');
     expect(result.reservation.checkedOutAt).toBeDefined();
     expect(result.reservation.actualDepartureTime).toBeDefined();
   });
@@ -151,7 +151,7 @@ describe('ReservationService — checkOut', () => {
   it('should mark room vacant_dirty', async () => {
     const db = createCheckOutDb();
     const svc = await createService(db);
-    await svc.checkOut('res-001');
+    await svc.checkOut('res-001', 'prop-001');
     expect(mockRoomStatusService.markVacantDirty).toHaveBeenCalledWith('room-001', 'prop-001');
   });
 
@@ -160,7 +160,7 @@ describe('ReservationService — checkOut', () => {
     const notLateProperty = { ...mockProperty, checkOutTime: '23:59' };
     const db = createCheckOutDb({ property: notLateProperty });
     const svc = await createService(db);
-    await svc.checkOut('res-001');
+    await svc.checkOut('res-001', 'prop-001');
     expect(mockWebhookService.emit).toHaveBeenCalledWith(
       'reservation.checked_out',
       'reservation',
@@ -174,14 +174,14 @@ describe('ReservationService — checkOut', () => {
     const authPayment = { id: 'pay-auth-001', folioId: 'folio-001', status: 'authorized', propertyId: 'prop-001' };
     const db = createCheckOutDb({ authorizedPayments: [authPayment] });
     const svc = await createService(db);
-    await svc.checkOut('res-001', { expressCheckout: true });
+    await svc.checkOut('res-001', 'prop-001', { expressCheckout: true });
     expect(mockPaymentService.capturePayment).toHaveBeenCalledWith('pay-auth-001', 'prop-001');
   });
 
   it('should settle zero-balance folios on express checkout', async () => {
     const db = createCheckOutDb();
     const svc = await createService(db);
-    await svc.checkOut('res-001', { expressCheckout: true });
+    await svc.checkOut('res-001', 'prop-001', { expressCheckout: true });
     expect(mockFolioService.settle).toHaveBeenCalledWith('folio-001', 'prop-001');
   });
 
@@ -190,7 +190,7 @@ describe('ReservationService — checkOut', () => {
     const db = createCheckOutDb();
     const svc = await createService(db);
     await expect(
-      svc.checkOut('res-001', { expressCheckout: true }),
+      svc.checkOut('res-001', 'prop-001', { expressCheckout: true }),
     ).rejects.toThrow(BadRequestException);
   });
 
@@ -199,7 +199,7 @@ describe('ReservationService — checkOut', () => {
     const lateProperty = { ...mockProperty, checkOutTime: '00:01' };
     const db = createCheckOutDb({ property: lateProperty });
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001');
+    const result = await svc.checkOut('res-001', 'prop-001');
     const updateCall = db.update.mock.results[0].value.set.mock.calls[0][0];
     expect(updateCall.isLateCheckout).toBe(true);
   });
@@ -208,7 +208,7 @@ describe('ReservationService — checkOut', () => {
     const lateProperty = { ...mockProperty, checkOutTime: '00:01', settings: { lateCheckoutFee: 75 } };
     const db = createCheckOutDb({ property: lateProperty });
     const svc = await createService(db);
-    await svc.checkOut('res-001');
+    await svc.checkOut('res-001', 'prop-001');
     expect(mockFolioService.postCharge).toHaveBeenCalledWith(
       'folio-001',
       expect.objectContaining({
@@ -223,7 +223,7 @@ describe('ReservationService — checkOut', () => {
     const authPayment = { id: 'pay-auth-001', folioId: 'folio-001', status: 'authorized', propertyId: 'prop-001' };
     const db = createCheckOutDb({ authorizedPayments: [authPayment] });
     const svc = await createService(db);
-    await svc.checkOut('res-001');
+    await svc.checkOut('res-001', 'prop-001');
     expect(mockPaymentService.voidPayment).toHaveBeenCalledWith('pay-auth-001', 'prop-001');
   });
 
@@ -233,7 +233,7 @@ describe('ReservationService — checkOut', () => {
     });
     const db = createCheckOutDb();
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001');
+    const result = await svc.checkOut('res-001', 'prop-001');
     expect(result.folioSummary).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ folioId: 'folio-001', balance: '150.00' }),
@@ -245,7 +245,7 @@ describe('ReservationService — checkOut', () => {
     const stayoverRes = { ...mockReservation, status: 'stayover' };
     const db = createCheckOutDb({ reservation: stayoverRes });
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001');
+    const result = await svc.checkOut('res-001', 'prop-001');
     expect(result.reservation.status).toBe('checked_out');
   });
 });

--- a/apps/api/src/modules/reservation/dto/list-reservations.dto.ts
+++ b/apps/api/src/modules/reservation/dto/list-reservations.dto.ts
@@ -1,12 +1,11 @@
 import { IsUUID, IsOptional, IsEnum, IsDateString, IsInt, Min, Max } from 'class-validator';
-import { ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class ListReservationsDto {
-  @ApiPropertyOptional()
-  @IsOptional()
+  @ApiProperty({ description: 'Property ID (required for tenant scoping)' })
   @IsUUID()
-  propertyId?: string;
+  propertyId!: string;
 
   @ApiPropertyOptional({
     enum: ['pending', 'confirmed', 'assigned', 'checked_in', 'stayover', 'due_out', 'checked_out', 'no_show', 'cancelled'],

--- a/apps/api/src/modules/reservation/reservation.controller.ts
+++ b/apps/api/src/modules/reservation/reservation.controller.ts
@@ -60,7 +60,7 @@ export class ReservationController {
   // --- CRUD routes ---
 
   @Get()
-  @ApiOperation({ summary: 'List reservations with filters' })
+  @ApiOperation({ summary: 'List reservations with filters (propertyId required)' })
   @ApiResponse({ status: 200, description: 'Paginated list of reservations' })
   listReservations(@Query() dto: ListReservationsDto) {
     return this.reservationService.list(dto);
@@ -76,22 +76,28 @@ export class ReservationController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Get reservation with guest, room, and rate details' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Reservation found' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
-  getReservationById(@Param('id', ParseUUIDPipe) id: string) {
-    return this.reservationService.findById(id);
+  getReservationById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.reservationService.findById(id, propertyId);
   }
 
   @Patch(':id')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Modify reservation (dates, room type, rate, occupancy)' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Reservation modified' })
   @ApiResponse({ status: 404, description: 'Reservation not found' })
   modifyReservation(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: ModifyReservationDto,
   ) {
-    return this.reservationService.modify(id, dto);
+    return this.reservationService.modify(id, propertyId, dto);
   }
 
   // --- Lifecycle transition routes ---
@@ -99,68 +105,88 @@ export class ReservationController {
   @Patch(':id/confirm')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Confirm reservation' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Reservation confirmed' })
-  confirmReservation(@Param('id', ParseUUIDPipe) id: string) {
-    return this.reservationService.confirm(id);
+  confirmReservation(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.reservationService.confirm(id, propertyId);
   }
 
   @Patch(':id/assign-room')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Assign specific room to reservation' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Room assigned' })
   assignRoom(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: AssignRoomDto,
   ) {
-    return this.reservationService.assignRoom(id, dto);
+    return this.reservationService.assignRoom(id, propertyId, dto);
   }
 
   @Patch(':id/cancel')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Cancel reservation with optional reason' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Reservation cancelled' })
   cancelReservation(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: CancelReservationDto,
   ) {
-    return this.reservationService.cancel(id, dto);
+    return this.reservationService.cancel(id, propertyId, dto);
   }
 
   @Patch(':id/no-show')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Mark reservation as no-show' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Reservation marked as no-show' })
-  markNoShow(@Param('id', ParseUUIDPipe) id: string) {
-    return this.reservationService.markNoShow(id);
+  markNoShow(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.reservationService.markNoShow(id, propertyId);
   }
 
   @Patch(':id/check-in')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Check in reservation with optional ID capture, deposit auth, room override' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Guest checked in' })
   checkIn(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: CheckInDto,
   ) {
-    return this.reservationService.checkIn(id, dto);
+    return this.reservationService.checkIn(id, propertyId, dto);
   }
 
   @Patch(':id/check-out')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Check out reservation with optional express checkout and late fee' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Guest checked out' })
   checkOut(
     @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: CheckOutDto,
   ) {
-    return this.reservationService.checkOut(id, dto);
+    return this.reservationService.checkOut(id, propertyId, dto);
   }
 
   @Post(':id/express-checkout')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Express checkout — auto-capture deposits and settle' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Express checkout completed' })
-  expressCheckOut(@Param('id', ParseUUIDPipe) id: string) {
-    return this.reservationService.expressCheckOut(id);
+  expressCheckOut(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.reservationService.expressCheckOut(id, propertyId);
   }
 }

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -61,25 +61,29 @@ export class ReservationService {
       throw new BadRequestException('Departure date must be after arrival date');
     }
 
-    // Check inventory availability
-    const availability = await this.availabilityService.searchAvailability(
-      dto.propertyId,
-      dto.arrivalDate,
-      dto.departureDate,
-      dto.roomTypeId,
-    );
-    const roomTypeAvail = availability.find((a: any) => a.roomTypeId === dto.roomTypeId);
-    if (!roomTypeAvail || roomTypeAvail.available <= 0) {
-      throw new BadRequestException(
-        `No availability for room type ${dto.roomTypeId} on the requested dates`,
-      );
-    }
-
     // Generate confirmation number
     const confirmationNumber = `HAIP-${Date.now().toString(36).toUpperCase()}-${randomUUID().slice(0, 4).toUpperCase()}`;
 
-    // Create booking + reservation in a transaction
+    // TOCTOU: availability check + insert run inside the same transaction so the
+    // race window between "there's space" and "we wrote the booking" is minimized.
+    // Postgres default isolation is READ COMMITTED, so concurrent txs can still
+    // double-book in theory; for stronger guarantees promote to SERIALIZABLE.
+    // See Bug 5 — kept at default to avoid driver-compat surprises.
     const result = await this.db.transaction(async (tx: any) => {
+      // Check inventory availability inside the tx
+      const availability = await this.availabilityService.searchAvailability(
+        dto.propertyId,
+        dto.arrivalDate,
+        dto.departureDate,
+        dto.roomTypeId,
+      );
+      const roomTypeAvail = availability.find((a: any) => a.roomTypeId === dto.roomTypeId);
+      if (!roomTypeAvail || roomTypeAvail.available <= 0) {
+        throw new BadRequestException(
+          `No availability for room type ${dto.roomTypeId} on the requested dates`,
+        );
+      }
+
       const [booking] = await tx
         .insert(bookings)
         .values({
@@ -132,20 +136,22 @@ export class ReservationService {
     return result;
   }
 
-  async confirm(id: string) {
-    const reservation = await this.findByIdRaw(id);
+  async confirm(id: string, propertyId: string) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'confirmed');
 
     const [updated] = await this.db
       .update(reservations)
       .set({ status: 'confirmed', updatedAt: new Date() })
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
     return updated;
   }
 
-  async assignRoom(id: string, dto: AssignRoomDto) {
-    const reservation = await this.findByIdRaw(id);
+  async assignRoom(id: string, propertyId: string, dto: AssignRoomDto) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'assigned');
 
     // Verify room exists, belongs to same property, and matches room type
@@ -172,13 +178,15 @@ export class ReservationService {
     const [updated] = await this.db
       .update(reservations)
       .set({ roomId: dto.roomId, status: 'assigned', updatedAt: new Date() })
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
     return updated;
   }
 
-  async cancel(id: string, dto: CancelReservationDto) {
-    const reservation = await this.findByIdRaw(id);
+  async cancel(id: string, propertyId: string, dto: CancelReservationDto) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'cancelled');
 
     const [updated] = await this.db
@@ -189,7 +197,9 @@ export class ReservationService {
         cancellationReason: dto.cancellationReason,
         updatedAt: new Date(),
       })
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
 
     // Emit reservation.cancelled so channel manager / ARI can push updated availability.
@@ -210,20 +220,22 @@ export class ReservationService {
     return updated;
   }
 
-  async markNoShow(id: string) {
-    const reservation = await this.findByIdRaw(id);
+  async markNoShow(id: string, propertyId: string) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'no_show');
 
     const [updated] = await this.db
       .update(reservations)
       .set({ status: 'no_show', updatedAt: new Date() })
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
     return updated;
   }
 
-  async checkIn(id: string, dto: CheckInDto = {}) {
-    const reservation = await this.findByIdRaw(id);
+  async checkIn(id: string, propertyId: string, dto: CheckInDto = {}) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'checked_in');
 
     // DNR check
@@ -327,7 +339,9 @@ export class ReservationService {
     const [updated] = await this.db
       .update(reservations)
       .set(updateData)
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
 
     // Auto-create guest folio on check-in
@@ -384,8 +398,8 @@ export class ReservationService {
     return { reservation: updated, folio, depositAuth };
   }
 
-  async checkOut(id: string, dto: CheckOutDto = {}) {
-    const reservation = await this.findByIdRaw(id);
+  async checkOut(id: string, propertyId: string, dto: CheckOutDto = {}) {
+    const reservation = await this.findByIdRaw(id, propertyId);
     assertTransition(reservation.status as ReservationStatus, 'checked_out');
 
     const now = new Date();
@@ -539,7 +553,9 @@ export class ReservationService {
     const [updated] = await this.db
       .update(reservations)
       .set(updateData)
-      .where(eq(reservations.id, id))
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      )
       .returning();
 
     // Emit webhook
@@ -554,8 +570,8 @@ export class ReservationService {
     return { reservation: updated, folioSummary };
   }
 
-  async expressCheckOut(id: string) {
-    return this.checkOut(id, { expressCheckout: true });
+  async expressCheckOut(id: string, propertyId: string) {
+    return this.checkOut(id, propertyId, { expressCheckout: true });
   }
 
   async groupCheckIn(propertyId: string, dto: GroupCheckInDto) {
@@ -566,9 +582,18 @@ export class ReservationService {
       error?: string;
     }> = [];
 
-    // Validate all reservations belong to the same property
+    // Validate all reservations belong to the same property.
+    // findByIdRaw is scoped by propertyId, and we also double-check the returned
+    // row's propertyId defensively for a clearer error message.
     for (const item of dto.reservations) {
-      const reservation = await this.findByIdRaw(item.reservationId);
+      let reservation: any;
+      try {
+        reservation = await this.findByIdRaw(item.reservationId, propertyId);
+      } catch {
+        throw new BadRequestException(
+          `Reservation ${item.reservationId} does not belong to property ${propertyId}`,
+        );
+      }
       if (reservation.propertyId !== propertyId) {
         throw new BadRequestException(
           `Reservation ${item.reservationId} does not belong to property ${propertyId}`,
@@ -579,7 +604,7 @@ export class ReservationService {
     // Process each check-in individually
     for (const item of dto.reservations) {
       try {
-        const result = await this.checkIn(item.reservationId, {
+        const result = await this.checkIn(item.reservationId, propertyId, {
           roomId: item.roomId,
           skipDepositAuth: item.skipDepositAuth,
         });
@@ -601,8 +626,8 @@ export class ReservationService {
     };
   }
 
-  async modify(id: string, dto: ModifyReservationDto) {
-    const reservation = await this.findByIdRaw(id);
+  async modify(id: string, propertyId: string, dto: ModifyReservationDto) {
+    const reservation = await this.findByIdRaw(id, propertyId);
 
     // Can only modify before check-out
     const nonModifiable: ReservationStatus[] = ['checked_out', 'no_show', 'cancelled'];
@@ -644,48 +669,59 @@ export class ReservationService {
     // If dates or room type change, re-check availability on the new window.
     // The existing reservation still occupies its old window (and room type) in searchAvailability,
     // so if roomType is unchanged we must exclude it from the count to avoid blocking itself on overlap.
-    if (arrivalChanged || departureChanged || roomTypeChanged) {
-      const newArrival = (dto.arrivalDate ?? reservation.arrivalDate) as string;
-      const newDeparture = (dto.departureDate ?? reservation.departureDate) as string;
-      const newRoomTypeId = (dto.roomTypeId ?? reservation.roomTypeId) as string;
+    //
+    // TOCTOU: we run the availability check and the update inside the same transaction
+    // so concurrent writers cannot slip between them. Postgres' default isolation
+    // (READ COMMITTED) still permits some overlap, but the race window is minimized.
+    // For stricter guarantees, raise the transaction to SERIALIZABLE — not done here
+    // to avoid breakage with drizzle-orm's postgres-js driver; see Bug 5.
+    const updated = await this.db.transaction(async (tx: any) => {
+      if (arrivalChanged || departureChanged || roomTypeChanged) {
+        const newArrival = (dto.arrivalDate ?? reservation.arrivalDate) as string;
+        const newDeparture = (dto.departureDate ?? reservation.departureDate) as string;
+        const newRoomTypeId = (dto.roomTypeId ?? reservation.roomTypeId) as string;
 
-      const availability = await this.availabilityService.searchAvailability(
-        reservation.propertyId,
-        newArrival,
-        newDeparture,
-        newRoomTypeId,
-      );
-
-      // Check each night in the requested window has availability.
-      // If the reservation currently occupies the same room type and overlaps the new window,
-      // it was counted as "sold" — give it back one unit when evaluating.
-      const currentCountsItself = !roomTypeChanged &&
-        reservation.arrivalDate < newDeparture &&
-        reservation.departureDate > newArrival;
-
-      const nightsOk = availability
-        .filter((a: any) => a.roomTypeId === newRoomTypeId)
-        .every((a: any) => {
-          const existingOccupiesThisNight =
-            currentCountsItself &&
-            (reservation.arrivalDate as string) <= a.date &&
-            (reservation.departureDate as string) > a.date;
-          const effectiveAvailable = a.available + (existingOccupiesThisNight ? 1 : 0);
-          return effectiveAvailable > 0;
-        });
-
-      if (!nightsOk) {
-        throw new ConflictException(
-          `No availability for room type ${newRoomTypeId} on ${newArrival} → ${newDeparture}`,
+        const availability = await this.availabilityService.searchAvailability(
+          reservation.propertyId,
+          newArrival,
+          newDeparture,
+          newRoomTypeId,
         );
-      }
-    }
 
-    const [updated] = await this.db
-      .update(reservations)
-      .set(updates)
-      .where(eq(reservations.id, id))
-      .returning();
+        // Check each night in the requested window has availability.
+        // If the reservation currently occupies the same room type and overlaps the new window,
+        // it was counted as "sold" — give it back one unit when evaluating.
+        const currentCountsItself = !roomTypeChanged &&
+          reservation.arrivalDate < newDeparture &&
+          reservation.departureDate > newArrival;
+
+        const nightsOk = availability
+          .filter((a: any) => a.roomTypeId === newRoomTypeId)
+          .every((a: any) => {
+            const existingOccupiesThisNight =
+              currentCountsItself &&
+              (reservation.arrivalDate as string) <= a.date &&
+              (reservation.departureDate as string) > a.date;
+            const effectiveAvailable = a.available + (existingOccupiesThisNight ? 1 : 0);
+            return effectiveAvailable > 0;
+          });
+
+        if (!nightsOk) {
+          throw new ConflictException(
+            `No availability for room type ${newRoomTypeId} on ${newArrival} → ${newDeparture}`,
+          );
+        }
+      }
+
+      const [row] = await tx
+        .update(reservations)
+        .set(updates)
+        .where(
+          and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+        )
+        .returning();
+      return row;
+    });
 
     // Emit reservation.modified so channel manager / ARI can push updated availability.
     await this.webhookService.emit(
@@ -707,8 +743,9 @@ export class ReservationService {
     return updated;
   }
 
-  async findById(id: string) {
-    // Join with guest, room type, rate plan, and room (if assigned)
+  async findById(id: string, propertyId: string) {
+    // Join with guest, room type, rate plan, and room (if assigned).
+    // Tenant-scoped via propertyId to prevent cross-tenant access.
     const results = await this.db
       .select({
         reservation: reservations,
@@ -722,7 +759,9 @@ export class ReservationService {
       .leftJoin(roomTypes, eq(reservations.roomTypeId, roomTypes.id))
       .leftJoin(ratePlans, eq(reservations.ratePlanId, ratePlans.id))
       .leftJoin(rooms, eq(reservations.roomId, rooms.id))
-      .where(eq(reservations.id, id));
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      );
 
     if (!results.length) {
       throw new NotFoundException(`Reservation ${id} not found`);
@@ -732,11 +771,9 @@ export class ReservationService {
   }
 
   async list(dto: ListReservationsDto) {
-    const conditions: any[] = [];
+    // propertyId is required by the DTO — always tenant-scope.
+    const conditions: any[] = [eq(reservations.propertyId, dto.propertyId)];
 
-    if (dto.propertyId) {
-      conditions.push(eq(reservations.propertyId, dto.propertyId));
-    }
     if (dto.status) {
       conditions.push(eq(reservations.status, dto.status as any));
     }
@@ -804,11 +841,13 @@ export class ReservationService {
     };
   }
 
-  private async findByIdRaw(id: string) {
+  private async findByIdRaw(id: string, propertyId: string) {
     const [reservation] = await this.db
       .select()
       .from(reservations)
-      .where(eq(reservations.id, id));
+      .where(
+        and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)),
+      );
     if (!reservation) {
       throw new NotFoundException(`Reservation ${id} not found`);
     }

--- a/apps/api/src/modules/room/room.controller.ts
+++ b/apps/api/src/modules/room/room.controller.ts
@@ -45,10 +45,14 @@ export class RoomController {
 
   @Get('types/:id')
   @ApiOperation({ summary: 'Get room type by ID' })
+  @ApiQuery({ name: 'propertyId', required: true })
   @ApiResponse({ status: 200, description: 'Room type found' })
   @ApiResponse({ status: 404, description: 'Room type not found' })
-  getRoomTypeById(@Param('id', ParseUUIDPipe) id: string) {
-    return this.roomService.findRoomTypeById(id);
+  getRoomTypeById(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.roomService.findRoomTypeById(id, propertyId);
   }
 
   // --- Room status routes (before :id to avoid conflicts) ---

--- a/apps/api/src/modules/room/room.service.ts
+++ b/apps/api/src/modules/room/room.service.ts
@@ -29,11 +29,11 @@ export class RoomService {
       );
   }
 
-  async findRoomTypeById(id: string) {
+  async findRoomTypeById(id: string, propertyId: string) {
     const [roomType] = await this.db
       .select()
       .from(roomTypes)
-      .where(eq(roomTypes.id, id));
+      .where(and(eq(roomTypes.id, id), eq(roomTypes.propertyId, propertyId)));
     if (!roomType) {
       throw new NotFoundException(`Room type ${id} not found`);
     }


### PR DESCRIPTION
## Summary

Third round of codex review fixes, plus a systematic audit of every service method across all modules for the multi-tenant leak class.

## Round-3 bugs fixed (6)

| # | Severity | Bug |
|---|----------|-----|
| 1 | CRITICAL | Reservation endpoints not tenant-scoped (list + all lifecycle routes) |
| 2 | HIGH | \`RolesGuard\` failed open when \`AUTH_ENABLED\` unset |
| 3 | HIGH | \`JwtStrategy\` not registered when \`AUTH_ENABLED\` unset (crash risk) |
| 4 | HIGH | Inbound reservation dedup missing \`propertyId\` scope |
| 5 | HIGH | Availability TOCTOU: check+write now in \`db.transaction()\` |
| 6 | MEDIUM | \`searchAvailability\` N+1 replaced with grouped count |

## Tenant-scoping audit

Reviewed every \`.select/.update/.delete\` WHERE clause in all service files. Additional leaks found and fixed:

- \`rate-plan.service\`: findById, update, calculateDerivedRate, createRestriction, findRestrictions, updateRestriction, deleteRestriction
- \`room.service.findRoomTypeById\`
- \`channel/rate-parity.service.getEffectiveRate\` (propertyId was a param but unused in WHERE)
- \`channel/ari.service.pushRates\` ratePlan lookup (defensive hardening)
- \`connect-events.service\`: deleteSubscription, testSubscription

Deliberate non-changes documented: \`guest.service\` (guests are cross-property by design), \`connect-*\` agent-facing APIs (bearer-credential model via confirmationNumber), internal scheduler-only methods.

## Test plan
- [x] \`pnpm build\` — green
- [x] \`pnpm typecheck\` — green
- [x] \`pnpm test\` — 551/551 api + 39/39 dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)