### PR TITLE
fix: PR C — operational (round 4, bugs 7/10/12)

### DIFF
--- a/apps/api/src/modules/agent/agent.controller.ts
+++ b/apps/api/src/modules/agent/agent.controller.ts
@@ -15,6 +15,7 @@ import { eq, and, desc } from 'drizzle-orm';
 import { guestReviews } from '@haip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { Roles } from '../auth/roles.decorator';
+import { CurrentUser, type AuthUser } from '../auth/current-user.decorator';
 import { AgentService } from './agent.service';
 import { UpdateAgentConfigDto } from './dto/agent-config.dto';
 import { RejectDecisionDto } from './dto/agent-decision.dto';
@@ -50,8 +51,9 @@ export class AgentController {
     @Param('propertyId', ParseUUIDPipe) propertyId: string,
     @Param('agentType') agentType: string,
     @Body() dto: UpdateAgentConfigDto,
+    @CurrentUser() user?: AuthUser,
   ) {
-    return this.agentService.updateConfig(propertyId, agentType, dto as any);
+    return this.agentService.updateConfig(propertyId, agentType, dto as any, user?.sub);
   }
 
   @Post(':propertyId/:agentType/run')
@@ -83,8 +85,9 @@ export class AgentController {
   async approveDecision(
     @Param('propertyId', ParseUUIDPipe) propertyId: string,
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user?: AuthUser,
   ) {
-    return this.agentService.approveDecision(propertyId, id);
+    return this.agentService.approveDecision(propertyId, id, user?.sub);
   }
 
   @Post(':propertyId/decisions/:id/reject')
@@ -93,8 +96,9 @@ export class AgentController {
     @Param('propertyId', ParseUUIDPipe) propertyId: string,
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: RejectDecisionDto,
+    @CurrentUser() user?: AuthUser,
   ) {
-    return this.agentService.rejectDecision(propertyId, id, undefined, dto.reason);
+    return this.agentService.rejectDecision(propertyId, id, user?.sub, dto.reason);
   }
 
   @Get(':propertyId/:agentType/performance')

--- a/apps/api/src/modules/agent/agent.service.spec.ts
+++ b/apps/api/src/modules/agent/agent.service.spec.ts
@@ -300,6 +300,78 @@ describe('AgentService', () => {
     await expect(service.getDecisions('prop-1', 'not_real')).rejects.toThrow(BadRequestException);
   });
 
+  // --- Audit logging ---
+
+  it('writes an audit log row when updateConfig changes a field', async () => {
+    const disabledConfig = { ...existingConfig, isEnabled: false };
+    const updatedConfig = { ...existingConfig, isEnabled: true };
+    const db = createMockDb({
+      selectResult: [disabledConfig],
+      updateResult: [updatedConfig],
+    });
+    const module = await Test.createTestingModule({
+      providers: [
+        AgentService,
+        { provide: DRIZZLE, useValue: db },
+        { provide: WebhookService, useValue: { emit: vi.fn() } },
+      ],
+    }).compile();
+    const service = module.get(AgentService);
+
+    await service.updateConfig('prop-1', 'pricing', { isEnabled: true }, 'user-42');
+
+    // First insert is the audit row (no other inserts happen in updateConfig).
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    const insertedValues = (db.insert.mock.results[0]!.value.values as any).mock.calls[0][0];
+    expect(insertedValues.action).toBe('update');
+    expect(insertedValues.entityType).toBe('agent_config');
+    expect(insertedValues.userId).toBe('user-42');
+    expect(insertedValues.previousValue).toEqual({ isEnabled: false });
+    expect(insertedValues.newValue).toEqual({ isEnabled: true });
+  });
+
+  it('skips audit log when updateConfig makes no effective change', async () => {
+    // isEnabled already true, update passes the same value
+    const db = createMockDb({
+      selectResult: [existingConfig],
+      updateResult: [existingConfig],
+    });
+    const module = await Test.createTestingModule({
+      providers: [
+        AgentService,
+        { provide: DRIZZLE, useValue: db },
+        { provide: WebhookService, useValue: { emit: vi.fn() } },
+      ],
+    }).compile();
+    const service = module.get(AgentService);
+
+    await service.updateConfig('prop-1', 'pricing', { isEnabled: true });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('writes an audit log row when rejectDecision is called', async () => {
+    const db = createMockDb({
+      selectResult: [pendingDecision],
+      updateResult: [{ ...pendingDecision, status: 'rejected' }],
+    });
+    const module = await Test.createTestingModule({
+      providers: [
+        AgentService,
+        { provide: DRIZZLE, useValue: db },
+        { provide: WebhookService, useValue: { emit: vi.fn() } },
+      ],
+    }).compile();
+    const service = module.get(AgentService);
+
+    await service.rejectDecision('prop-1', 'dec-1', 'user-99', 'not confident');
+
+    expect(db.insert).toHaveBeenCalledTimes(1);
+    const insertedValues = (db.insert.mock.results[0]!.value.values as any).mock.calls[0][0];
+    expect(insertedValues.entityType).toBe('agent_decision');
+    expect(insertedValues.userId).toBe('user-99');
+    expect(insertedValues.newValue).toMatchObject({ status: 'rejected', reason: 'not confident' });
+  });
+
   // --- getPerformance logic ---
 
   it('calculates performance metrics correctly', () => {

--- a/apps/api/src/modules/agent/agent.service.ts
+++ b/apps/api/src/modules/agent/agent.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject, NotFoundException, BadRequestException } from '@nestjs/common';
 import { eq, and, desc } from 'drizzle-orm';
-import { agentConfigs, agentDecisions, agentTrainingSnapshots } from '@haip/database';
+import { agentConfigs, agentDecisions, agentTrainingSnapshots, auditLogs } from '@haip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { WebhookService } from '../webhook/webhook.service';
 import type {
@@ -165,6 +165,17 @@ export class AgentService {
       .where(eq(agentDecisions.id, decisionId))
       .returning();
 
+    await this.db.insert(auditLogs).values({
+      propertyId,
+      action: 'update',
+      entityType: 'agent_decision',
+      entityId: decisionId,
+      userId: userId ?? null,
+      previousValue: { status: 'pending' },
+      newValue: { status: 'approved', agentType: decision.agentType, decisionType: decision.decisionType },
+      description: `Agent decision approved and executed: ${decision.agentType}/${decision.decisionType}`,
+    });
+
     await this.webhookService.emit(
       'agent.decision_executed',
       'agent_decision',
@@ -193,6 +204,17 @@ export class AgentService {
       })
       .where(eq(agentDecisions.id, decisionId))
       .returning();
+
+    await this.db.insert(auditLogs).values({
+      propertyId,
+      action: 'update',
+      entityType: 'agent_decision',
+      entityId: decisionId,
+      userId: userId ?? null,
+      previousValue: { status: 'pending' },
+      newValue: { status: 'rejected', reason: reason ?? null },
+      description: `Agent decision rejected: ${decision.agentType}/${decision.decisionType}`,
+    });
 
     return updated;
   }
@@ -260,8 +282,13 @@ export class AgentService {
     return config;
   }
 
-  /** Update agent config. */
-  async updateConfig(propertyId: string, agentType: string, updates: Record<string, unknown>) {
+  /** Update agent config — writes an audit log row describing the diff. */
+  async updateConfig(
+    propertyId: string,
+    agentType: string,
+    updates: Record<string, unknown>,
+    userId?: string,
+  ) {
     const config = await this.getOrCreateConfig(propertyId, agentType);
 
     const setValues: Record<string, unknown> = { updatedAt: new Date() };
@@ -276,6 +303,36 @@ export class AgentService {
       .set(setValues)
       .where(eq(agentConfigs.id, config.id))
       .returning();
+
+    // Build diff of the fields the user actually changed (sensitive config only).
+    const auditFields = ['isEnabled', 'mode', 'autopilotConfidenceThreshold', 'config'];
+    const diff: Record<string, { old: unknown; new: unknown }> = {};
+    for (const field of auditFields) {
+      if (updates[field] === undefined) continue;
+      const oldValue = (config as any)[field];
+      const newValue = (updated as any)[field];
+      // Only record if actually changed (string-compare to handle numeric thresholds).
+      if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
+        diff[field] = { old: oldValue, new: newValue };
+      }
+    }
+
+    if (Object.keys(diff).length > 0) {
+      await this.db.insert(auditLogs).values({
+        propertyId,
+        action: 'update',
+        entityType: 'agent_config',
+        entityId: config.id,
+        userId: userId ?? null,
+        previousValue: Object.fromEntries(
+          Object.entries(diff).map(([k, v]) => [k, v.old]),
+        ),
+        newValue: Object.fromEntries(
+          Object.entries(diff).map(([k, v]) => [k, v.new]),
+        ),
+        description: `Agent config updated: ${agentType} (${Object.keys(diff).join(', ')})`,
+      });
+    }
 
     return updated;
   }

--- a/apps/api/src/modules/connect/connect-events.service.spec.ts
+++ b/apps/api/src/modules/connect/connect-events.service.spec.ts
@@ -131,6 +131,59 @@ describe('ConnectEventsService', () => {
     });
   });
 
+  describe('handleEvent', () => {
+    it('enqueues a delivery via WebhookDeliveryService for each matching subscription', async () => {
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([mockSubscription]),
+        }),
+      }));
+
+      const deliveryService = { enqueue: vi.fn().mockResolvedValue({ id: 'del-1' }) };
+      const svc = new ConnectEventsService(mockDb, deliveryService as any);
+
+      await svc.handleEvent({
+        event: 'reservation.created',
+        entityType: 'reservation',
+        entityId: 'res-1',
+        propertyId: 'prop-1',
+        data: { foo: 'bar' },
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(deliveryService.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'reservation.created',
+          propertyId: 'prop-1',
+          entityType: 'reservation',
+          entityId: 'res-1',
+        }),
+        'sub-1',
+      );
+    });
+
+    it('does nothing when no subscriptions match', async () => {
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([mockSubscription]),
+        }),
+      }));
+      const deliveryService = { enqueue: vi.fn() };
+      const svc = new ConnectEventsService(mockDb, deliveryService as any);
+
+      await svc.handleEvent({
+        event: 'unrelated.event',
+        entityType: 'x',
+        entityId: 'y',
+        propertyId: 'prop-1',
+        data: {},
+        timestamp: new Date().toISOString(),
+      });
+
+      expect(deliveryService.enqueue).not.toHaveBeenCalled();
+    });
+  });
+
   describe('pollEvents', () => {
     it('should return events filtered by type', async () => {
       const mockEvents = [

--- a/apps/api/src/modules/connect/connect-events.service.ts
+++ b/apps/api/src/modules/connect/connect-events.service.ts
@@ -1,13 +1,17 @@
-import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException, Optional } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import { eq, and, gte, desc } from 'drizzle-orm';
 import { agentWebhookSubscriptions, auditLogs } from '@haip/database';
 import { DRIZZLE } from '../../database/database.module';
 import type { CreateSubscriptionDto } from './dto/agent-event-subscription.dto';
+import { WebhookDeliveryService } from '../webhook/webhook-delivery.service';
 
 @Injectable()
 export class ConnectEventsService {
-  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+  constructor(
+    @Inject(DRIZZLE) private readonly db: any,
+    @Optional() private readonly deliveryService?: WebhookDeliveryService,
+  ) {}
 
   /**
    * Create an event subscription for an OTAIP agent.
@@ -174,17 +178,53 @@ export class ConnectEventsService {
     for (const sub of subscriptions) {
       const events = (sub.events ?? []) as string[];
       if (events.some((pattern: string) => this.matchesEventPattern(payload.event, pattern))) {
-        // Log the delivery attempt (no actual HTTP call yet)
-        await this.db
-          .update(agentWebhookSubscriptions)
-          .set({
-            lastDeliveryAt: new Date(),
-            lastDeliveryStatus: 'logged',
-            updatedAt: new Date(),
-          })
-          .where(eq(agentWebhookSubscriptions.id, sub.id));
+        if (this.deliveryService) {
+          // Enqueue a real HTTP delivery (HMAC-signed, retried).
+          await this.deliveryService.enqueue(
+            {
+              eventType: payload.event,
+              propertyId: payload.propertyId,
+              entityType: payload.entityType,
+              entityId: payload.entityId,
+              data: payload.data ?? {},
+              timestamp: payload.timestamp ?? new Date().toISOString(),
+            },
+            sub.id,
+          );
+        } else {
+          // Fallback — just log the match (for tests / environments without delivery service).
+          await this.db
+            .update(agentWebhookSubscriptions)
+            .set({
+              lastDeliveryAt: new Date(),
+              lastDeliveryStatus: 'logged',
+              updatedAt: new Date(),
+            })
+            .where(eq(agentWebhookSubscriptions.id, sub.id));
+        }
       }
     }
+  }
+
+  /**
+   * List delivery attempts for a subscription (scoped by propertyId).
+   */
+  async listDeliveries(subscriptionId: string, propertyId: string, limit = 50) {
+    if (!this.deliveryService) return [];
+    // Verify subscription belongs to propertyId before returning deliveries.
+    const [subscription] = await this.db
+      .select()
+      .from(agentWebhookSubscriptions)
+      .where(
+        and(
+          eq(agentWebhookSubscriptions.id, subscriptionId),
+          eq(agentWebhookSubscriptions.propertyId, propertyId),
+        ),
+      );
+    if (!subscription) {
+      throw new NotFoundException(`Subscription ${subscriptionId} not found`);
+    }
+    return this.deliveryService.listDeliveries(subscriptionId, propertyId, limit);
   }
 
   /**

--- a/apps/api/src/modules/connect/connect.controller.ts
+++ b/apps/api/src/modules/connect/connect.controller.ts
@@ -122,6 +122,22 @@ export class ConnectController {
     return this.eventsService.testSubscription(id, propertyId);
   }
 
+  @Get('subscriptions/:id/deliveries')
+  @ApiOperation({ summary: 'List webhook delivery attempts for a subscription' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  @ApiQuery({ name: 'limit', required: false })
+  async listDeliveries(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @Query('limit') limit?: string,
+  ) {
+    return this.eventsService.listDeliveries(
+      id,
+      propertyId,
+      limit ? parseInt(limit, 10) : undefined,
+    );
+  }
+
   // --- Event Polling ---
 
   @Get('events')

--- a/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createHmac } from 'crypto';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+
+/**
+ * Stateful mock DB that stores webhook_deliveries in memory so the service's
+ * read-modify-write cycle actually works. Subscriptions are handed back from
+ * a lookup map. Only the fields the service actually uses are modelled.
+ */
+function createStatefulMockDb(subscription: any) {
+  const deliveries = new Map<string, any>();
+  let idCounter = 1;
+
+  // Single-table lookup by probing call args — Drizzle operators return opaque
+  // objects, so we use a simple heuristic: track the last table referenced.
+  let currentTable: 'webhook_deliveries' | 'subscriptions' = 'webhook_deliveries';
+
+  const identifyTable = (tbl: any): 'webhook_deliveries' | 'subscriptions' => {
+    // @haip/database exports identifiable symbols on each pgTable. Fall back
+    // to a constructor-name check; the test just needs to distinguish.
+    const name = tbl?.[Symbol.for('drizzle:Name')] ?? tbl?._?.name ?? '';
+    if (String(name).includes('webhook_deliveries')) return 'webhook_deliveries';
+    if (String(name).includes('agent_webhook_subscriptions')) return 'subscriptions';
+    // Last-resort: alternate between calls based on recent context.
+    return currentTable;
+  };
+
+  const makeSelectChain = (tableId: 'webhook_deliveries' | 'subscriptions') => ({
+    from: vi.fn(() => {
+      currentTable = tableId;
+      return {
+        where: vi.fn(() => {
+          // Resolve with all rows for simplicity; callers use .id match.
+          if (tableId === 'subscriptions') {
+            return Promise.resolve([subscription]);
+          }
+          // For webhook_deliveries the service expects either a single-row
+          // lookup (by id) or a list of pending rows. We return ALL rows; the
+          // service filters by id after.
+          return Promise.resolve(Array.from(deliveries.values()));
+        }),
+      };
+    }),
+  });
+
+  return {
+    _deliveries: deliveries,
+    select: vi.fn((arg?: any) => {
+      // select() with no arg = full row; from() dispatches by table.
+      return {
+        from: vi.fn((tbl: any) => {
+          const tableId = identifyTable(tbl);
+          return {
+            where: vi.fn(() => {
+              if (tableId === 'subscriptions') {
+                return Promise.resolve([subscription]);
+              }
+              return Promise.resolve(Array.from(deliveries.values()));
+            }),
+            limit: vi.fn(() => Promise.resolve(Array.from(deliveries.values()))),
+          };
+        }),
+      };
+    }),
+    insert: vi.fn((tbl: any) => ({
+      values: vi.fn((vals: any) => ({
+        returning: vi.fn(() => {
+          const id = `del-${idCounter++}`;
+          const row = { id, ...vals };
+          deliveries.set(id, row);
+          return Promise.resolve([row]);
+        }),
+      })),
+    })),
+    update: vi.fn((tbl: any) => ({
+      set: vi.fn((vals: any) => ({
+        where: vi.fn(() => {
+          // Without parsing the eq() operator, we apply the update to the
+          // most recent delivery row (tests only touch one at a time).
+          const last = Array.from(deliveries.values()).pop();
+          if (last) Object.assign(last, vals);
+          return Promise.resolve();
+        }),
+      })),
+    })),
+  };
+}
+
+describe('WebhookDeliveryService', () => {
+  const subscription = {
+    id: 'sub-1',
+    propertyId: 'prop-1',
+    callbackUrl: 'https://hooks.test/endpoint',
+    secret: 'super-secret',
+    isActive: true,
+    failureCount: 0,
+  };
+
+  const payload = {
+    eventType: 'reservation.created',
+    propertyId: 'prop-1',
+    entityType: 'reservation',
+    entityId: 'res-1',
+    data: { foo: 'bar' },
+    timestamp: new Date().toISOString(),
+  };
+
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalEnv = process.env['NODE_ENV'];
+
+  beforeEach(() => {
+    process.env['NODE_ENV'] = 'test';
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as any;
+  });
+
+  afterEach(() => {
+    process.env['NODE_ENV'] = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('enqueues a delivery and POSTs with HMAC signature + event headers', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    const db = createStatefulMockDb(subscription);
+    const service = new WebhookDeliveryService(db as any);
+
+    const delivery = await service.enqueue(payload, subscription.id);
+    // Await the async attempt fired by enqueue.
+    await new Promise((r) => setImmediate(r));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://hooks.test/endpoint');
+    expect(init.method).toBe('POST');
+
+    const body = init.body as string;
+    const expectedSig = `sha256=${createHmac('sha256', subscription.secret).update(body).digest('hex')}`;
+    expect(init.headers['X-HAIP-Signature']).toBe(expectedSig);
+    expect(init.headers['X-HAIP-Event-Id']).toBe(delivery.id);
+    expect(init.headers['X-HAIP-Event-Type']).toBe('reservation.created');
+    expect(init.headers['Content-Type']).toBe('application/json');
+
+    // Row should be marked delivered.
+    const stored = db._deliveries.get(delivery.id);
+    expect(stored.status).toBe('delivered');
+    expect(stored.attempts).toBe(1);
+  });
+
+  it('schedules a retry on non-2xx response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const db = createStatefulMockDb(subscription);
+    const service = new WebhookDeliveryService(db as any);
+
+    const delivery = await service.enqueue(payload, subscription.id);
+    await new Promise((r) => setImmediate(r));
+
+    const stored = db._deliveries.get(delivery.id);
+    expect(stored.status).toBe('pending');
+    expect(stored.attempts).toBe(1);
+    expect(stored.lastStatusCode).toBe(500);
+    expect(stored.lastError).toBe('HTTP 500');
+    expect(stored.nextRetryAt).toBeInstanceOf(Date);
+  });
+
+  it('marks failed after max attempts', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const db = createStatefulMockDb(subscription);
+    const service = new WebhookDeliveryService(db as any);
+
+    const delivery = await service.enqueue(payload, subscription.id);
+    await new Promise((r) => setImmediate(r));
+
+    // Simulate 4 more retry attempts (total 5 = MAX).
+    for (let i = 0; i < 4; i++) {
+      await service.attemptDelivery(delivery.id);
+    }
+
+    const stored = db._deliveries.get(delivery.id);
+    expect(stored.status).toBe('failed');
+    expect(stored.attempts).toBe(5);
+  });
+
+  it('signs "unsigned" when subscription has no secret', async () => {
+    fetchMock.mockResolvedValue({ ok: true, status: 200 });
+    const sub = { ...subscription, secret: null };
+    const db = createStatefulMockDb(sub);
+    const service = new WebhookDeliveryService(db as any);
+
+    await service.enqueue(payload, sub.id);
+    await new Promise((r) => setImmediate(r));
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(init.headers['X-HAIP-Signature']).toBe('unsigned');
+  });
+});

--- a/apps/api/src/modules/webhook/webhook-delivery.service.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.ts
@@ -1,0 +1,267 @@
+import {
+  Injectable,
+  Inject,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { eq, and, lte, or, isNull } from 'drizzle-orm';
+import { webhookDeliveries, agentWebhookSubscriptions } from '@haip/database';
+import { DRIZZLE } from '../../database/database.module';
+
+// Exponential backoff schedule in milliseconds: 30s, 2m, 10m, 1h, 6h.
+const RETRY_SCHEDULE_MS = [
+  30 * 1000,
+  2 * 60 * 1000,
+  10 * 60 * 1000,
+  60 * 60 * 1000,
+  6 * 60 * 60 * 1000,
+];
+const MAX_ATTEMPTS = RETRY_SCHEDULE_MS.length;
+
+// Interval for scanning pending retries. Disabled in tests (NODE_ENV=test).
+const RETRY_SCAN_INTERVAL_MS = 30 * 1000;
+
+// HTTP timeout per delivery.
+const REQUEST_TIMEOUT_MS = 5000;
+
+export interface DeliveryPayload {
+  eventType: string;
+  propertyId: string;
+  entityType: string;
+  entityId: string;
+  data: Record<string, unknown>;
+  timestamp: string;
+}
+
+/**
+ * WebhookDeliveryService — delivers events to subscribers with HMAC signing and retry.
+ *
+ * Not using BullMQ because Redis isn't wired up. Pragmatic replacement:
+ *   - insert one webhook_deliveries row per (event, matching-subscription)
+ *   - fire the HTTP POST immediately (fire-and-forget, caught)
+ *   - a periodic scan re-tries any still-pending row whose nextRetryAt <= now
+ *   - after MAX_ATTEMPTS, mark as 'failed'
+ */
+@Injectable()
+export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WebhookDeliveryService.name);
+  private scanTimer: NodeJS.Timeout | null = null;
+
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  onModuleInit() {
+    // Skip the background scanner in tests to keep Vitest fast and deterministic.
+    if (process.env['NODE_ENV'] === 'test') return;
+    this.scanTimer = setInterval(() => {
+      this.processPending().catch((err) =>
+        this.logger.error(`Retry scan failed: ${err?.message ?? err}`),
+      );
+    }, RETRY_SCAN_INTERVAL_MS);
+  }
+
+  onModuleDestroy() {
+    if (this.scanTimer) clearInterval(this.scanTimer);
+  }
+
+  /**
+   * Enqueue deliveries for an event — one row per matching subscription,
+   * then fire the first attempt asynchronously.
+   */
+  async enqueue(payload: DeliveryPayload, subscriptionId: string) {
+    const [delivery] = await this.db
+      .insert(webhookDeliveries)
+      .values({
+        propertyId: payload.propertyId,
+        subscriptionId,
+        eventType: payload.eventType,
+        payload,
+        status: 'pending',
+        attempts: 0,
+      })
+      .returning();
+
+    // Fire the first attempt without awaiting (tests can await via attemptDelivery).
+    this.attemptDelivery(delivery.id).catch((err) =>
+      this.logger.error(`Delivery ${delivery.id} failed unexpectedly: ${err?.message ?? err}`),
+    );
+
+    return delivery;
+  }
+
+  /**
+   * Attempt a single delivery. Loads the row, signs the payload, POSTs,
+   * and records success or schedules the next retry.
+   */
+  async attemptDelivery(deliveryId: string): Promise<void> {
+    const [delivery] = await this.db
+      .select()
+      .from(webhookDeliveries)
+      .where(eq(webhookDeliveries.id, deliveryId));
+
+    if (!delivery || delivery.status !== 'pending') return;
+
+    const [subscription] = await this.db
+      .select()
+      .from(agentWebhookSubscriptions)
+      .where(eq(agentWebhookSubscriptions.id, delivery.subscriptionId));
+
+    if (!subscription || !subscription.isActive) {
+      await this.db
+        .update(webhookDeliveries)
+        .set({
+          status: 'failed',
+          lastError: 'Subscription inactive or missing',
+          lastAttemptAt: new Date(),
+        })
+        .where(eq(webhookDeliveries.id, deliveryId));
+      return;
+    }
+
+    const attemptNumber = delivery.attempts + 1;
+    const body = JSON.stringify(delivery.payload);
+    const signature = subscription.secret
+      ? `sha256=${createHmac('sha256', subscription.secret).update(body).digest('hex')}`
+      : 'unsigned';
+
+    let statusCode: number | null = null;
+    let errorMessage: string | null = null;
+    let ok = false;
+
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      try {
+        const resp = await fetch(subscription.callbackUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-HAIP-Signature': signature,
+            'X-HAIP-Event-Id': delivery.id,
+            'X-HAIP-Event-Type': delivery.eventType,
+          },
+          body,
+          signal: controller.signal,
+        });
+        statusCode = resp.status;
+        ok = resp.ok;
+        if (!ok) errorMessage = `HTTP ${resp.status}`;
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch (err: any) {
+      errorMessage = err?.message ?? 'Network error';
+    }
+
+    const now = new Date();
+    if (ok) {
+      await this.db
+        .update(webhookDeliveries)
+        .set({
+          status: 'delivered',
+          attempts: attemptNumber,
+          lastAttemptAt: now,
+          deliveredAt: now,
+          lastStatusCode: statusCode,
+          lastError: null,
+          nextRetryAt: null,
+        })
+        .where(eq(webhookDeliveries.id, deliveryId));
+
+      await this.db
+        .update(agentWebhookSubscriptions)
+        .set({
+          lastDeliveryAt: now,
+          lastDeliveryStatus: 'delivered',
+          updatedAt: now,
+        })
+        .where(eq(agentWebhookSubscriptions.id, subscription.id));
+      return;
+    }
+
+    // Failure — schedule retry or mark failed.
+    if (attemptNumber >= MAX_ATTEMPTS) {
+      await this.db
+        .update(webhookDeliveries)
+        .set({
+          status: 'failed',
+          attempts: attemptNumber,
+          lastAttemptAt: now,
+          lastStatusCode: statusCode,
+          lastError: errorMessage,
+          nextRetryAt: null,
+        })
+        .where(eq(webhookDeliveries.id, deliveryId));
+
+      await this.db
+        .update(agentWebhookSubscriptions)
+        .set({
+          lastDeliveryAt: now,
+          lastDeliveryStatus: 'failed',
+          failureCount: (subscription.failureCount ?? 0) + 1,
+          updatedAt: now,
+        })
+        .where(eq(agentWebhookSubscriptions.id, subscription.id));
+
+      this.logger.warn(
+        `Webhook delivery ${deliveryId} FAILED after ${attemptNumber} attempts: ${errorMessage}`,
+      );
+      return;
+    }
+
+    const delayMs = RETRY_SCHEDULE_MS[attemptNumber] ?? RETRY_SCHEDULE_MS[RETRY_SCHEDULE_MS.length - 1]!;
+    await this.db
+      .update(webhookDeliveries)
+      .set({
+        status: 'pending',
+        attempts: attemptNumber,
+        lastAttemptAt: now,
+        lastStatusCode: statusCode,
+        lastError: errorMessage,
+        nextRetryAt: new Date(now.getTime() + delayMs),
+      })
+      .where(eq(webhookDeliveries.id, deliveryId));
+  }
+
+  /**
+   * Scan for pending deliveries whose nextRetryAt <= now and re-attempt them.
+   * Runs on an interval. Also handles never-attempted rows (nextRetryAt IS NULL).
+   */
+  async processPending(): Promise<number> {
+    const now = new Date();
+    const rows = await this.db
+      .select()
+      .from(webhookDeliveries)
+      .where(
+        and(
+          eq(webhookDeliveries.status, 'pending'),
+          or(
+            isNull(webhookDeliveries.nextRetryAt),
+            lte(webhookDeliveries.nextRetryAt, now),
+          ),
+        ),
+      );
+
+    for (const row of rows) {
+      await this.attemptDelivery(row.id);
+    }
+    return rows.length;
+  }
+
+  /**
+   * List deliveries for a subscription (scoped by propertyId).
+   */
+  async listDeliveries(subscriptionId: string, propertyId: string, limit = 50) {
+    return this.db
+      .select()
+      .from(webhookDeliveries)
+      .where(
+        and(
+          eq(webhookDeliveries.subscriptionId, subscriptionId),
+          eq(webhookDeliveries.propertyId, propertyId),
+        ),
+      )
+      .limit(limit);
+  }
+}

--- a/apps/api/src/modules/webhook/webhook.module.ts
+++ b/apps/api/src/modules/webhook/webhook.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { WebhookService } from './webhook.service';
+import { WebhookDeliveryService } from './webhook-delivery.service';
 
 @Module({
-  providers: [WebhookService],
-  exports: [WebhookService],
+  providers: [WebhookService, WebhookDeliveryService],
+  exports: [WebhookService, WebhookDeliveryService],
 })
 export class WebhookModule {}

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -31,6 +31,13 @@ async function main() {
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audit_run_status') THEN CREATE TYPE audit_run_status AS ENUM ('running','completed','failed','rolled_back'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'channel_status') THEN CREATE TYPE channel_status AS ENUM ('active','inactive','error','pending_setup'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sync_direction') THEN CREATE TYPE sync_direction AS ENUM ('push','pull','bidirectional'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'tax_rule_type') THEN CREATE TYPE tax_rule_type AS ENUM ('percentage','flat_per_night','flat_per_stay'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'review_source') THEN CREATE TYPE review_source AS ENUM ('google','tripadvisor','booking_com','expedia','other'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'review_response_status') THEN CREATE TYPE review_response_status AS ENUM ('pending','drafted','approved','posted'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'agent_type') THEN CREATE TYPE agent_type AS ENUM ('pricing','demand_forecast','channel_mix','overbooking','night_audit','housekeeping','cancellation','guest_comms','review_response'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'agent_mode') THEN CREATE TYPE agent_mode AS ENUM ('manual','suggest','autopilot'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'agent_decision_status') THEN CREATE TYPE agent_decision_status AS ENUM ('pending','approved','rejected','auto_executed','expired'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'webhook_delivery_status') THEN CREATE TYPE webhook_delivery_status AS ENUM ('pending','delivered','failed'); END IF; END $$`,
   ];
 
   for (const e of enums) {
@@ -394,6 +401,93 @@ async function main() {
       date_range_end date,
       created_at timestamptz NOT NULL DEFAULT now()
     )`,
+    // tax_profiles
+    `CREATE TABLE IF NOT EXISTS tax_profiles (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      name varchar(100) NOT NULL,
+      jurisdiction_code varchar(50) NOT NULL,
+      is_active boolean NOT NULL DEFAULT true,
+      effective_from date NOT NULL,
+      effective_to date,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    // tax_rules
+    `CREATE TABLE IF NOT EXISTS tax_rules (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      tax_profile_id uuid NOT NULL REFERENCES tax_profiles(id),
+      name varchar(100) NOT NULL,
+      code varchar(30) NOT NULL,
+      type tax_rule_type NOT NULL,
+      rate numeric(8,4) NOT NULL,
+      applies_to_charge_types text[],
+      exemptions jsonb,
+      is_compounding boolean NOT NULL DEFAULT false,
+      sort_order integer NOT NULL DEFAULT 0,
+      is_active boolean NOT NULL DEFAULT true,
+      effective_from date NOT NULL,
+      effective_to date,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    // guest_reviews
+    `CREATE TABLE IF NOT EXISTS guest_reviews (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      source review_source NOT NULL,
+      guest_name varchar(200) NOT NULL,
+      rating integer NOT NULL,
+      review_text text NOT NULL,
+      stay_date varchar(10),
+      reservation_id uuid REFERENCES reservations(id),
+      response_status review_response_status NOT NULL DEFAULT 'pending',
+      response_text text,
+      responded_at timestamptz,
+      responded_by uuid,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    // agent_configs
+    `CREATE TABLE IF NOT EXISTS agent_configs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      agent_type agent_type NOT NULL,
+      is_enabled boolean NOT NULL DEFAULT false,
+      mode agent_mode NOT NULL DEFAULT 'suggest',
+      autopilot_confidence_threshold numeric(3,2) DEFAULT '0.85',
+      config jsonb DEFAULT '{}'::jsonb,
+      model_state jsonb DEFAULT '{}'::jsonb,
+      last_trained_at timestamptz,
+      last_run_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS agent_configs_property_agent_unique ON agent_configs (property_id, agent_type)`,
+    // agent_decisions
+    `CREATE TABLE IF NOT EXISTS agent_decisions (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      agent_type agent_type NOT NULL,
+      decision_type varchar(100) NOT NULL,
+      input_snapshot jsonb DEFAULT '{}'::jsonb,
+      recommendation jsonb DEFAULT '{}'::jsonb,
+      confidence numeric(3,2) NOT NULL,
+      status agent_decision_status NOT NULL DEFAULT 'pending',
+      approved_by uuid,
+      executed_at timestamptz,
+      outcome jsonb,
+      outcome_recorded_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    // agent_training_snapshots
+    `CREATE TABLE IF NOT EXISTS agent_training_snapshots (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      agent_type agent_type NOT NULL,
+      snapshot_date date NOT NULL,
+      data jsonb DEFAULT '{}'::jsonb,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`,
     // agent_webhook_subscriptions
     `CREATE TABLE IF NOT EXISTS agent_webhook_subscriptions (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -409,6 +503,22 @@ async function main() {
       failure_count integer NOT NULL DEFAULT 0,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    // webhook_deliveries
+    `CREATE TABLE IF NOT EXISTS webhook_deliveries (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      subscription_id uuid NOT NULL REFERENCES agent_webhook_subscriptions(id),
+      event_type varchar(100) NOT NULL,
+      payload jsonb NOT NULL,
+      status webhook_delivery_status NOT NULL DEFAULT 'pending',
+      attempts integer NOT NULL DEFAULT 0,
+      last_attempt_at timestamptz,
+      next_retry_at timestamptz,
+      last_status_code integer,
+      last_error text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      delivered_at timestamptz
     )`,
   ];
 

--- a/packages/database/src/schema/connect.ts
+++ b/packages/database/src/schema/connect.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, varchar, boolean, timestamp, jsonb, integer } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, varchar, boolean, timestamp, jsonb, integer, text, pgEnum } from 'drizzle-orm/pg-core';
 import { properties } from './property.js';
 
 /**
@@ -27,4 +27,36 @@ export const agentWebhookSubscriptions = pgTable('agent_webhook_subscriptions', 
 
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+/**
+ * Webhook delivery status.
+ */
+export const webhookDeliveryStatusEnum = pgEnum('webhook_delivery_status', [
+  'pending',
+  'delivered',
+  'failed',
+]);
+
+/**
+ * Webhook Deliveries — one row per (event, subscription) pair.
+ * Tracks delivery attempts with retry schedule and HMAC-signed POSTs.
+ */
+export const webhookDeliveries = pgTable('webhook_deliveries', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  propertyId: uuid('property_id').notNull().references(() => properties.id),
+  subscriptionId: uuid('subscription_id').notNull().references(() => agentWebhookSubscriptions.id),
+
+  eventType: varchar('event_type', { length: 100 }).notNull(),
+  payload: jsonb('payload').notNull(),
+
+  status: webhookDeliveryStatusEnum('status').notNull().default('pending'),
+  attempts: integer('attempts').notNull().default(0),
+  lastAttemptAt: timestamp('last_attempt_at', { withTimezone: true }),
+  nextRetryAt: timestamp('next_retry_at', { withTimezone: true }),
+  lastStatusCode: integer('last_status_code'),
+  lastError: text('last_error'),
+
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  deliveredAt: timestamp('delivered_at', { withTimezone: true }),
 });

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -64,7 +64,11 @@ export {
 } from './channel.js';
 
 // Connect / Agent Subscriptions
-export { agentWebhookSubscriptions } from './connect.js';
+export {
+  agentWebhookSubscriptions,
+  webhookDeliveryStatusEnum,
+  webhookDeliveries,
+} from './connect.js';
 
 // Tax
 export {


### PR DESCRIPTION
## Summary

Third of 4 PRs from round-4 codex review. Operational correctness.

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 7 | HIGH | Outbound webhook delivery not implemented | HMAC-signed POST with DB-backed retry + exponential backoff |
| 10 | HIGH | \`push-schema.ts\` missing agent + 3 other tables | 7 tables + 7 enums synced to bootstrap script |
| 12 | MEDIUM | Agent config/decision mutations unaudited | auditLogs row on updateConfig/approveDecision/rejectDecision |

## Notes

- **BullMQ deferred**: Redis/BullMQ isn't wired up in this repo. Used brief's explicit fallback: DB-backed \`webhook_deliveries\` table + \`setInterval\` scanner (30s) + 5-attempt exponential backoff. Swap to BullMQ when Redis module lands.
- **push-schema.ts** is still not a real migration strategy — long-term it should be replaced with Drizzle migrations. This PR brings it back in sync with schema.

## Test plan
- [x] \`pnpm build\` green
- [x] \`pnpm typecheck\` green
- [x] \`pnpm test\` — 562/562 (+9 new: webhook delivery, agent audit, handleEvent enqueue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)