### PR TITLE
fix(security): close cross-tenant authorization gaps (PR1)

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { APP_GUARD } from '@nestjs/core';
 import { JwtStrategy } from './jwt.strategy';
 import { JwtAuthGuard } from './auth.guard';
 import { RolesGuard } from './roles.guard';
+import { PropertyScopeGuard } from './property-scope.guard';
 import { PermissionsGuard } from './permissions.guard';
 import { PermissionsService } from './permissions.service';
 import { ApiKeyGuard } from './api-key.guard';
@@ -49,10 +50,12 @@ import { WsAuthService } from './ws-auth.service';
     },
     // Global guards — applied to ALL endpoints, in order:
     // 1. JwtAuthGuard populates req.user, 2. RolesGuard checks @Roles(),
-    // 3. PermissionsGuard checks @RequirePermissions() (local authz). All three
+    // 3. PropertyScopeGuard binds the principal to the request's propertyId,
+    // 4. PermissionsGuard checks @RequirePermissions() (local authz). All
     // short-circuit to allow when AUTH_ENABLED=false.
     { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
+    { provide: APP_GUARD, useClass: PropertyScopeGuard },
     { provide: APP_GUARD, useClass: PermissionsGuard },
     // Resolves effective permissions from the local RBAC tables. Exported so the
     // admin module can reuse it.

--- a/apps/api/src/modules/auth/property-access.ts
+++ b/apps/api/src/modules/auth/property-access.ts
@@ -1,0 +1,17 @@
+import type { AuthUser } from './current-user.decorator';
+
+/**
+ * Platform-level roles that bypass property scoping — these operators can act
+ * across tenants (e.g. support/ops). Keep in sync with the same intent in the
+ * HTTP PropertyScopeGuard and the WebSocket EventsGateway.
+ */
+export const PLATFORM_ROLES = new Set(['admin', 'platform_admin', 'superadmin']);
+
+/**
+ * Whether an authenticated principal may act on a given property. Platform admins
+ * always may; everyone else must have the property in their `property_ids` claim.
+ */
+export function userCanAccessProperty(user: AuthUser, propertyId: string): boolean {
+  if (user.roles?.some((r) => PLATFORM_ROLES.has(r))) return true;
+  return (user.propertyIds ?? []).includes(propertyId);
+}

--- a/apps/api/src/modules/auth/property-scope.guard.spec.ts
+++ b/apps/api/src/modules/auth/property-scope.guard.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { ForbiddenException, type ExecutionContext } from '@nestjs/common';
+import { PropertyScopeGuard } from './property-scope.guard';
+
+function ctx(request: any): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => request }),
+  } as unknown as ExecutionContext;
+}
+
+function guardWith(authEnabled: string) {
+  const config = { get: (_k: string, def?: string) => (authEnabled ?? def) } as any;
+  return new PropertyScopeGuard(config);
+}
+
+const member = { sub: 'u1', email: 'u@x.com', name: 'U', roles: ['front_desk'], propertyIds: ['propA'] };
+const admin = { sub: 'a1', email: 'a@x.com', name: 'A', roles: ['admin'], propertyIds: [] };
+
+describe('PropertyScopeGuard', () => {
+  it('bypasses entirely when AUTH_ENABLED=false', () => {
+    const guard = guardWith('false');
+    // foreign property, but auth off → allowed (demo)
+    expect(guard.canActivate(ctx({ user: member, query: { propertyId: 'propB' } }))).toBe(true);
+  });
+
+  it('allows a member to access their own property', () => {
+    const guard = guardWith('true');
+    expect(guard.canActivate(ctx({ user: member, query: { propertyId: 'propA' } }))).toBe(true);
+  });
+
+  it('rejects a non-member accessing a foreign property', () => {
+    const guard = guardWith('true');
+    expect(() => guard.canActivate(ctx({ user: member, query: { propertyId: 'propB' } }))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('reads propertyId from the body when not in the query', () => {
+    const guard = guardWith('true');
+    expect(() => guard.canActivate(ctx({ user: member, body: { propertyId: 'propB' } }))).toThrow(
+      ForbiddenException,
+    );
+  });
+
+  it('lets platform admins cross properties', () => {
+    const guard = guardWith('true');
+    expect(guard.canActivate(ctx({ user: admin, query: { propertyId: 'propZ' } }))).toBe(true);
+  });
+
+  it('skips routes that carry no propertyId', () => {
+    const guard = guardWith('true');
+    expect(guard.canActivate(ctx({ user: member, query: {} }))).toBe(true);
+  });
+
+  it('skips @Public routes that have no authenticated user', () => {
+    const guard = guardWith('true');
+    expect(guard.canActivate(ctx({ query: { propertyId: 'propB' } }))).toBe(true);
+  });
+});

--- a/apps/api/src/modules/auth/property-scope.guard.ts
+++ b/apps/api/src/modules/auth/property-scope.guard.ts
@@ -1,0 +1,60 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import type { AuthUser } from './current-user.decorator';
+import { userCanAccessProperty } from './property-access';
+
+/**
+ * Property-scope guard — binds the authenticated principal to the `propertyId`
+ * it operates on.
+ *
+ * Most routes are gated only by `@Roles()` (global Keycloak realm roles like
+ * `front_desk`), which says *what* a user may do but not *at which property*.
+ * Without this guard, any authenticated user could pass an arbitrary `propertyId`
+ * (query/body/param) and reach another tenant's data — the DB queries scope by
+ * that same client-supplied id. This guard enforces what the WebSocket gateway
+ * already does for socket events: a non-platform user must have the property in
+ * their `property_ids` claim.
+ *
+ * - Bypassed entirely when `AUTH_ENABLED=false` (demo).
+ * - Skips `@Public()` routes (no principal to scope — e.g. inbound OTA webhooks).
+ * - Skips routes that carry no `propertyId` (not property-scoped).
+ * - Platform admins bypass (see `userCanAccessProperty`).
+ */
+@Injectable()
+export class PropertyScopeGuard implements CanActivate {
+  constructor(private readonly configService: ConfigService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'true');
+    if (authEnabled === 'false') {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user: AuthUser | undefined = request.user;
+    // Unauthenticated routes (e.g. @Public webhooks) carry no principal to scope;
+    // leave authentication of those to their own mechanism.
+    if (!user) {
+      return true;
+    }
+
+    const propertyId: unknown =
+      request.query?.propertyId ?? request.body?.propertyId ?? request.params?.propertyId;
+    // Routes without a propertyId aren't property-scoped (e.g. global admin lists,
+    // /properties). Nothing to enforce here.
+    if (!propertyId || typeof propertyId !== 'string') {
+      return true;
+    }
+
+    if (!userCanAccessProperty(user, propertyId)) {
+      throw new ForbiddenException('You do not have access to this property');
+    }
+
+    return true;
+  }
+}

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
@@ -4,7 +4,6 @@ import {
   Req,
   Res,
   Logger,
-  Headers,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Public } from '../../../auth/public.decorator';
@@ -21,7 +20,11 @@ import {
  * Booking.com pushes reservation notifications as OTA XML to this endpoint.
  *
  * @Public() — no JWT required (Booking.com can't authenticate to our IdP).
- * Security is via Basic Auth verification in the request.
+ *
+ * NOTE: caller authentication for this webhook is design item C1 (per-OTA
+ * signature / Basic-Auth / IP-allowlist) and is NOT yet implemented — the
+ * endpoint is currently unauthenticated. Tenant ROUTING is enforced here by
+ * matching the OTA hotel code to a channel connection's config.hotelId.
  */
 @ApiTags('Channel Manager — Booking.com')
 @Controller('channels/inbound/booking-com')
@@ -44,7 +47,6 @@ export class BookingComInboundController {
   async receiveReservation(
     @Req() req: any,
     @Res() res: any,
-    @Headers('authorization') authHeader?: string,
   ) {
     try {
       // Read raw XML body
@@ -70,17 +72,23 @@ export class BookingComInboundController {
         return this.sendErrorXml(res, '400', 'No reservations in payload');
       }
 
-      // Find channel connection for booking_com
-      const connection = await this.findBookingComConnection();
-
-      if (!connection) {
-        this.logger.error('No active Booking.com channel connection found');
-        return this.sendErrorXml(res, '500', 'No active Booking.com connection configured');
-      }
-
-      // Process each reservation
+      // Process each reservation, routing each to the connection that matches its
+      // OTA hotel code. (Auth of the caller itself is tracked as design item C1 —
+      // this endpoint is not yet authenticated; see the class doc.)
       const results = [];
       for (const reservation of reservations) {
+        const connection = await this.findBookingComConnection(reservation.channelHotelId);
+        if (!connection) {
+          this.logger.error(
+            `Booking.com reservation ${reservation.externalConfirmation}: no connection matches hotelCode='${reservation.channelHotelId ?? '(missing)'}' — rejected`,
+          );
+          results.push({
+            externalConfirmation: reservation.externalConfirmation,
+            error: 'No matching channel connection for hotel code',
+            success: false,
+          });
+          continue;
+        }
         try {
           const result = await this.inboundReservationService.processInboundReservation(
             connection.id,
@@ -152,10 +160,17 @@ export class BookingComInboundController {
         return this.sendErrorXml(res, '400', 'Missing reservation ID in cancellation');
       }
 
-      // Build a cancellation ChannelReservation
-      const connection = await this.findBookingComConnection();
+      // Route the cancellation to the connection matching the OTA hotel code so a
+      // caller can't cancel another tenant's reservation by guessing its id.
+      const cancelHotelId =
+        (parsed.data as any).RoomStays?.RoomStay?.BasicPropertyInfo?.['@_HotelCode'] ??
+        (parsed.data as any).BasicPropertyInfo?.['@_HotelCode'] ??
+        (parsed.data as any)['@_HotelCode'];
+      const connection = await this.findBookingComConnection(
+        cancelHotelId != null ? String(cancelHotelId) : undefined,
+      );
       if (!connection) {
-        return this.sendErrorXml(res, '500', 'No active Booking.com connection configured');
+        return this.sendErrorXml(res, '400', 'No matching channel connection for hotel code');
       }
 
       // Process as cancellation through the standard flow
@@ -199,10 +214,17 @@ export class BookingComInboundController {
 
   // --- Private ---
 
-  private async findBookingComConnection() {
-    // Find first active Booking.com connection
+  /**
+   * Resolve the Booking.com connection for a given OTA hotel code. NEVER defaults
+   * to the first connection: with two tenants on Booking.com that would attribute
+   * the reservation/cancellation to an arbitrary property (confused-deputy).
+   */
+  private async findBookingComConnection(hotelId: string | undefined) {
+    if (!hotelId) return null;
     const connections = await this.channelService.findByAdapterType('booking_com');
-    return connections[0] ?? null;
+    return (
+      connections.find((c: any) => String((c.config ?? {}).hotelId ?? '') === hotelId) ?? null
+    );
   }
 
   private sendErrorXml(res: any, code: string, message: string) {

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com.mapper.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com.mapper.ts
@@ -190,9 +190,16 @@ export function mapOtaReservationToHaip(
       ? new Date(createDateStr)
       : new Date();
 
+    // OTA hotel code — routes the reservation to the right tenant's connection.
+    const channelHotelId =
+      roomStay.BasicPropertyInfo?.['@_HotelCode'] ??
+      (hotelRes as any).BasicPropertyInfo?.['@_HotelCode'] ??
+      (hotelRes as any).RoomStays?.RoomStay?.BasicPropertyInfo?.['@_HotelCode'];
+
     reservations.push({
       externalConfirmation,
       channelCode: 'booking_com',
+      channelHotelId: channelHotelId != null ? String(channelHotelId) : undefined,
       guestFirstName,
       guestLastName,
       guestEmail,

--- a/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.spec.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ExpediaInboundController } from './expedia-inbound.controller';
+
+// Parse + map are stubbed so the test drives the routing decision directly.
+vi.mock('./expedia.xml', () => ({ parseExpediaResponse: () => ({ data: {} }) }));
+let mockReservations: any[] = [];
+vi.mock('./expedia.reservation-mapper', () => ({
+  mapExpediaBookingToHaip: () => mockReservations,
+}));
+
+function makeRes() {
+  const res: any = { statusCode: 0, body: '' };
+  res.status = (c: number) => { res.statusCode = c; return res; };
+  res.send = (b: any) => { res.body = b; return res; };
+  return res;
+}
+const req = { rawBody: '<x/>' };
+
+describe('ExpediaInboundController — tenant routing', () => {
+  let inbound: { processInboundReservation: ReturnType<typeof vi.fn> };
+  let channel: { findByAdapterType: ReturnType<typeof vi.fn> };
+  let controller: ExpediaInboundController;
+
+  beforeEach(() => {
+    inbound = { processInboundReservation: vi.fn().mockResolvedValue({ confirmationNumber: 'PMS1' }) };
+    channel = { findByAdapterType: vi.fn() };
+    controller = new ExpediaInboundController(inbound as any, channel as any);
+  });
+
+  it('routes a booking to the connection whose config.hotelId matches', async () => {
+    mockReservations = [{ externalConfirmation: 'E1', channelHotelId: 'HOTEL_B' }];
+    channel.findByAdapterType.mockResolvedValue([
+      { id: 'conn-A', propertyId: 'pA', config: { hotelId: 'HOTEL_A' } },
+      { id: 'conn-B', propertyId: 'pB', config: { hotelId: 'HOTEL_B' } },
+    ]);
+
+    await controller.receiveBooking(req as any, makeRes());
+
+    expect(inbound.processInboundReservation).toHaveBeenCalledTimes(1);
+    expect(inbound.processInboundReservation).toHaveBeenCalledWith('conn-B', expect.objectContaining({ externalConfirmation: 'E1' }));
+  });
+
+  it('rejects a booking when no connection matches the hotelId (no default to [0])', async () => {
+    mockReservations = [{ externalConfirmation: 'E2', channelHotelId: 'HOTEL_X' }];
+    channel.findByAdapterType.mockResolvedValue([
+      { id: 'conn-A', propertyId: 'pA', config: { hotelId: 'HOTEL_A' } },
+    ]);
+
+    await controller.receiveBooking(req as any, makeRes());
+
+    expect(inbound.processInboundReservation).not.toHaveBeenCalled();
+  });
+
+  it('rejects a booking with no hotelId rather than guessing', async () => {
+    mockReservations = [{ externalConfirmation: 'E3' }];
+    channel.findByAdapterType.mockResolvedValue([
+      { id: 'conn-A', propertyId: 'pA', config: { hotelId: 'HOTEL_A' } },
+    ]);
+
+    await controller.receiveBooking(req as any, makeRes());
+
+    expect(inbound.processInboundReservation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.ts
@@ -37,13 +37,25 @@ export class ExpediaInboundController {
       }
 
       const connections = await this.channelService.findByAdapterType('expedia');
-      const connection = connections[0];
-      if (!connection) {
+      if (connections.length === 0) {
         this.logger.error('No active Expedia channel connection found');
         return res.status(500).send('No active Expedia connection configured');
       }
 
       for (const reservation of reservations) {
+        // Route to the connection whose config.hotelId matches the booking's hotel.
+        // NEVER fall back to connections[0]: with two tenants on Expedia that would
+        // attribute the booking to an arbitrary property (confused-deputy).
+        const hotelId = reservation.channelHotelId;
+        const connection = hotelId
+          ? connections.find((c: any) => String((c.config ?? {}).hotelId ?? '') === hotelId)
+          : undefined;
+        if (!connection) {
+          this.logger.error(
+            `Expedia booking ${reservation.externalConfirmation}: no connection matches hotelId='${hotelId ?? '(missing)'}' — rejected`,
+          );
+          continue;
+        }
         try {
           await this.inboundReservationService.processInboundReservation(connection.id, reservation);
         } catch (error: any) {

--- a/apps/api/src/modules/channel/adapters/expedia/expedia.reservation-mapper.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia.reservation-mapper.ts
@@ -28,9 +28,15 @@ export function mapExpediaBookingToHaip(data: Record<string, unknown>): ChannelR
     const stay = roomStay.StayDate ?? roomStay ?? {};
     const total = roomStay.Total ?? b.Total ?? {};
 
+    // EQC carries the Expedia hotel id per booking; used to route to the right
+    // tenant's connection. Left undefined when absent so the receiver rejects
+    // rather than guessing.
+    const hotelId = b['@_hotelId'] ?? b.Hotel?.['@_id'] ?? roomStay['@_hotelId'] ?? b['@_hotelid'];
+
     return {
       externalConfirmation: String(b['@_id'] ?? b['@_confirmId'] ?? b.UniqueID?.['@_id'] ?? `EXP-${Date.now()}`),
       channelCode: 'expedia',
+      channelHotelId: hotelId != null ? String(hotelId) : undefined,
       guestFirstName: String(name.GivenName ?? name['@_givenName'] ?? 'Guest'),
       guestLastName: String(name.Surname ?? name['@_surname'] ?? 'Unknown'),
       guestEmail: guest.Email ? String(guest.Email) : undefined,

--- a/apps/api/src/modules/channel/ari.service.spec.ts
+++ b/apps/api/src/modules/channel/ari.service.spec.ts
@@ -154,7 +154,7 @@ describe('AriService', () => {
       await service.pushAvailability('prop-1', '2024-06-01', '2024-06-02');
 
       expect(mockDb.insert).toHaveBeenCalled(); // logSync
-      expect(mockChannelService.updateSyncStatus).toHaveBeenCalledWith('conn-1', 'success', undefined);
+      expect(mockChannelService.updateSyncStatus).toHaveBeenCalledWith('conn-1', 'prop-1', 'success', undefined);
     });
 
     it('should skip connections with no room type mapping', async () => {

--- a/apps/api/src/modules/channel/ari.service.ts
+++ b/apps/api/src/modules/channel/ari.service.ts
@@ -98,6 +98,7 @@ export class AriService {
       await this.logSync(propertyId, conn.id, 'push', 'availability_push', items, result, startDate, endDate);
       await this.channelService.updateSyncStatus(
         conn.id,
+        conn.propertyId,
         result.success ? 'success' : 'failed',
         result.errors.length > 0 ? result.errors[0]!.message : undefined,
       );
@@ -213,6 +214,7 @@ export class AriService {
       const overallSuccess = rateResult.success && restrictionResult.success;
       await this.channelService.updateSyncStatus(
         conn.id,
+        conn.propertyId,
         overallSuccess ? 'success' : 'failed',
         [...rateResult.errors, ...restrictionResult.errors].map((e) => e.message).join('; ') || undefined,
       );

--- a/apps/api/src/modules/channel/channel-adapter.interface.ts
+++ b/apps/api/src/modules/channel/channel-adapter.interface.ts
@@ -121,6 +121,12 @@ export interface ReservationPullParams {
 export interface ChannelReservation {
   externalConfirmation: string;
   channelCode: string;
+  /**
+   * The OTA's hotel/property identifier from the inbound payload. Inbound webhook
+   * receivers MUST match this against a channel connection's `config.hotelId` to
+   * route the booking to the correct tenant — never default to the first connection.
+   */
+  channelHotelId?: string;
   guestFirstName: string;
   guestLastName: string;
   guestEmail?: string;

--- a/apps/api/src/modules/channel/channel.service.spec.ts
+++ b/apps/api/src/modules/channel/channel.service.spec.ts
@@ -164,7 +164,7 @@ describe('ChannelService', () => {
       const updateChain = { where: vi.fn().mockResolvedValue(undefined) };
       mockDb.chain.set.mockReturnValue(updateChain);
 
-      await service.updateSyncStatus('conn-1', 'success');
+      await service.updateSyncStatus('conn-1', 'prop-1', 'success');
 
       expect(mockDb.db.update).toHaveBeenCalled();
     });
@@ -173,7 +173,7 @@ describe('ChannelService', () => {
       const updateChain = { where: vi.fn().mockResolvedValue(undefined) };
       mockDb.chain.set.mockReturnValue(updateChain);
 
-      await service.updateSyncStatus('conn-1', 'failed', 'Timeout');
+      await service.updateSyncStatus('conn-1', 'prop-1', 'failed', 'Timeout');
 
       expect(mockDb.chain.set).toHaveBeenCalledWith(
         expect.objectContaining({ lastSyncError: 'Timeout' }),

--- a/apps/api/src/modules/channel/channel.service.ts
+++ b/apps/api/src/modules/channel/channel.service.ts
@@ -151,9 +151,13 @@ export class ChannelService {
 
   async updateSyncStatus(
     id: string,
+    propertyId: string,
     status: string,
     error?: string,
   ) {
+    // propertyId is part of the WHERE (not just the caller's responsibility): every
+    // property-scoped write must filter by propertyId so this stays safe even if a
+    // future caller passes a client-supplied connection id.
     await this.db
       .update(channelConnections)
       .set({
@@ -162,6 +166,6 @@ export class ChannelService {
         lastSyncError: error ?? null,
         updatedAt: new Date(),
       })
-      .where(eq(channelConnections.id, id));
+      .where(and(eq(channelConnections.id, id), eq(channelConnections.propertyId, propertyId)));
   }
 }

--- a/apps/api/src/modules/channel/content-sync.service.spec.ts
+++ b/apps/api/src/modules/channel/content-sync.service.spec.ts
@@ -30,7 +30,7 @@ function createMockDb() {
 const PROP = 'p1';
 const property = { id: PROP, name: 'Grand', description: 'd', addressLine1: 'a', city: 'c', countryCode: 'US', starRating: 5 };
 const rt = { id: 'rt1', name: 'Standard', description: 'sd', maxOccupancy: 2, bedType: 'king', amenities: ['wifi'] };
-const conn = { id: 'cc1', adapterType: 'mock', config: {}, roomTypeMapping: [{ roomTypeId: 'rt1', channelRoomCode: 'EXP_STD' }] };
+const conn = { id: 'cc1', propertyId: 'p1', adapterType: 'mock', config: {}, roomTypeMapping: [{ roomTypeId: 'rt1', channelRoomCode: 'EXP_STD' }] };
 
 function setup(overrides: { roomTypeRows?: any[]; propertyRows?: any[] } = {}) {
   const mock = createMockDb();
@@ -73,7 +73,7 @@ describe('ContentSyncService', () => {
     const log = s.mock.inserted.find((r) => r.table === contentSyncLogs);
     expect(log?.values.action).toBe('content_push');
     expect(log?.values.status).toBe('success');
-    expect(s.channelService.updateSyncStatus).toHaveBeenCalledWith('cc1', 'success', undefined);
+    expect(s.channelService.updateSyncStatus).toHaveBeenCalledWith('cc1', 'p1', 'success', undefined);
   });
 
   it('skips room-type mappings whose room type is not at the property', async () => {

--- a/apps/api/src/modules/channel/content-sync.service.ts
+++ b/apps/api/src/modules/channel/content-sync.service.ts
@@ -102,6 +102,7 @@ export class ContentSyncService {
       await this.logSync(propertyId, conn.id, params, result);
       await this.channelService.updateSyncStatus(
         conn.id,
+        conn.propertyId,
         result.success ? 'success' : 'failed',
         result.errors.length > 0 ? result.errors[0]!.message : undefined,
       );

--- a/apps/api/src/modules/events/events.gateway.ts
+++ b/apps/api/src/modules/events/events.gateway.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import { Server, Socket } from 'socket.io';
 import { WsAuthService } from '../auth/ws-auth.service';
 import type { AuthUser } from '../auth/current-user.decorator';
+import { userCanAccessProperty } from '../auth/property-access';
 
 /**
  * Events gateway — real-time PMS event broadcasts.
@@ -143,12 +144,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   private userCanAccessProperty(user: AuthUser, propertyId: string): boolean {
-    // Platform-level roles that bypass property scoping (same intent as the
-    // HTTP RolesGuard — admins can cross tenants for ops).
-    const platformRoles = new Set(['admin', 'platform_admin', 'superadmin']);
-    if (user.roles?.some((r) => platformRoles.has(r))) return true;
-
-    const allowed = user.propertyIds ?? [];
-    return allowed.includes(propertyId);
+    // Shared with the HTTP PropertyScopeGuard so socket and REST scoping can't drift.
+    return userCanAccessProperty(user, propertyId);
   }
 }

--- a/apps/api/src/modules/housekeeping/housekeeping.controller.ts
+++ b/apps/api/src/modules/housekeeping/housekeeping.controller.ts
@@ -14,6 +14,7 @@ import {
 import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { HousekeepingService } from './housekeeping.service';
+import { RoomService } from '../room/room.service';
 import { CreateTaskDto } from './dto/create-task.dto';
 import { UpdateTaskDto } from './dto/update-task.dto';
 import { ListTasksDto } from './dto/list-tasks.dto';
@@ -25,7 +26,10 @@ import { InspectTaskDto } from './dto/inspect-task.dto';
 @ApiTags('housekeeping')
 @Controller('housekeeping')
 export class HousekeepingController {
-  constructor(private readonly housekeepingService: HousekeepingService) {}
+  constructor(
+    private readonly housekeepingService: HousekeepingService,
+    private readonly roomService: RoomService,
+  ) {}
 
   @Get('/dashboard')
   @ApiOperation({ summary: 'Get housekeeping dashboard' })
@@ -71,7 +75,10 @@ export class HousekeepingController {
   @Roles('admin', 'housekeeping', 'housekeeping_manager')
   @ApiOperation({ summary: 'Create housekeeping task' })
   @HttpCode(HttpStatus.CREATED)
-  createTask(@Body() dto: CreateTaskDto) {
+  async createTask(@Body() dto: CreateTaskDto) {
+    // roomId is client-supplied — verify it belongs to the request's property (throws
+    // NotFound otherwise) so a caller can't attach a task to another tenant's room.
+    await this.roomService.findRoomById(dto.roomId, dto.propertyId);
     return this.housekeepingService.create(dto);
   }
 

--- a/apps/api/src/modules/housekeeping/housekeeping.service.ts
+++ b/apps/api/src/modules/housekeeping/housekeeping.service.ts
@@ -36,7 +36,7 @@ export class HousekeepingService {
     let checklist = dto.checklist;
 
     if (!checklist) {
-      checklist = await this.generateChecklist(dto.type, dto.roomId);
+      checklist = await this.generateChecklist(dto.type, dto.roomId, dto.propertyId);
     }
 
     const [task] = await this.db
@@ -538,23 +538,27 @@ export class HousekeepingService {
     );
   }
 
-  private async generateChecklist(taskType: string, roomId: string) {
+  // propertyId is REQUIRED so the room/reservation reads below stay tenant-scoped:
+  // roomId comes from the request body, so without an `eq(...propertyId)` filter a
+  // caller at property A could pass a roomId from property B and leak that room's
+  // ADA status / next-guest VIP level (cross-tenant IDOR).
+  private async generateChecklist(taskType: string, roomId: string, propertyId: string) {
     const template = CHECKLIST_TEMPLATES[taskType];
     if (!template) return [];
 
     const items = template.map((item) => ({ ...item }));
 
-    // Check if room is ADA accessible
+    // Check if room is ADA accessible (scoped to the property)
     const [room] = await this.db
       .select({ isAccessible: rooms.isAccessible })
       .from(rooms)
-      .where(eq(rooms.id, roomId));
+      .where(and(eq(rooms.id, roomId), eq(rooms.propertyId, propertyId)));
 
     if (room?.isAccessible) {
       items.push(...ADA_EXTRA_ITEMS.map((item) => ({ ...item })));
     }
 
-    // Check if next guest is VIP
+    // Check if next guest is VIP (scoped to the property)
     const [nextReservation] = await this.db
       .select({ vipLevel: guests.vipLevel })
       .from(reservations)
@@ -562,6 +566,7 @@ export class HousekeepingService {
       .where(
         and(
           eq(reservations.roomId, roomId),
+          eq(reservations.propertyId, propertyId),
           inArray(reservations.status, ['confirmed', 'assigned'] as any),
         ),
       )


### PR DESCRIPTION
First of two security-remediation PRs from the code + security review. **PR1 = cross-tenant & authorization correctness** (the exploitable multi-tenancy findings). PR2 (deployment & input hardening) follows.

All guard changes are **no-ops when `AUTH_ENABLED=false`**, so the docker-compose demo + CI `demo-smoke` + the hosted demo stay green.

## Fixes
- **Housekeeping IDOR** — `generateChecklist` reads of `rooms`/`reservations` are now scoped by `propertyId` (was leaking another property's room ADA status + next-guest VIP level via a client-supplied `roomId`). The create endpoint also validates room ownership via the existing `RoomService.findRoomById`.
- **Inbound OTA tenant routing** — Expedia and Booking.com inbound webhooks route each booking to the connection whose `config.hotelId` matches the payload's hotel id, **rejecting on no match**, instead of defaulting to `connections[0]` (which misrouted bookings across tenants once two hotels used one OTA). Added `channelHotelId` to `ChannelReservation`.
- **`updateSyncStatus` scoping** — now includes `propertyId` in its WHERE clause (+ callers pass `conn.propertyId`).
- **Systemic property→tenant binding** — new global `PropertyScopeGuard` binds the authenticated principal to the request's `propertyId` on **all** HTTP routes (most are gated only by global `@Roles`, which never checked `property_ids`). Generalizes what the WebSocket gateway already did; shared `userCanAccessProperty()` keeps socket + REST scoping from drifting.

## Honesty note
The Booking.com inbound controller's "Security is via Basic Auth verification" comment was false — the header was never checked. That comment is corrected: caller **authentication** of inbound webhooks is design item **C1** (not implemented yet). This PR enforces tenant **routing**, not authentication — the endpoints remain `@Public()` pending C1.

## Verification
- API suite **782** green (10 new: PropertyScopeGuard spec, Expedia inbound routing spec, updated channel/housekeeping specs).
- `typecheck` + `lint` clean (0 errors).
- Demo unaffected (guards bypass when AUTH off).

Depends on Keycloak provisioning the `property_ids` claim per user when AUTH is enabled (tracked as a design item).

https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt)_