### PR TITLE
feat(tax): split_component rule type + Germany Berlin profile

### DIFF
--- a/apps/api/src/modules/tax/dto/create-tax-rule.dto.ts
+++ b/apps/api/src/modules/tax/dto/create-tax-rule.dto.ts
@@ -1,4 +1,17 @@
-import { IsString, IsNumber, IsBoolean, IsOptional, IsArray, IsDateString, IsObject, IsEnum, IsInt } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsBoolean,
+  IsOptional,
+  IsArray,
+  IsDateString,
+  IsObject,
+  IsEnum,
+  IsInt,
+  ValidateIf,
+  Min,
+  Max,
+} from 'class-validator';
 
 export class CreateTaxRuleDto {
   @IsString()
@@ -7,11 +20,19 @@ export class CreateTaxRuleDto {
   @IsString()
   code!: string;
 
-  @IsEnum(['percentage', 'flat_per_night', 'flat_per_stay'])
-  type!: 'percentage' | 'flat_per_night' | 'flat_per_stay';
+  @IsEnum(['percentage', 'flat_per_night', 'flat_per_stay', 'split_component'])
+  type!: 'percentage' | 'flat_per_night' | 'flat_per_stay' | 'split_component';
 
   @IsString()
   rate!: string;
+
+  // Required when type === 'split_component', otherwise ignored.
+  // Represents the % of the charge amount to which `rate` is applied.
+  @ValidateIf((o) => o.type === 'split_component')
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  @Max(100)
+  splitPercentage?: number;
 
   @IsArray()
   @IsString({ each: true })

--- a/apps/api/src/modules/tax/dto/update-tax-rule.dto.ts
+++ b/apps/api/src/modules/tax/dto/update-tax-rule.dto.ts
@@ -1,4 +1,17 @@
-import { IsString, IsBoolean, IsOptional, IsArray, IsDateString, IsObject, IsEnum, IsInt } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsBoolean,
+  IsOptional,
+  IsArray,
+  IsDateString,
+  IsObject,
+  IsEnum,
+  IsInt,
+  ValidateIf,
+  Min,
+  Max,
+} from 'class-validator';
 
 export class UpdateTaxRuleDto {
   @IsString()
@@ -9,13 +22,21 @@ export class UpdateTaxRuleDto {
   @IsOptional()
   code?: string;
 
-  @IsEnum(['percentage', 'flat_per_night', 'flat_per_stay'])
+  @IsEnum(['percentage', 'flat_per_night', 'flat_per_stay', 'split_component'])
   @IsOptional()
-  type?: 'percentage' | 'flat_per_night' | 'flat_per_stay';
+  type?: 'percentage' | 'flat_per_night' | 'flat_per_stay' | 'split_component';
 
   @IsString()
   @IsOptional()
   rate?: string;
+
+  // Required when type === 'split_component'. Percentage of charge amount
+  // (0.01–100) to which the `rate` applies.
+  @ValidateIf((o) => o.type === 'split_component')
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0.01)
+  @Max(100)
+  splitPercentage?: number;
 
   @IsArray()
   @IsString({ each: true })

--- a/apps/api/src/modules/tax/tax.service.spec.ts
+++ b/apps/api/src/modules/tax/tax.service.spec.ts
@@ -801,4 +801,265 @@ describe('TaxService', () => {
       expect(result.taxes).toHaveLength(0);
     });
   });
