### PR TITLE
docs(readme): document the ChatGPT gateway (Connect GPT, v1.2.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 The hotel industry runs on closed-source, legacy PMS platforms that charge per-room fees, lock data behind proprietary APIs, and treat integrations as an afterthought. Hotels pay $5–15/room/month just for the privilege of managing their own operations.
 
-HAIP is a **complete, production-grade hotel Property Management System** built from scratch with modern architecture. Reservation lifecycle, folio & billing, rate plans, housekeeping with digital checklists, night audit, channel distribution to 450+ OTAs, Stripe payment processing, Keycloak authentication, local user & role administration, media management for property and room photos, tax calculation engine, revenue management — and **12 built-in AI agents** that orchestrate revenue strategy, optimize pricing, predict cancellations, detect audit anomalies, prioritize receivables collections, forecast group pickup, schedule housekeeping, automate guest communications, and draft review responses. All open source under Apache 2.0.
+HAIP is a **complete, production-grade hotel Property Management System** built from scratch with modern architecture. Reservation lifecycle, folio & billing, rate plans, housekeeping with digital checklists, night audit, channel distribution to 450+ OTAs, Stripe payment processing, Keycloak authentication, local user & role administration, media management for property and room photos, tax calculation engine, revenue management — and **12 built-in AI agents** that orchestrate revenue strategy, optimize pricing, predict cancellations, detect audit anomalies, prioritize receivables collections, forecast group pickup, schedule housekeeping, automate guest communications, and draft review responses. It even ships a **ChatGPT gateway** so guests can search and book a room by chatting. All open source under Apache 2.0.
 
 What makes HAIP different is that **AI agents are built into the architecture from day one** — not as a bolt-on, but as first-class citizens with their own lifecycle, decision logging, and learning loop. HAIP is the sister project to [OTAIP](https://github.com/telivity-otaip/otaip) (Open Travel AI Platform). Together they form **Telivity's open-source travel infrastructure**. OTAIP agents connect to HAIP via the Connect API — the PMS works without AI, but the AI makes it extraordinary.
 
@@ -343,6 +343,13 @@ This creates a learning loop: each decision becomes training data for model impr
 - Event format: `entity.action` (e.g., `reservation.created`, `housekeeping.task_completed`)
 - Subscription management for external consumers
 
+### ChatGPT Gateway (Connect GPT)
+- A standalone, deployable **gateway that exposes HAIP hotel search & booking as a ChatGPT Custom GPT Action** (`tools/haip-connect-gpt`) — guests search availability and create/modify/cancel reservations by chatting
+- A thin, typed client over HAIP's existing **Connect API** (`/api/v1/connect/*`) — no hotel logic is reimplemented; it builds a ChatGPT-importable **OpenAPI 3.1** spec for 6 operations (`searchHotels`, `getProperty`, `create`/`get`/`modify`/`cancelReservation`)
+- **Secure by design** — the gateway injects HAIP's API key server-side (the GPT never sees it), and response guards ensure **only selling prices** reach the model (net/wholesale/cost stripped)
+- **PII-scrubbed tool-call logging** for training, with an optional Supabase/Postgres sink
+- Host-agnostic — ships as a **Vercel** serverless function, a plain Node server, or a Docker container
+
 ### Admin Dashboard
 - React SPA with **15 pages**: Dashboard, Reservations, Check-In/Out, Guests, Rooms, Housekeeping, Rate Plans, Folios, Night Audit, Reports, Channel Manager, Revenue Management, Communications, Reviews, Settings
 - Revenue Management page: KPI cards, pending AI recommendations with approve/reject, agent performance metrics, per-agent configuration
@@ -561,6 +568,8 @@ haip/
 │   ├── database/                   # Drizzle ORM schema + migrations
 │   │   └── src/schema/             # Table files (property, room, guest, agent, etc.)
 │   └── shared/                     # Shared types, enums, webhook events
+├── tools/
+│   └── haip-connect-gpt/           # ChatGPT Custom GPT gateway over the Connect API (Vercel)
 ├── docker-compose.yml              # PostgreSQL + Redis + Keycloak + API
 ├── CLAUDE.md                       # AI agent constitution
 └── .env.example                    # Environment template
@@ -892,6 +901,8 @@ OTAIP Agent → ConnectAdapter (HAIP) → Connect API → HAIP PMS → PostgreSQ
 ```
 
 The PMS is the product. OTAIP agents are the intelligence on top.
+
+> **ChatGPT too** — `tools/haip-connect-gpt` wraps this same Connect API as a ChatGPT Custom GPT Action (OpenAPI 3.1, server-side key injection, selling-price-only responses), so a guest can search and book straight from ChatGPT. See [`tools/haip-connect-gpt/README.md`](./tools/haip-connect-gpt/README.md).
 
 ---
 


### PR DESCRIPTION
Of the versions in question, v1.3.0 and v1.3.1 (media, RBAC, channel content, Expedia, room photos) were already documented in #113. The remaining gap is **v1.2.9 — the ChatGPT gateway** (`tools/haip-connect-gpt`, shipped in #106), which exposes HAIP hotel search + booking as a ChatGPT Custom GPT over the Connect API but was never mentioned in the README.

## Added
- **ChatGPT Gateway (Connect GPT)** feature section — Custom GPT Action over `/api/v1/connect/*`, OpenAPI 3.1 for 6 ops, server-side API-key injection, selling-price-only responses, PII-scrubbed logging, Vercel/Node/Docker hosting.
- A pointer in the OTAIP / Connect API section and a one-line headline mention ("guests can search and book by chatting").
- `tools/haip-connect-gpt/` in the project tree.

Docs-only; no code changes.

https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt)_