### PR TITLE
fix: local dev startup — circular dep + missing scripts (#87)

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,11 +368,11 @@ cp .env.example .env
 # Build workspace packages (database + shared)
 pnpm build
 
-# Run database migrations
-pnpm --filter @telivityhaip/api run migrate
+# Run database migrations (pushes schema to Postgres)
+pnpm --filter @telivityhaip/database run migrate
 
 # Seed demo data (Telivity Grand Hotel)
-pnpm --filter @telivityhaip/api run seed
+pnpm --filter @telivityhaip/database run seed
 
 # Start the API (with hot reload)
 pnpm dev

--- a/apps/api/src/modules/channel/channel-adapter.factory.ts
+++ b/apps/api/src/modules/channel/channel-adapter.factory.ts
@@ -1,8 +1,11 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
 import type { ChannelAdapter } from './channel-adapter.interface';
 import { MockChannelAdapter } from './adapters/mock.adapter';
-import { BookingComAdapter } from './adapters/booking-com';
-import { SiteMinderAdapter } from './adapters/siteminder';
+// Import directly from the adapter files (not the barrel index) to avoid a
+// circular import: barrel re-exports BookingComInboundController, which
+// imports InboundReservationService, which imports ChannelAdapterFactory.
+import { BookingComAdapter } from './adapters/booking-com/booking-com.adapter';
+import { SiteMinderAdapter } from './adapters/siteminder/siteminder.adapter';
 
 /**
  * Factory that maps adapterType strings to ChannelAdapter instances.

--- a/apps/api/src/modules/channel/channel.module.ts
+++ b/apps/api/src/modules/channel/channel.module.ts
@@ -6,9 +6,11 @@ import { InboundReservationService } from './inbound-reservation.service';
 import { RateParityService } from './rate-parity.service';
 import { ChannelAdapterFactory } from './channel-adapter.factory';
 import { MockChannelAdapter } from './adapters/mock.adapter';
-import { BookingComAdapter } from './adapters/booking-com';
+// Import adapters directly from their files (not the barrel index) to avoid a
+// circular import loop through the inbound controller.
+import { BookingComAdapter } from './adapters/booking-com/booking-com.adapter';
 import { BookingComInboundController } from './adapters/booking-com/booking-com-inbound.controller';
-import { SiteMinderAdapter } from './adapters/siteminder';
+import { SiteMinderAdapter } from './adapters/siteminder/siteminder.adapter';
 import { ReservationModule } from '../reservation/reservation.module';
 import { WebhookModule } from '../webhook/webhook.module';
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -41,8 +41,9 @@
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --coverage",
     "seed": "tsx src/seed.ts",
+    "migrate": "tsx src/push-schema.ts",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate",
+    "db:migrate": "tsx src/push-schema.ts",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {


### PR DESCRIPTION
Fixes #87.

## Summary

Three problems reported by a new developer trying to boot HAIP locally:

### 1. \`ChannelAdapterFactory\` circular import crash

\`pnpm dev\` crashed with \`ReferenceError: Cannot access 'ChannelAdapterFactory' before initialization\`. Cycle:

\`\`\`
channel-adapter.factory.ts
  → ./adapters/booking-com (barrel index)
    → BookingComInboundController
      → inbound-reservation.service
        → ChannelAdapterFactory  ❌ cycle
\`\`\`

The barrel index re-exports the inbound controller alongside the adapter, so importing the adapter from the barrel pulls controller wiring into factory module init.

**Fix**: \`channel-adapter.factory.ts\` and \`channel.module.ts\` now import \`BookingComAdapter\` and \`SiteMinderAdapter\` directly from their \`.adapter.ts\` files, bypassing the barrel. Inline comments document why.

### 2. Missing \`migrate\` / \`seed\` scripts

README called \`pnpm --filter @telivityhaip/api run migrate|seed\` but those scripts lived on \`@telivityhaip/database\` (or didn't exist). Also, \`db:migrate\` pointed at \`drizzle-kit migrate\` which expects pre-generated SQL that isn't checked in.

**Fix**:
- Added \`"migrate": "tsx src/push-schema.ts"\` to \`packages/database/package.json\`
- Redirected \`db:migrate\` to the same (drizzle-kit migrate is a dead end without generated SQL files)
- README now uses the correct filter: \`pnpm --filter @telivityhaip/database run migrate|seed\`

### 3. README verification

Walked the full Quick Start flow. All steps now work end-to-end.

## Test plan
- [x] \`pnpm dev\` — \`Nest application successfully started\`, API on localhost:3000
- [x] \`pnpm --filter @telivityhaip/database run migrate\` — \`Schema pushed successfully\`
- [x] \`pnpm -w build\` green
- [x] \`pnpm -w typecheck\` green
- [x] \`pnpm -w test\` — 575/575
- [x] \`pnpm --filter @telivityhaip/api lint\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)