+
+  // =========================================================================
+  // Split-component tax (Germany Berlin — breakfast split across VAT rates)
+  // =========================================================================
+
+  describe('Split-Component Tax (Germany Berlin)', () => {
+    const berlinProfile = {
+      id: 'tp-berlin',
+      propertyId: 'prop-004',
+      name: 'Germany Berlin Tax Profile',
+      jurisdictionCode: 'DE-BE-BERLIN',
+      isActive: true,
+      effectiveFrom: '2024-01-01',
+      effectiveTo: null,
+    };
+
+    const berlinRules = [
+      {
+        id: 'rule-de-accom',
+        taxProfileId: 'tp-berlin',
+        name: 'Accommodation VAT',
+        code: 'DE_ACCOM_VAT',
+        type: 'percentage',
+        rate: '7.00',
+        splitPercentage: null,
+        appliesToChargeTypes: ['room', 'room_upgrade'],
+        exemptions: null,
+        isCompounding: false,
+        isActive: true,
+        sortOrder: 1,
+        effectiveFrom: '2024-01-01',
+        effectiveTo: null,
+      },
+      {
+        id: 'rule-de-city',
+        taxProfileId: 'tp-berlin',
+        name: 'City Tax (Übernachtungsteuer)',
+        code: 'DE_CITY_TAX',
+        type: 'percentage',
+        rate: '5.00',
+        splitPercentage: null,
+        appliesToChargeTypes: ['room'],
+        exemptions: { guestTypes: ['business'] },
+        isCompounding: false,
+        isActive: true,
+        sortOrder: 2,
+        effectiveFrom: '2024-01-01',
+        effectiveTo: null,
+      },
+      {
+        id: 'rule-de-food',
+        taxProfileId: 'tp-berlin',
+        name: 'Food VAT',
+        code: 'DE_FOOD_VAT',
+        type: 'split_component',
+        rate: '7.00',
+        splitPercentage: '70.00',
+        appliesToChargeTypes: ['breakfast', 'meal', 'half_board', 'full_board'],
+        exemptions: null,
+        isCompounding: false,
+        isActive: true,
+        sortOrder: 1,
+        effectiveFrom: '2024-01-01',
+        effectiveTo: null,
+      },
+      {
+        id: 'rule-de-bev',
+        taxProfileId: 'tp-berlin',
+        name: 'Beverage VAT',
+        code: 'DE_BEVERAGE_VAT',
+        type: 'split_component',
+        rate: '19.00',
+        splitPercentage: '30.00',
+        appliesToChargeTypes: ['breakfast', 'meal', 'half_board', 'full_board'],
+        exemptions: null,
+        isCompounding: false,
+        isActive: true,
+        sortOrder: 2,
+        effectiveFrom: '2024-01-01',
+        effectiveTo: null,
+      },
+      {
+        id: 'rule-de-std',
+        taxProfileId: 'tp-berlin',
+        name: 'Standard VAT',
+        code: 'DE_STD_VAT',
+        type: 'percentage',
+        rate: '19.00',
+        splitPercentage: null,
+        appliesToChargeTypes: ['minibar', 'spa', 'parking', 'telephone', 'laundry'],
+        exemptions: null,
+        isCompounding: false,
+        isActive: true,
+        sortOrder: 1,
+        effectiveFrom: '2024-01-01',
+        effectiveTo: null,
+      },
+    ];
+
+    function buildBerlinDb(rulesOverride?: any[], guestOverride?: any) {
+      const rules = rulesOverride ?? berlinRules;
+      let selectCallCount = 0;
+      return {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockReturnValue(rules),
+              then: (resolve: any) => {
+                selectCallCount++;
+                if (selectCallCount === 1) return resolve([berlinProfile]);
+                if (guestOverride !== undefined) return resolve([guestOverride]);
+                return resolve(rules);
+              },
+            }),
+          }),
+        })),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      };
+    }
+
+    async function makeService(mockDb: any) {
+      const module = await Test.createTestingModule({
+        providers: [TaxService, { provide: DRIZZLE, useValue: mockDb }],
+      }).compile();
+      return module.get<TaxService>(TaxService);
+    }
+
+    it('should calculate split-component tax on a €20 breakfast (7% on 70% + 19% on 30%)', async () => {
+      // Use only the two split rules to isolate the math
+      const splitOnlyRules = berlinRules.filter(r => r.type === 'split_component');
+      const service = await makeService(buildBerlinDb(splitOnlyRules));
+
+      const items = await service.calculateTaxes('20.00', 'breakfast', 'prop-004', '2026-04-07');
+
+      expect(items).toHaveLength(2);
+      // 7% of (20 * 70%) = 7% of 14 = 0.98
+      expect(items[0]!.code).toBe('DE_FOOD_VAT');
+      expect(items[0]!.amount).toBe('0.98');
+      // 19% of (20 * 30%) = 19% of 6 = 1.14
+      expect(items[1]!.code).toBe('DE_BEVERAGE_VAT');
+      expect(items[1]!.amount).toBe('1.14');
+
+      const total = items.reduce((sum, i) => sum + parseFloat(i.amount), 0);
+      expect(total).toBeCloseTo(2.12, 2);
+    });
+
+    it('should back-calculate €22.12 gross breakfast to €20 net', async () => {
+      const splitOnlyRules = berlinRules.filter(r => r.type === 'split_component');
+      const service = await makeService(buildBerlinDb(splitOnlyRules));
+
+      const result = await service.backCalculateFromInclusive(
+        '22.12',
+        'breakfast',
+        'prop-004',
+        '2026-04-07',
+      );
+
+      // Effective rate = 0.7*0.07 + 0.3*0.19 = 0.049 + 0.057 = 0.106 (10.6%)
+      // net = 22.12 / 1.106 = 20.00 (to 2 dp)
+      expect(parseFloat(result.baseAmount)).toBeCloseTo(20, 1);
+    });
+
+    it('should apply 7% accommodation VAT + 5% city tax on a €100 room charge', async () => {
+      const service = await makeService(buildBerlinDb());
+
+      const items = await service.calculateTaxes('100.00', 'room', 'prop-004', '2026-04-07');
+
+      expect(items).toHaveLength(2);
+      expect(items[0]!.code).toBe('DE_ACCOM_VAT');
+      expect(items[0]!.amount).toBe('7.00');
+      expect(items[1]!.code).toBe('DE_CITY_TAX');
+      expect(items[1]!.amount).toBe('5.00');
+      const total = items.reduce((sum, i) => sum + parseFloat(i.amount), 0);
+      expect(total).toBeCloseTo(12, 2);
+    });
+
+    it('should apply split-component rules on a €20 breakfast (full Berlin profile)', async () => {
+      const service = await makeService(buildBerlinDb());
+
+      const items = await service.calculateTaxes('20.00', 'breakfast', 'prop-004', '2026-04-07');
+
+      // Only split rules apply to breakfast charge type
+      expect(items).toHaveLength(2);
+      const total = items.reduce((sum, i) => sum + parseFloat(i.amount), 0);
+      expect(total).toBeCloseTo(2.12, 2);
+    });
+
+    it('should apply 19% standard VAT on a €10 minibar charge', async () => {
+      const service = await makeService(buildBerlinDb());
+
+      const items = await service.calculateTaxes('10.00', 'minibar', 'prop-004', '2026-04-07');
+
+      expect(items).toHaveLength(1);
+      expect(items[0]!.code).toBe('DE_STD_VAT');
+      expect(items[0]!.amount).toBe('1.90');
+    });
+
+    it('should exempt business guests from city tax (only accommodation VAT applies)', async () => {
+      const service = await makeService(
+        buildBerlinDb(undefined, { id: 'guest-biz', vipLevel: 'business' }),
+      );
+
+      const items = await service.calculateTaxes('100.00', 'room', 'prop-004', '2026-04-07', {
+        guestId: 'guest-biz',
+      });
+
+      expect(items).toHaveLength(1);
+      expect(items[0]!.code).toBe('DE_ACCOM_VAT');
+      expect(items[0]!.amount).toBe('7.00');
+      expect(items.find(i => i.code === 'DE_CITY_TAX')).toBeUndefined();
+    });
+
+    it('should calculate independent split rules that do not sum to 100%', async () => {
+      // Two split rules: 50% at 10%, 30% at 20% — should each compute independently
+      const partialRules = [
+        {
+          id: 'rule-split-a',
+          taxProfileId: 'tp-berlin',
+          name: 'Split A',
+          code: 'SPLIT_A',
+          type: 'split_component',
+          rate: '10.00',
+          splitPercentage: '50.00',
+          appliesToChargeTypes: ['breakfast'],
+          exemptions: null,
+          isCompounding: false,
+          isActive: true,
+          sortOrder: 1,
+          effectiveFrom: '2024-01-01',
+          effectiveTo: null,
+        },
+        {
+          id: 'rule-split-b',
+          taxProfileId: 'tp-berlin',
+          name: 'Split B',
+          code: 'SPLIT_B',
+          type: 'split_component',
+          rate: '20.00',
+          splitPercentage: '30.00',
+          appliesToChargeTypes: ['breakfast'],
+          exemptions: null,
+          isCompounding: false,
+          isActive: true,
+          sortOrder: 2,
+          effectiveFrom: '2024-01-01',
+          effectiveTo: null,
+        },
+      ];
+      const service = await makeService(buildBerlinDb(partialRules));
+
+      const items = await service.calculateTaxes('100.00', 'breakfast', 'prop-004', '2026-04-07');
+
+      expect(items).toHaveLength(2);
+      // 10% of (100 * 50%) = 10% of 50 = 5.00
+      expect(items[0]!.amount).toBe('5.00');
+      // 20% of (100 * 30%) = 20% of 30 = 6.00
+      expect(items[1]!.amount).toBe('6.00');
+    });
+  });
 });

--- a/apps/api/src/modules/tax/tax.service.ts
+++ b/apps/api/src/modules/tax/tax.service.ts
@@ -88,6 +88,8 @@ export class TaxService {
         code: dto.code,
         type: dto.type,
         rate: dto.rate,
+        splitPercentage:
+          dto.splitPercentage !== undefined ? dto.splitPercentage.toString() : null,
         appliesToChargeTypes: dto.appliesToChargeTypes,
         exemptions: dto.exemptions,
         isCompounding: dto.isCompounding ?? false,
@@ -242,6 +244,19 @@ export class TaxService {
           taxAmount = base.times(rateValue).div(100);
           break;
         }
+        case 'split_component': {
+          // Rate is applied only to `splitPercentage %` of the charge.
+          // Compounding interacts the same way as percentage — if the rule is
+          // compounding we still scale the (running) base by the split fraction
+          // before applying the rate.
+          const splitPct = rule.splitPercentage
+            ? new Decimal(rule.splitPercentage)
+            : new Decimal(0);
+          const base = rule.isCompounding ? runningBase : amount;
+          const taxableBase = base.times(splitPct).div(100);
+          taxAmount = taxableBase.times(rateValue).div(100);
+          break;
+        }
         case 'flat_per_night':
           taxAmount = rateValue.times(options?.numberOfNights ?? 1);
           break;
@@ -311,6 +326,16 @@ export class TaxService {
         case 'percentage':
           totalPercentageRate = totalPercentageRate.plus(rateValue);
           break;
+        case 'split_component': {
+          // Effective rate contribution is (splitPercentage/100) * rate.
+          // Keep it in "percent" units (consistent with totalPercentageRate)
+          // by multiplying rate by splitPercentage/100.
+          const splitPct = rule.splitPercentage
+            ? new Decimal(rule.splitPercentage)
+            : new Decimal(0);
+          totalPercentageRate = totalPercentageRate.plus(rateValue.times(splitPct).div(100));
+          break;
+        }
         case 'flat_per_night':
           totalFlat = totalFlat.plus(rateValue.times(options?.numberOfNights ?? 1));
           break;

--- a/packages/database/src/migrations/0001_split_component_tax.sql
+++ b/packages/database/src/migrations/0001_split_component_tax.sql
@@ -1,0 +1,27 @@
+-- Migration: add 'split_component' value to tax_rule_type enum and
+-- split_percentage column to tax_rules.
+--
+-- German hotels need to split a single breakfast charge across two VAT rates
+-- (7% on food portion, 19% on beverage portion). The split_component rule
+-- type applies its rate to splitPercentage % of the charge instead of 100%.
+--
+-- drizzle-kit generate cannot run in this repo (CJS/.js extension issue —
+-- see packages/database/src/push-schema.ts), so this migration is authored
+-- by hand. push-schema.ts also reflects the same DDL idempotently.
+
+-- 1. Add new enum value (idempotent — no-op if already present)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_enum e
+    JOIN pg_type t ON t.oid = e.enumtypid
+    WHERE t.typname = 'tax_rule_type'
+      AND e.enumlabel = 'split_component'
+  ) THEN
+    ALTER TYPE tax_rule_type ADD VALUE 'split_component';
+  END IF;
+END $$;
+
+-- 2. Add split_percentage column (nullable — required by DTO layer only when
+--    type = 'split_component')
+ALTER TABLE tax_rules ADD COLUMN IF NOT EXISTS split_percentage numeric(5,2);

--- a/packages/database/src/migrations/meta/_journal.json
+++ b/packages/database/src/migrations/meta/_journal.json
@@ -1,0 +1,1 @@
+{"version":"7","dialect":"postgresql","entries":[]}

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -31,7 +31,9 @@ async function main() {
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audit_run_status') THEN CREATE TYPE audit_run_status AS ENUM ('running','completed','failed','rolled_back'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'channel_status') THEN CREATE TYPE channel_status AS ENUM ('active','inactive','error','pending_setup'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sync_direction') THEN CREATE TYPE sync_direction AS ENUM ('push','pull','bidirectional'); END IF; END $$`,
-    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'tax_rule_type') THEN CREATE TYPE tax_rule_type AS ENUM ('percentage','flat_per_night','flat_per_stay'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'tax_rule_type') THEN CREATE TYPE tax_rule_type AS ENUM ('percentage','flat_per_night','flat_per_stay','split_component'); END IF; END $$`,
+    // Idempotent add: append split_component to tax_rule_type if it already existed without it
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_enum e JOIN pg_type t ON t.oid = e.enumtypid WHERE t.typname = 'tax_rule_type' AND e.enumlabel = 'split_component') THEN ALTER TYPE tax_rule_type ADD VALUE 'split_component'; END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'review_source') THEN CREATE TYPE review_source AS ENUM ('google','tripadvisor','booking_com','expedia','other'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'review_response_status') THEN CREATE TYPE review_response_status AS ENUM ('pending','drafted','approved','posted'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'agent_type') THEN CREATE TYPE agent_type AS ENUM ('pricing','demand_forecast','channel_mix','overbooking','night_audit','housekeeping','cancellation','guest_comms','review_response'); END IF; END $$`,
@@ -423,6 +425,7 @@ async function main() {
       code varchar(30) NOT NULL,
       type tax_rule_type NOT NULL,
       rate numeric(8,4) NOT NULL,
+      split_percentage numeric(5,2),
       applies_to_charge_types text[],
       exemptions jsonb,
       is_compounding boolean NOT NULL DEFAULT false,
@@ -526,6 +529,14 @@ async function main() {
 
   for (const t of tables) {
     await db.execute(sql.raw(t));
+  }
+
+  // Idempotent column additions for pre-existing databases
+  const alters = [
+    `ALTER TABLE tax_rules ADD COLUMN IF NOT EXISTS split_percentage numeric(5,2)`,
+  ];
+  for (const a of alters) {
+    await db.execute(sql.raw(a));
   }
 
   console.log('Schema pushed successfully — all tables created.');

--- a/packages/database/src/schema/tax.ts
+++ b/packages/database/src/schema/tax.ts
@@ -27,6 +27,7 @@ export const taxRuleTypeEnum = pgEnum('tax_rule_type', [
   'percentage',       // e.g., 6% of charge amount
   'flat_per_night',   // e.g., $2.50 per night
   'flat_per_stay',    // e.g., $10 one-time per stay
+  'split_component',  // rate applied to splitPercentage % of the charge (e.g., DE breakfast: 7% VAT on 70% food portion)
 ]);
 
 /**
@@ -49,6 +50,11 @@ export const taxRules = pgTable('tax_rules', {
   type: taxRuleTypeEnum('type').notNull(),
 
   rate: numeric('rate', { precision: 8, scale: 4 }).notNull(), // 6.0000 for 6%, or 2.50 for flat
+
+  // Only used when type = 'split_component'. Percentage of the charge to which
+  // `rate` is applied (e.g., 70.00 = rate applies to 70% of charge).
+  // Nullable — required at the DTO layer only when type=split_component.
+  splitPercentage: numeric('split_percentage', { precision: 5, scale: 2 }),
 
   appliesToChargeTypes: text('applies_to_charge_types').array(), // ['room', 'room_upgrade'] or null for all
   exemptions: jsonb('exemptions').$type<{

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -734,6 +734,83 @@ async function main() {
   ]);
 
   // -----------------------------------------------------------------------
+  // 14. Tax Profile — Germany Berlin (split-component breakfast VAT)
+  //     German hotels split a single breakfast charge across two VAT rates:
+  //     7% on the food portion (70%) and 19% on the beverage portion (30%).
+  // -----------------------------------------------------------------------
+  const berlinTaxProfileId = sid('a5000001', 4);
+
+  await db.insert(schema.taxProfiles).values({
+    id: berlinTaxProfileId,
+    propertyId,
+    name: 'Germany Berlin Tax Profile',
+    jurisdictionCode: 'DE-BE-BERLIN',
+    isActive: false, // inactive — only one profile active per property
+    effectiveFrom: '2024-01-01',
+  });
+
+  await db.insert(schema.taxRules).values([
+    {
+      id: sid('a5400001', 1),
+      taxProfileId: berlinTaxProfileId,
+      name: 'Accommodation VAT',
+      code: 'DE_ACCOM_VAT',
+      type: 'percentage',
+      rate: '7.00',
+      appliesToChargeTypes: ['room', 'room_upgrade'],
+      sortOrder: 1,
+      effectiveFrom: '2024-01-01',
+    },
+    {
+      id: sid('a5400001', 2),
+      taxProfileId: berlinTaxProfileId,
+      name: 'City Tax (Übernachtungsteuer)',
+      code: 'DE_CITY_TAX',
+      type: 'percentage',
+      rate: '5.00',
+      appliesToChargeTypes: ['room'],
+      exemptions: { guestTypes: ['business'] },
+      sortOrder: 2,
+      effectiveFrom: '2024-01-01',
+    },
+    {
+      id: sid('a5400001', 3),
+      taxProfileId: berlinTaxProfileId,
+      name: 'Food VAT',
+      code: 'DE_FOOD_VAT',
+      type: 'split_component',
+      rate: '7.00',
+      splitPercentage: '70.00',
+      appliesToChargeTypes: ['breakfast', 'meal', 'half_board', 'full_board'],
+      sortOrder: 1,
+      effectiveFrom: '2024-01-01',
+    },
+    {
+      id: sid('a5400001', 4),
+      taxProfileId: berlinTaxProfileId,
+      name: 'Beverage VAT',
+      code: 'DE_BEVERAGE_VAT',
+      type: 'split_component',
+      rate: '19.00',
+      splitPercentage: '30.00',
+      appliesToChargeTypes: ['breakfast', 'meal', 'half_board', 'full_board'],
+      sortOrder: 2,
+      effectiveFrom: '2024-01-01',
+    },
+    {
+      id: sid('a5400001', 5),
+      taxProfileId: berlinTaxProfileId,
+      name: 'Standard VAT',
+      code: 'DE_STD_VAT',
+      type: 'percentage',
+      rate: '19.00',
+      appliesToChargeTypes: ['minibar', 'spa', 'parking', 'telephone', 'laundry'],
+      sortOrder: 1,
+      effectiveFrom: '2024-01-01',
+    },
+  ]);
+
+  // -----------------------------------------------------------------------
   // Done
   // -----------------------------------------------------------------------
   console.log('Seed complete.');
@@ -748,7 +825,7 @@ async function main() {
   console.log('  Night Audit:   1 completed run');
   console.log('  Channels:      2 connections');
   console.log('  Webhooks:      1 subscription');
-  console.log('  Tax Profiles:  3 (Miami Beach 13%, Barcelona IVA+tourist, Amsterdam BTW+tourist)');
+  console.log('  Tax Profiles:  4 (Miami Beach 13%, Barcelona IVA+tourist, Amsterdam BTW+tourist, Berlin split-component)');
 
   await client.end();
 }


### PR DESCRIPTION
## Summary

Germany requires split-rate VAT on composite charges: 7% on the food portion of breakfast, 19% on the beverage portion. The existing tax engine applied one rate per charge type — this adds a \`split_component\` rule type that taxes a configurable percentage of the charge at its own rate, so multiple rules stack to the correct effective rate.

## Example

€20 breakfast in Berlin:

| Rule | Type | Rate | Split% | Tax |
|---|---|---|---|---|
| Food VAT | split_component | 7% | 70% | €20 × 0.70 × 0.07 = **€0.98** |
| Beverage VAT | split_component | 19% | 30% | €20 × 0.30 × 0.19 = **€1.14** |
| | | | **Total** | **€2.12** |

## Changes

- **Schema**: \`'split_component'\` enum value + \`splitPercentage numeric(5,2)\` column
- **Migration**: hand-authored \`0001_split_component_tax.sql\` (drizzle-kit generate broken in this repo; \`push-schema.ts\` mirrors the migration)
- **TaxService**: \`calculateTaxes\` + \`backCalculateFromInclusive\` handle split_component via decimal.js (no parseFloat)
- **DTOs**: \`splitPercentage\` with \`@ValidateIf(type==='split_component')\`, \`@Min(0.01)\`, \`@Max(100)\`
- **Seed**: Germany Berlin profile with 5 rules (accommodation VAT, city tax w/ business exemption, food/beverage split, standard VAT)

## Test plan
- [x] \`pnpm -w build\` green
- [x] \`pnpm -w typecheck\` green
- [x] \`pnpm -w test\` — **582/582 passing** (+7 tests: split calc, back-calc, Berlin integration, business exemption, non-100% splits)
- [x] \`pnpm --filter @telivityhaip/api lint\` — 0 errors

Refs #87.

🤖 Generated with [Claude Code](https://claude.com/claude-code)