### PR TITLE
fix(security): deployment & input hardening (PR2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,20 @@ REDIS_URL=redis://localhost:6379
 PORT=3000
 NODE_ENV=development
 
+# In production the API refuses to boot with an insecure config
+# (AUTH_ENABLED=false or STRIPE_MODE=mock) to prevent an accidental insecure
+# real deployment. The intentional public demo sets this to opt out.
+# HAIP_ALLOW_INSECURE=false
+
+# CORS: comma-separated allowlist of browser origins, or '*' for any. When unset,
+# production defaults to same-origin only; dev allows all.
+# CORS_ORIGINS=https://app.example.com,https://admin.example.com
+
+# Optional brute-force rate limit (in-memory). Defaults: 300 req / 60s per IP.
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+# RATE_LIMIT_DISABLED=false
+
 # Authentication (Keycloak OIDC)
 # AUTH_ENABLED controls whether JWT auth is enforced:
 #   false (default) — all requests pass through, no JWT required. Use for dev/testing.

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
+import { RateLimitGuard } from './common/security/rate-limit.guard';
 import { DatabaseModule } from './database/database.module';
 import { HealthModule } from './modules/health/health.module';
 import { PropertyModule } from './modules/property/property.module';
@@ -74,5 +76,11 @@ if (process.env['NODE_ENV'] === 'production' || process.env['SERVE_DASHBOARD'] =
   );
 }
 
-@Module({ imports })
+@Module({
+  imports,
+  providers: [
+    // Global, in-memory brute-force mitigation (interim, pre-C2). Runs first.
+    { provide: APP_GUARD, useClass: RateLimitGuard },
+  ],
+})
 export class AppModule {}

--- a/apps/api/src/common/audit/audit-actor.ts
+++ b/apps/api/src/common/audit/audit-actor.ts
@@ -1,0 +1,45 @@
+import { createParamDecorator, type ExecutionContext } from '@nestjs/common';
+import type { AuthUser } from '../../modules/auth/current-user.decorator';
+
+/** Who performed an audited action + from where. All optional (null in AUTH-off demo). */
+export interface AuditActor {
+  userId?: string | null;
+  userEmail?: string | null;
+  ipAddress?: string | null;
+}
+
+/** Map an AuditActor to the auditLogs actor columns (always defined, possibly null). */
+export function actorFields(actor?: AuditActor): {
+  userId: string | null;
+  userEmail: string | null;
+  ipAddress: string | null;
+} {
+  return {
+    userId: actor?.userId ?? null,
+    userEmail: actor?.userEmail ?? null,
+    ipAddress: actor?.ipAddress ?? null,
+  };
+}
+
+/**
+ * Controller param decorator — builds an AuditActor from the authenticated
+ * principal (req.user) and request IP. Undefined fields when auth is off so the
+ * audit row records nulls rather than forging an actor from client input.
+ */
+export const AuditActorCtx = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext): AuditActor => {
+    const req = ctx.switchToHttp().getRequest();
+    const user: AuthUser | undefined = req?.user;
+    const fwd = req?.headers?.['x-forwarded-for'];
+    const ip =
+      (typeof fwd === 'string' && fwd.length > 0 ? fwd.split(',')[0]!.trim() : undefined) ??
+      req?.ip ??
+      req?.socket?.remoteAddress ??
+      null;
+    return {
+      userId: user?.sub ?? null,
+      userEmail: user?.email ?? null,
+      ipAddress: ip,
+    };
+  },
+);

--- a/apps/api/src/common/config/assert-secure-config.spec.ts
+++ b/apps/api/src/common/config/assert-secure-config.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { assertSecureConfig } from './assert-secure-config';
+
+describe('assertSecureConfig', () => {
+  it('does nothing outside production', () => {
+    expect(() => assertSecureConfig({ NODE_ENV: 'development', AUTH_ENABLED: 'false', STRIPE_MODE: 'mock' } as any)).not.toThrow();
+  });
+
+  it('refuses to boot in production with AUTH disabled', () => {
+    expect(() => assertSecureConfig({ NODE_ENV: 'production', AUTH_ENABLED: 'false', STRIPE_MODE: 'live' } as any)).toThrow(/AUTH_ENABLED=false/);
+  });
+
+  it('refuses to boot in production with mock payments', () => {
+    expect(() => assertSecureConfig({ NODE_ENV: 'production', AUTH_ENABLED: 'true', STRIPE_MODE: 'mock' } as any)).toThrow(/STRIPE_MODE=mock/);
+  });
+
+  it('allows the explicit insecure opt-in (public demo)', () => {
+    expect(() =>
+      assertSecureConfig({ NODE_ENV: 'production', AUTH_ENABLED: 'false', STRIPE_MODE: 'mock', HAIP_ALLOW_INSECURE: 'true' } as any),
+    ).not.toThrow();
+  });
+
+  it('passes a properly-configured production', () => {
+    expect(() => assertSecureConfig({ NODE_ENV: 'production', AUTH_ENABLED: 'true', STRIPE_MODE: 'live' } as any)).not.toThrow();
+  });
+});

--- a/apps/api/src/common/config/assert-secure-config.ts
+++ b/apps/api/src/common/config/assert-secure-config.ts
@@ -1,0 +1,22 @@
+/**
+ * Refuse to boot an insecure configuration in production. The #1 real-world
+ * breach risk is shipping with AUTH_ENABLED=false (or STRIPE_MODE=mock) to a
+ * production host. The intentional public demo opts out with
+ * HAIP_ALLOW_INSECURE=true.
+ *
+ * Pure function over an env map so it's unit-testable; main.ts calls it with
+ * process.env at startup.
+ */
+export function assertSecureConfig(env: NodeJS.ProcessEnv = process.env): void {
+  if (env['NODE_ENV'] !== 'production') return;
+  if (env['HAIP_ALLOW_INSECURE'] === 'true') return;
+  const problems: string[] = [];
+  if (env['AUTH_ENABLED'] === 'false') problems.push('AUTH_ENABLED=false');
+  if ((env['STRIPE_MODE'] ?? 'mock') === 'mock') problems.push('STRIPE_MODE=mock');
+  if (problems.length > 0) {
+    throw new Error(
+      `Refusing to start in production with insecure config: ${problems.join(', ')}. ` +
+        'Set real values, or set HAIP_ALLOW_INSECURE=true to override (e.g. for the public demo).',
+    );
+  }
+}

--- a/apps/api/src/common/filters/all-exceptions.filter.spec.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BadRequestException, type ArgumentsHost } from '@nestjs/common';
+import { AllExceptionsFilter } from './all-exceptions.filter';
+
+function makeHost() {
+  const res: any = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  const host = {
+    switchToHttp: () => ({
+      getResponse: () => res,
+      getRequest: () => ({ method: 'GET', url: '/x' }),
+    }),
+  } as unknown as ArgumentsHost;
+  return { host, res };
+}
+
+describe('AllExceptionsFilter', () => {
+  const filter = new AllExceptionsFilter();
+
+  it('passes through HttpExceptions with their status', () => {
+    const { host, res } = makeHost();
+    filter.catch(new BadRequestException('bad input'), host);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('maps unknown errors to a generic 500 (no stack/detail leaked)', () => {
+    const { host, res } = makeHost();
+    filter.catch(new Error('ECONNREFUSED postgres at 10.0.0.5:5432 — secret detail'), host);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ statusCode: 500, message: 'Internal server error' });
+  });
+});

--- a/apps/api/src/common/filters/all-exceptions.filter.ts
+++ b/apps/api/src/common/filters/all-exceptions.filter.ts
@@ -1,0 +1,47 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+
+/**
+ * Global exception filter.
+ *
+ * HttpExceptions keep their intended status + message (already safe). Any other
+ * error (DB driver error, Decimal parse, TypeError, …) is logged in full
+ * server-side but returned to the client as a generic 500 with no stack, SQL,
+ * or internal detail — closes the info-disclosure gap from the security review.
+ */
+@Catch()
+export class AllExceptionsFilter implements ExceptionFilter {
+  private readonly logger = new Logger('UnhandledException');
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const res = ctx.getResponse();
+    const req = ctx.getRequest();
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus();
+      res.status(status).json(
+        typeof exception.getResponse() === 'string'
+          ? { statusCode: status, message: exception.getResponse() }
+          : exception.getResponse(),
+      );
+      return;
+    }
+
+    const err = exception as { message?: string; stack?: string };
+    this.logger.error(
+      `Unhandled error on ${req?.method} ${req?.url}: ${err?.message ?? exception}`,
+      err?.stack,
+    );
+    res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: 'Internal server error',
+    });
+  }
+}

--- a/apps/api/src/common/http/security-headers.ts
+++ b/apps/api/src/common/http/security-headers.ts
@@ -1,0 +1,23 @@
+import type { Request, Response, NextFunction } from 'express';
+
+/**
+ * Minimal security-response-headers middleware (dependency-free stand-in for
+ * helmet's defaults). Sets the headers that matter for a JSON API serving a
+ * bundled SPA: no MIME sniffing, deny framing, referrer privacy, and HSTS in
+ * production. Kept small and explicit so it's easy to audit.
+ */
+export function securityHeaders() {
+  const isProd = process.env['NODE_ENV'] === 'production';
+  return (_req: Request, res: Response, next: NextFunction) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+    res.removeHeader('X-Powered-By');
+    if (isProd) {
+      res.setHeader('Strict-Transport-Security', 'max-age=15552000; includeSubDomains');
+    }
+    next();
+  };
+}

--- a/apps/api/src/common/security/is-safe-url.validator.ts
+++ b/apps/api/src/common/security/is-safe-url.validator.ts
@@ -1,0 +1,38 @@
+import {
+  registerDecorator,
+  type ValidationOptions,
+  ValidatorConstraint,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+import { isLiterallySafeHttpUrl } from './url-guard';
+
+@ValidatorConstraint({ name: 'isSafeHttpUrl', async: false })
+class SafeHttpUrlConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: any): boolean {
+    if (typeof value !== 'string') return false;
+    const requireHttps = args?.constraints?.[0]?.requireHttps ?? false;
+    return isLiterallySafeHttpUrl(value, { requireHttps });
+  }
+  defaultMessage(): string {
+    return 'must be a public http(s) URL (private/loopback hosts are not allowed)';
+  }
+}
+
+/**
+ * Validates a URL is a public http(s) target and not a private/loopback/
+ * metadata host (literal check; DNS is re-checked server-side at use time).
+ */
+export function IsSafeHttpUrl(
+  opts: { requireHttps?: boolean } = {},
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [opts],
+      validator: SafeHttpUrlConstraint,
+    });
+  };
+}

--- a/apps/api/src/common/security/rate-limit.guard.spec.ts
+++ b/apps/api/src/common/security/rate-limit.guard.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { HttpException, type ExecutionContext } from '@nestjs/common';
+import { RateLimitGuard } from './rate-limit.guard';
+
+function ctx(ip: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ ip, headers: {} }) }),
+  } as unknown as ExecutionContext;
+}
+
+function guard(env: Record<string, string>) {
+  const cfg = { get: (k: string, d?: string) => env[k] ?? d } as any;
+  // Force-enable (the guard disables itself under NODE_ENV=test).
+  const g = new RateLimitGuard(cfg);
+  (g as any).disabled = env['DISABLED'] === 'true';
+  return g;
+}
+
+describe('RateLimitGuard', () => {
+  it('allows up to the limit then throws 429', () => {
+    const g = guard({ RATE_LIMIT_MAX: '3', RATE_LIMIT_WINDOW_MS: '60000' });
+    expect(g.canActivate(ctx('1.2.3.4'))).toBe(true);
+    expect(g.canActivate(ctx('1.2.3.4'))).toBe(true);
+    expect(g.canActivate(ctx('1.2.3.4'))).toBe(true);
+    expect(() => g.canActivate(ctx('1.2.3.4'))).toThrow(HttpException);
+  });
+
+  it('tracks limits per client IP', () => {
+    const g = guard({ RATE_LIMIT_MAX: '1' });
+    expect(g.canActivate(ctx('1.1.1.1'))).toBe(true);
+    expect(g.canActivate(ctx('2.2.2.2'))).toBe(true); // different IP, fresh budget
+    expect(() => g.canActivate(ctx('1.1.1.1'))).toThrow(HttpException);
+  });
+
+  it('is a no-op when disabled', () => {
+    const g = guard({ RATE_LIMIT_MAX: '1', DISABLED: 'true' });
+    for (let i = 0; i < 10; i++) expect(g.canActivate(ctx('9.9.9.9'))).toBe(true);
+  });
+});

--- a/apps/api/src/common/security/rate-limit.guard.ts
+++ b/apps/api/src/common/security/rate-limit.guard.ts
@@ -1,0 +1,69 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Minimal in-memory fixed-window rate limiter (dependency-free stand-in for
+ * @nestjs/throttler). Global, per client IP. This is an INTERIM brute-force
+ * mitigation — notably for the Connect confirmation-number enumeration — pending
+ * the C2 credential redesign.
+ *
+ * Tunable via env: RATE_LIMIT_MAX (default 300) per RATE_LIMIT_WINDOW_MS
+ * (default 60000). Disabled when NODE_ENV=test or RATE_LIMIT_DISABLED=true.
+ * In-memory only (per instance); a Redis-backed limiter is the production
+ * upgrade path.
+ */
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  private readonly hits = new Map<string, { count: number; resetAt: number }>();
+  private readonly max: number;
+  private readonly windowMs: number;
+  private readonly disabled: boolean;
+
+  constructor(private readonly configService: ConfigService) {
+    this.max = Number(this.configService.get('RATE_LIMIT_MAX', '300')) || 300;
+    this.windowMs = Number(this.configService.get('RATE_LIMIT_WINDOW_MS', '60000')) || 60000;
+    this.disabled =
+      process.env['NODE_ENV'] === 'test' ||
+      this.configService.get<string>('RATE_LIMIT_DISABLED', 'false') === 'true';
+  }
+
+  canActivate(context: ExecutionContext): boolean {
+    if (this.disabled) return true;
+    const req = context.switchToHttp().getRequest();
+    if (!req) return true; // non-HTTP (ws) contexts
+
+    const ip = this.clientIp(req);
+    const now = Date.now();
+    const entry = this.hits.get(ip);
+    if (!entry || now >= entry.resetAt) {
+      this.hits.set(ip, { count: 1, resetAt: now + this.windowMs });
+      this.sweep(now);
+      return true;
+    }
+    entry.count++;
+    if (entry.count > this.max) {
+      throw new HttpException('Too many requests', HttpStatus.TOO_MANY_REQUESTS);
+    }
+    return true;
+  }
+
+  private clientIp(req: any): string {
+    const fwd = req.headers?.['x-forwarded-for'];
+    if (typeof fwd === 'string' && fwd.length > 0) return fwd.split(',')[0]!.trim();
+    return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+  }
+
+  /** Bound memory: drop expired windows occasionally. */
+  private sweep(now: number): void {
+    if (this.hits.size < 10_000) return;
+    for (const [k, v] of this.hits) {
+      if (now >= v.resetAt) this.hits.delete(k);
+    }
+  }
+}

--- a/apps/api/src/common/security/url-guard.spec.ts
+++ b/apps/api/src/common/security/url-guard.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { isPrivateIp, isLiterallySafeHttpUrl, assertSafeOutboundUrl, UnsafeUrlError } from './url-guard';
+
+describe('isPrivateIp', () => {
+  it.each([
+    '127.0.0.1', '10.1.2.3', '172.16.0.1', '172.31.255.255', '192.168.1.1',
+    '169.254.169.254', '100.64.0.1', '0.0.0.0', '::1', 'fe80::1', 'fc00::1', '::ffff:10.0.0.1',
+  ])('flags %s as private', (ip) => {
+    expect(isPrivateIp(ip)).toBe(true);
+  });
+
+  it.each(['8.8.8.8', '1.1.1.1', '172.15.0.1', '172.32.0.1', '93.184.216.34'])(
+    'allows public %s',
+    (ip) => {
+      expect(isPrivateIp(ip)).toBe(false);
+    },
+  );
+});
+
+describe('isLiterallySafeHttpUrl', () => {
+  it('rejects non-http(s) schemes', () => {
+    expect(isLiterallySafeHttpUrl('ftp://example.com')).toBe(false);
+    expect(isLiterallySafeHttpUrl('file:///etc/passwd')).toBe(false);
+  });
+  it('rejects localhost and private/metadata literals', () => {
+    expect(isLiterallySafeHttpUrl('http://localhost/x')).toBe(false);
+    expect(isLiterallySafeHttpUrl('http://127.0.0.1/x')).toBe(false);
+    expect(isLiterallySafeHttpUrl('http://169.254.169.254/latest/meta-data/')).toBe(false);
+    expect(isLiterallySafeHttpUrl('http://10.0.0.5/internal')).toBe(false);
+  });
+  it('accepts a public https URL', () => {
+    expect(isLiterallySafeHttpUrl('https://hooks.example.com/haip')).toBe(true);
+  });
+  it('enforces https when required', () => {
+    expect(isLiterallySafeHttpUrl('http://hooks.example.com', { requireHttps: true })).toBe(false);
+    expect(isLiterallySafeHttpUrl('https://hooks.example.com', { requireHttps: true })).toBe(true);
+  });
+});
+
+describe('assertSafeOutboundUrl', () => {
+  it('rejects a literal metadata IP without needing DNS', async () => {
+    await expect(assertSafeOutboundUrl('http://169.254.169.254/')).rejects.toBeInstanceOf(UnsafeUrlError);
+  });
+  it('rejects an http URL when https is required', async () => {
+    await expect(
+      assertSafeOutboundUrl('http://1.1.1.1/', { requireHttps: true }),
+    ).rejects.toBeInstanceOf(UnsafeUrlError);
+  });
+  it('allows a public literal IP over https', async () => {
+    await expect(assertSafeOutboundUrl('https://1.1.1.1/', { requireHttps: true })).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/common/security/url-guard.ts
+++ b/apps/api/src/common/security/url-guard.ts
@@ -1,0 +1,102 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * SSRF protection for server-side outbound requests to user-supplied URLs
+ * (webhook delivery, etc.). Rejects non-http(s) schemes and any host that
+ * resolves to a private / loopback / link-local / metadata address.
+ */
+
+export class UnsafeUrlError extends Error {}
+
+function ipv4ToParts(ip: string): number[] | null {
+  const parts = ip.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+  return parts;
+}
+
+/** True for loopback / private / link-local / CGNAT / metadata / unspecified ranges. */
+export function isPrivateIp(ip: string): boolean {
+  const v = isIP(ip);
+  if (v === 4) {
+    const p = ipv4ToParts(ip);
+    if (!p) return true; // unparseable → treat as unsafe
+    const [a, b] = p as [number, number, number, number];
+    if (a === 0 || a === 10 || a === 127) return true; // this-host, private, loopback
+    if (a === 169 && b === 254) return true; // link-local + 169.254.169.254 metadata
+    if (a === 172 && b >= 16 && b <= 31) return true; // private
+    if (a === 192 && b === 168) return true; // private
+    if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+    if (a === 192 && b === 0) return true; // 192.0.0.0/24 IETF protocol
+    if (a >= 224) return true; // multicast / reserved
+    return false;
+  }
+  if (v === 6) {
+    const ip6 = ip.toLowerCase().replace(/^\[|\]$/g, '');
+    if (ip6 === '::1' || ip6 === '::') return true; // loopback / unspecified
+    if (ip6.startsWith('fe80') || ip6.startsWith('fc') || ip6.startsWith('fd')) return true; // link-local / ULA
+    // IPv4-mapped (::ffff:a.b.c.d) — re-check the embedded v4
+    const mapped = ip6.match(/::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) return isPrivateIp(mapped[1]!);
+    return false;
+  }
+  return true; // not an IP literal handled here
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, '');
+  if (h === 'localhost' || h.endsWith('.localhost') || h.endsWith('.internal') || h.endsWith('.local')) {
+    return true;
+  }
+  if (isIP(h) && isPrivateIp(h)) return true;
+  return false;
+}
+
+/**
+ * Validate a URL is a safe public http(s) target. Resolves DNS and re-checks the
+ * resolved addresses to defeat DNS-rebinding. Throws UnsafeUrlError otherwise.
+ */
+export async function assertSafeOutboundUrl(
+  raw: string,
+  opts: { requireHttps?: boolean } = {},
+): Promise<void> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new UnsafeUrlError('Invalid URL');
+  }
+  const scheme = url.protocol.replace(/:$/, '');
+  if (opts.requireHttps ? scheme !== 'https' : scheme !== 'http' && scheme !== 'https') {
+    throw new UnsafeUrlError(`Disallowed URL scheme: ${scheme}`);
+  }
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  if (isBlockedHostname(hostname)) {
+    throw new UnsafeUrlError('URL host is not allowed (private/loopback)');
+  }
+  // If the host is a DNS name, resolve and re-check every address.
+  if (isIP(hostname) === 0) {
+    let addrs: { address: string }[];
+    try {
+      addrs = await lookup(hostname, { all: true });
+    } catch {
+      throw new UnsafeUrlError('URL host could not be resolved');
+    }
+    if (addrs.length === 0 || addrs.some((a) => isPrivateIp(a.address))) {
+      throw new UnsafeUrlError('URL host resolves to a private address');
+    }
+  }
+}
+
+/** Sync, literal-only check for DTO validation (no DNS). */
+export function isLiterallySafeHttpUrl(raw: string, opts: { requireHttps?: boolean } = {}): boolean {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return false;
+  }
+  const scheme = url.protocol.replace(/:$/, '');
+  if (opts.requireHttps ? scheme !== 'https' : scheme !== 'http' && scheme !== 'https') return false;
+  return !isBlockedHostname(url.hostname.replace(/^\[|\]$/g, ''));
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,9 +3,28 @@ import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { json, raw } from 'express';
 import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
+import { securityHeaders } from './common/http/security-headers';
+import { assertSecureConfig } from './common/config/assert-secure-config';
+
+function corsOrigins(): boolean | string[] {
+  const raw = process.env['CORS_ORIGINS'];
+  if (!raw || raw.trim() === '') {
+    // No allowlist configured: in production default to same-origin only (no
+    // cross-origin); in dev allow everything for convenience.
+    return process.env['NODE_ENV'] === 'production' ? [] : true;
+  }
+  if (raw.trim() === '*') return true;
+  return raw.split(',').map((o) => o.trim()).filter(Boolean);
+}
 
 async function bootstrap() {
+  assertSecureConfig();
+
   const app = await NestFactory.create(AppModule);
+
+  // Security response headers (helmet-equivalent defaults).
+  app.use(securityHeaders());
 
   // Stripe webhook signature verification requires the exact raw request body.
   // Install raw-body middleware for the webhook path BEFORE the global JSON
@@ -26,8 +45,11 @@ async function bootstrap() {
     }),
   );
 
-  // CORS
-  app.enableCors();
+  // Map unhandled (non-HTTP) errors to a generic 500 — no stack/SQL leakage.
+  app.useGlobalFilters(new AllExceptionsFilter());
+
+  // CORS — explicit allowlist from CORS_ORIGINS (no longer wide-open).
+  app.enableCors({ origin: corsOrigins(), credentials: true });
 
   // OpenAPI / Swagger
   const config = new DocumentBuilder()

--- a/apps/api/src/modules/admin/admin.controller.ts
+++ b/apps/api/src/modules/admin/admin.controller.ts
@@ -16,6 +16,7 @@ import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
 import { RequirePermissions } from '../auth/permissions.decorator';
 import { CurrentUser, type AuthUser } from '../auth/current-user.decorator';
+import { AuditActorCtx, type AuditActor } from '../../common/audit/audit-actor';
 import { PermissionsService } from '../auth/permissions.service';
 import { PERMISSIONS, ALL_PERMISSIONS } from '../auth/permissions.catalog';
 import { UsersService } from './users.service';
@@ -82,8 +83,8 @@ export class AdminController {
   @RequirePermissions('admin.users.manage')
   @ApiOperation({ summary: 'Create a local user' })
   @ApiResponse({ status: 201, description: 'User created' })
-  createUser(@Body() dto: CreateUserDto) {
-    return this.usersService.create(dto);
+  createUser(@Body() dto: CreateUserDto, @AuditActorCtx() actor: AuditActor) {
+    return this.usersService.create(dto, actor);
   }
 
   @Patch('users/:id')
@@ -93,8 +94,9 @@ export class AdminController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateUserDto,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.usersService.update(id, propertyId, dto);
+    return this.usersService.update(id, propertyId, dto, actor);
   }
 
   @Delete('users/:id')
@@ -104,8 +106,9 @@ export class AdminController {
   disableUser(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.usersService.disable(id, propertyId);
+    return this.usersService.disable(id, propertyId, actor);
   }
 
   @Put('users/:id/roles')
@@ -115,8 +118,9 @@ export class AdminController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: AssignRolesDto,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.usersService.assignRoles(id, propertyId, dto.roleIds);
+    return this.usersService.assignRoles(id, propertyId, dto.roleIds, actor);
   }
 
   @Get('users/:id/effective-permissions')
@@ -141,8 +145,8 @@ export class AdminController {
   @Post('roles')
   @RequirePermissions('admin.roles.manage')
   @ApiOperation({ summary: 'Create a custom role' })
-  createRole(@Body() dto: CreateRoleDto) {
-    return this.rolesService.create(dto);
+  createRole(@Body() dto: CreateRoleDto, @AuditActorCtx() actor: AuditActor) {
+    return this.rolesService.create(dto, actor);
   }
 
   @Patch('roles/:id')
@@ -152,8 +156,9 @@ export class AdminController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateRoleDto,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.rolesService.update(id, propertyId, dto);
+    return this.rolesService.update(id, propertyId, dto, actor);
   }
 
   @Delete('roles/:id')
@@ -163,8 +168,9 @@ export class AdminController {
   deleteRole(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.rolesService.delete(id, propertyId);
+    return this.rolesService.delete(id, propertyId, actor);
   }
 
   @Put('roles/:id/permissions')
@@ -174,8 +180,9 @@ export class AdminController {
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: SetRolePermissionsDto,
+    @AuditActorCtx() actor: AuditActor,
   ) {
-    return this.rolesService.setPermissions(id, propertyId, dto.permissionKeys);
+    return this.rolesService.setPermissions(id, propertyId, dto.permissionKeys, actor);
   }
 }
 

--- a/apps/api/src/modules/admin/roles.service.ts
+++ b/apps/api/src/modules/admin/roles.service.ts
@@ -9,6 +9,7 @@ import { and, eq, or, isNull, inArray } from 'drizzle-orm';
 import { roles, rolePermissions, userRoles, auditLogs } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { isPermissionKey } from '../auth/permissions.catalog';
+import { actorFields, type AuditActor } from '../../common/audit/audit-actor';
 import { CreateRoleDto } from './dto/create-role.dto';
 import { UpdateRoleDto } from './dto/update-role.dto';
 
@@ -64,7 +65,7 @@ export class RolesService {
     return row;
   }
 
-  async create(dto: CreateRoleDto) {
+  async create(dto: CreateRoleDto, actor?: AuditActor) {
     const [dupe] = await this.db
       .select({ id: roles.id })
       .from(roles)
@@ -89,11 +90,12 @@ export class RolesService {
       entityType: 'role',
       entityId: role.id,
       description: 'role.created',
+      ...actorFields(actor),
     });
     return { ...role, permissions: [] };
   }
 
-  async update(id: string, propertyId: string, dto: UpdateRoleDto) {
+  async update(id: string, propertyId: string, dto: UpdateRoleDto, actor?: AuditActor) {
     await this.getCustomRole(id, propertyId);
     const [role] = await this.db
       .update(roles)
@@ -106,11 +108,12 @@ export class RolesService {
       entityType: 'role',
       entityId: id,
       description: 'role.updated',
+      ...actorFields(actor),
     });
     return role;
   }
 
-  async delete(id: string, propertyId: string) {
+  async delete(id: string, propertyId: string, actor?: AuditActor) {
     await this.getCustomRole(id, propertyId);
     const [assigned] = await this.db
       .select({ id: userRoles.id })
@@ -131,12 +134,13 @@ export class RolesService {
         entityType: 'role',
         entityId: id,
         description: 'role.deleted',
+        ...actorFields(actor),
       });
     });
     return { deleted: true };
   }
 
-  async setPermissions(id: string, propertyId: string, permissionKeys: string[]) {
+  async setPermissions(id: string, propertyId: string, permissionKeys: string[], actor?: AuditActor) {
     await this.getCustomRole(id, propertyId);
     const invalid = permissionKeys.filter((k) => !isPermissionKey(k));
     if (invalid.length) {
@@ -158,6 +162,7 @@ export class RolesService {
         entityType: 'role',
         entityId: id,
         description: 'role.permissions_updated',
+        ...actorFields(actor),
       });
     });
     return { roleId: id, permissions: unique };

--- a/apps/api/src/modules/admin/users.service.ts
+++ b/apps/api/src/modules/admin/users.service.ts
@@ -9,6 +9,7 @@ import { and, eq, or, isNull, inArray } from 'drizzle-orm';
 import { users, roles, userRoles, auditLogs } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { PermissionsService } from '../auth/permissions.service';
+import { actorFields, type AuditActor } from '../../common/audit/audit-actor';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 
@@ -75,7 +76,7 @@ export class UsersService {
     return row;
   }
 
-  async create(dto: CreateUserDto) {
+  async create(dto: CreateUserDto, actor?: AuditActor) {
     const [dupe] = await this.db
       .select({ id: users.id })
       .from(users)
@@ -114,43 +115,52 @@ export class UsersService {
         entityType: 'user',
         entityId: user.id,
         description: 'user.created',
+        ...actorFields(actor),
       });
       return user;
     });
   }
 
-  async update(id: string, propertyId: string, dto: UpdateUserDto) {
+  async update(id: string, propertyId: string, dto: UpdateUserDto, actor?: AuditActor) {
     await this.getOwned(id, propertyId);
-    const [user] = await this.db
-      .update(users)
-      .set({ ...dto, updatedAt: new Date() })
-      .where(and(eq(users.id, id), eq(users.propertyId, propertyId)))
-      .returning();
-    await this.db.insert(auditLogs).values({
-      propertyId,
-      action: 'update',
-      entityType: 'user',
-      entityId: id,
-      description: 'user.updated',
+    // Transactional: the mutation and its audit row commit together, so an audit
+    // failure can't leave an unrecorded change (GDPR/PCI accountability).
+    return this.db.transaction(async (tx: any) => {
+      const [user] = await tx
+        .update(users)
+        .set({ ...dto, updatedAt: new Date() })
+        .where(and(eq(users.id, id), eq(users.propertyId, propertyId)))
+        .returning();
+      await tx.insert(auditLogs).values({
+        propertyId,
+        action: 'update',
+        entityType: 'user',
+        entityId: id,
+        description: 'user.updated',
+        ...actorFields(actor),
+      });
+      return user;
     });
-    return user;
   }
 
   /** DELETE = soft-disable (preserves history). */
-  async disable(id: string, propertyId: string) {
+  async disable(id: string, propertyId: string, actor?: AuditActor) {
     await this.getOwned(id, propertyId);
-    await this.db
-      .update(users)
-      .set({ status: 'disabled', updatedAt: new Date() })
-      .where(and(eq(users.id, id), eq(users.propertyId, propertyId)));
-    await this.db.insert(auditLogs).values({
-      propertyId,
-      action: 'update',
-      entityType: 'user',
-      entityId: id,
-      description: 'user.disabled',
+    return this.db.transaction(async (tx: any) => {
+      await tx
+        .update(users)
+        .set({ status: 'disabled', updatedAt: new Date() })
+        .where(and(eq(users.id, id), eq(users.propertyId, propertyId)));
+      await tx.insert(auditLogs).values({
+        propertyId,
+        action: 'update',
+        entityType: 'user',
+        entityId: id,
+        description: 'user.disabled',
+        ...actorFields(actor),
+      });
+      return { disabled: true };
     });
-    return { disabled: true };
   }
 
   private async assertRolesExist(roleIds: string[], propertyId: string) {
@@ -163,7 +173,7 @@ export class UsersService {
     }
   }
 
-  async assignRoles(userId: string, propertyId: string, roleIds: string[]) {
+  async assignRoles(userId: string, propertyId: string, roleIds: string[], actor?: AuditActor) {
     await this.getOwned(userId, propertyId);
     await this.assertRolesExist(roleIds, propertyId);
     await this.db.transaction(async (tx: any) => {
@@ -181,6 +191,7 @@ export class UsersService {
         entityType: 'user',
         entityId: userId,
         description: 'user.roles_updated',
+        ...actorFields(actor),
       });
     });
     return this.effectivePermissions(userId, propertyId);

--- a/apps/api/src/modules/auth/api-key.guard.spec.ts
+++ b/apps/api/src/modules/auth/api-key.guard.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { UnauthorizedException, InternalServerErrorException, type ExecutionContext } from '@nestjs/common';
+import { ApiKeyGuard } from './api-key.guard';
+
+function ctx(apiKey?: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({ getRequest: () => ({ headers: apiKey ? { 'x-api-key': apiKey } : {} }) }),
+  } as unknown as ExecutionContext;
+}
+
+function guard(env: Record<string, string | undefined>) {
+  const cfg = { get: (k: string, d?: string) => env[k] ?? d } as any;
+  return new ApiKeyGuard(cfg);
+}
+
+describe('ApiKeyGuard', () => {
+  it('bypasses when AUTH_ENABLED=false', () => {
+    expect(guard({ AUTH_ENABLED: 'false' }).canActivate(ctx())).toBe(true);
+  });
+
+  it('fails closed when no key is configured', () => {
+    expect(() => guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: '' }).canActivate(ctx('x'))).toThrow(
+      InternalServerErrorException,
+    );
+  });
+
+  it('accepts a valid key (constant-time compare)', () => {
+    expect(guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: 'k1,k2' }).canActivate(ctx('k2'))).toBe(true);
+  });
+
+  it('rejects an invalid or missing key', () => {
+    const g = guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: 'k1' });
+    expect(() => g.canActivate(ctx('nope'))).toThrow(UnauthorizedException);
+    expect(() => g.canActivate(ctx())).toThrow(UnauthorizedException);
+  });
+});

--- a/apps/api/src/modules/auth/api-key.guard.ts
+++ b/apps/api/src/modules/auth/api-key.guard.ts
@@ -6,6 +6,15 @@ import {
   InternalServerErrorException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { timingSafeEqual } from 'node:crypto';
+
+/** Constant-time string compare (avoids leaking the key via response timing). */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
 
 /**
  * API-key guard for agent-facing endpoints (e.g. Connect API).
@@ -49,7 +58,7 @@ export class ApiKeyGuard implements CanActivate {
     const headerValue = req.headers['x-api-key'] ?? req.headers['X-API-Key' as any];
     const provided = Array.isArray(headerValue) ? headerValue[0] : headerValue;
 
-    if (!provided || !validKeys.includes(provided)) {
+    if (!provided || !validKeys.some((k) => safeEqual(k, provided))) {
       throw new UnauthorizedException('Invalid or missing API key');
     }
 

--- a/apps/api/src/modules/connect/dto/agent-event-subscription.dto.ts
+++ b/apps/api/src/modules/connect/dto/agent-event-subscription.dto.ts
@@ -3,9 +3,9 @@ import {
   IsUUID,
   IsOptional,
   IsArray,
-  IsUrl,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsSafeHttpUrl } from '../../../common/security/is-safe-url.validator';
 
 export class CreateSubscriptionDto {
   @ApiProperty()
@@ -22,7 +22,7 @@ export class CreateSubscriptionDto {
   subscriberName?: string;
 
   @ApiProperty({ example: 'https://otaip.example.com/webhooks/haip' })
-  @IsUrl()
+  @IsSafeHttpUrl({ requireHttps: true })
   callbackUrl!: string;
 
   @ApiProperty({ example: ['reservation.*', 'folio.charge_posted'] })

--- a/apps/api/src/modules/guest/guest.controller.ts
+++ b/apps/api/src/modules/guest/guest.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
+import { AuditActorCtx, type AuditActor } from '../../common/audit/audit-actor';
 import { GuestService } from './guest.service';
 import { CreateGuestDto } from './dto/create-guest.dto';
 import { UpdateGuestDto } from './dto/update-guest.dto';
@@ -82,7 +83,8 @@ export class GuestController {
   async deleteGuest(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @AuditActorCtx() actor: AuditActor,
   ): Promise<void> {
-    await this.guestService.delete(id, propertyId);
+    await this.guestService.delete(id, propertyId, actor);
   }
 }

--- a/apps/api/src/modules/guest/guest.service.ts
+++ b/apps/api/src/modules/guest/guest.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject, NotFoundException } from '@nestjs/common';
 import { eq, ilike, or, and, sql, inArray } from 'drizzle-orm';
 import { guests, reservations, auditLogs } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
+import { actorFields, type AuditActor } from '../../common/audit/audit-actor';
 import { CreateGuestDto } from './dto/create-guest.dto';
 import { UpdateGuestDto } from './dto/update-guest.dto';
 import { SearchGuestsDto } from './dto/search-guests.dto';
@@ -109,7 +110,7 @@ export class GuestService {
     return guest;
   }
 
-  async delete(id: string, propertyId: string) {
+  async delete(id: string, propertyId: string, actor?: AuditActor) {
     // Bug 4: GDPR right-to-erasure. Hard DELETE fails on FK constraints from
     // bookings.guest_id / reservations.guest_id (operational/legal retention
     // requires we keep stay history). Instead, anonymize PII in place and
@@ -162,6 +163,7 @@ export class GuestService {
       entityType: 'guest',
       entityId: id,
       description: 'gdpr_erasure',
+      ...actorFields(actor),
     });
 
     return { deleted: true };

--- a/apps/api/src/modules/media/dto/create-media.dto.ts
+++ b/apps/api/src/modules/media/dto/create-media.dto.ts
@@ -6,11 +6,11 @@ import {
   IsEnum,
   IsInt,
   IsBoolean,
-  IsUrl,
   MaxLength,
   Min,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsSafeHttpUrl } from '../../../common/security/is-safe-url.validator';
 
 export const MEDIA_OWNER_TYPES = ['property', 'room_type', 'room'] as const;
 export const MEDIA_CATEGORIES = [
@@ -36,7 +36,7 @@ export class CreateMediaDto {
   ownerId!: string;
 
   @ApiProperty({ example: 'https://images.example.com/hero.jpg' })
-  @IsUrl({ require_tld: false })
+  @IsSafeHttpUrl()
   @MaxLength(2048)
   url!: string;
 

--- a/apps/api/src/modules/media/media.controller.ts
+++ b/apps/api/src/modules/media/media.controller.ts
@@ -12,6 +12,7 @@ import {
   ParseUUIDPipe,
   UploadedFile,
   UseInterceptors,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -68,7 +69,18 @@ export class MediaController {
 
   @Post('upload')
   @Roles('admin')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(
+    FileInterceptor('file', {
+      // Cap upload size (DoS: the buffer is held in memory) and reject obvious
+      // non-images early. Content is additionally magic-byte checked in the
+      // service so a forged Content-Type can't smuggle HTML/SVG.
+      limits: { fileSize: 15 * 1024 * 1024, files: 1 },
+      fileFilter: (_req, file, cb) => {
+        const ok = ['image/jpeg', 'image/png', 'image/webp'].includes(file.mimetype);
+        cb(ok ? null : new BadRequestException('Only JPEG, PNG, or WebP images are allowed'), ok);
+      },
+    }),
+  )
   @ApiConsumes('multipart/form-data')
   @ApiOperation({ summary: 'Upload an image to object storage and attach it' })
   @ApiResponse({ status: 201, description: 'Media created from upload' })

--- a/apps/api/src/modules/media/media.service.ts
+++ b/apps/api/src/modules/media/media.service.ts
@@ -304,10 +304,16 @@ export class MediaService {
     if (!file) {
       throw new BadRequestException('No file uploaded (field "file")');
     }
+    // Verify the bytes actually are a JPEG/PNG/WebP — a forged Content-Type must
+    // not let an attacker store HTML/SVG that later executes from the CDN origin.
+    const detected = sniffImageType(file.buffer);
+    if (!detected) {
+      throw new BadRequestException('File is not a valid JPEG, PNG, or WebP image');
+    }
     await this.assertOwnerAtProperty(dto.ownerType, dto.ownerId, dto.propertyId);
     const { storageKey, url } = await this.storage.put(file.buffer, {
       propertyId: dto.propertyId,
-      contentType: file.mimetype,
+      contentType: detected, // store the sniffed type, not the client-supplied one
       filename: file.originalname,
     });
     const row = await this.insertMedia({
@@ -319,11 +325,37 @@ export class MediaService {
       category: dto.category,
       caption: dto.caption,
       altText: dto.altText,
-      contentType: file.mimetype,
+      contentType: detected,
       fileSize: file.size,
       isPrimary: false,
     });
     await this.emitContentChanged(dto.ownerType, dto.propertyId);
     return row;
   }
+}
+
+/**
+ * Identify an image by magic bytes (not the client-declared MIME). Returns the
+ * canonical content type for JPEG/PNG/WebP, or null if the bytes don't match —
+ * dependency-free so no risk of a forged Content-Type smuggling HTML/SVG.
+ */
+function sniffImageType(buf: Buffer): 'image/jpeg' | 'image/png' | 'image/webp' | null {
+  if (!buf || buf.length < 12) return null;
+  // JPEG: FF D8 FF
+  if (buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'image/jpeg';
+  // PNG: 89 50 4E 47 0D 0A 1A 0A
+  if (
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+  // WebP: "RIFF" .... "WEBP"
+  if (
+    buf.toString('ascii', 0, 4) === 'RIFF' &&
+    buf.toString('ascii', 8, 12) === 'WEBP'
+  ) {
+    return 'image/webp';
+  }
+  return null;
 }

--- a/apps/api/src/modules/payment/dto/authorize-payment.dto.ts
+++ b/apps/api/src/modules/payment/dto/authorize-payment.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsUUID,
   IsDateString,
+  IsNumberString,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -20,7 +21,7 @@ export class AuthorizePaymentDto {
   propertyId!: string;
 
   @ApiProperty({ example: '500.00' })
-  @IsString()
+  @IsNumberString({}, { message: 'amount must be a numeric decimal string' })
   @IsNotEmpty()
   amount!: string;
 

--- a/apps/api/src/modules/payment/dto/create-payment.dto.ts
+++ b/apps/api/src/modules/payment/dto/create-payment.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsUUID,
   IsEnum,
+  IsNumberString,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
@@ -24,7 +25,7 @@ export class CreatePaymentDto {
   method!: string;
 
   @ApiProperty({ example: '150.00' })
-  @IsString()
+  @IsNumberString({}, { message: 'amount must be a numeric decimal string' })
   @IsNotEmpty()
   amount!: string;
 

--- a/apps/api/src/modules/payment/stripe-webhook.controller.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.controller.ts
@@ -10,7 +10,7 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
-import { eq } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
 import { payments } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { WebhookService } from '../webhook/webhook.service';
@@ -138,7 +138,7 @@ export class StripeWebhookController {
     await this.db
       .update(payments)
       .set({ status: 'captured', processedAt: new Date(), updatedAt: new Date() })
-      .where(eq(payments.id, payment.id));
+      .where(and(eq(payments.id, payment.id), eq(payments.propertyId, payment.propertyId)));
 
     // Recalculate folio balance after payment state change
     await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
@@ -165,7 +165,7 @@ export class StripeWebhookController {
     await this.db
       .update(payments)
       .set({ status: 'failed', notes: errorMessage, updatedAt: new Date() })
-      .where(eq(payments.id, payment.id));
+      .where(and(eq(payments.id, payment.id), eq(payments.propertyId, payment.propertyId)));
 
     // Recalculate folio balance after payment state change
     await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
@@ -190,7 +190,7 @@ export class StripeWebhookController {
     await this.db
       .update(payments)
       .set({ status: 'voided', updatedAt: new Date() })
-      .where(eq(payments.id, payment.id));
+      .where(and(eq(payments.id, payment.id), eq(payments.propertyId, payment.propertyId)));
 
     // Recalculate folio balance after payment state change
     await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
@@ -223,7 +223,7 @@ export class StripeWebhookController {
     await this.db
       .update(payments)
       .set({ status, updatedAt: new Date() })
-      .where(eq(payments.id, payment.id));
+      .where(and(eq(payments.id, payment.id), eq(payments.propertyId, payment.propertyId)));
 
     // Recalculate folio balance after refund
     await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);

--- a/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createHmac } from 'crypto';
 import { WebhookDeliveryService } from './webhook-delivery.service';
 
+// The SSRF URL guard does real DNS resolution (covered by its own spec); stub it
+// here so these tests exercise delivery logic without network.
+vi.mock('../../common/security/url-guard', () => ({
+  assertSafeOutboundUrl: vi.fn().mockResolvedValue(undefined),
+}));
+
 /**
  * Stateful mock DB that stores webhook_deliveries in memory so the service's
  * read-modify-write cycle actually works. Subscriptions are handed back from

--- a/apps/api/src/modules/webhook/webhook-delivery.service.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.ts
@@ -9,6 +9,7 @@ import { createHmac } from 'crypto';
 import { eq, and, lte, or, isNull } from 'drizzle-orm';
 import { webhookDeliveries, agentWebhookSubscriptions } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
+import { assertSafeOutboundUrl } from '../../common/security/url-guard';
 
 // Exponential backoff schedule in milliseconds: 30s, 2m, 10m, 1h, 6h.
 const RETRY_SCHEDULE_MS = [
@@ -130,6 +131,10 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
     let ok = false;
 
     try {
+      // SSRF guard: re-validate the callback URL (incl. DNS resolution) right
+      // before the request so a stored or rebinding URL can't reach internal
+      // addresses (metadata, localhost, RFC1918).
+      await assertSafeOutboundUrl(subscription.callbackUrl, { requireHttps: true });
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
       try {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,10 @@ services:
       # STRIPE_SECRET_KEY:
       # STRIPE_WEBHOOK_SECRET:
       AUTH_ENABLED: 'false'
+      # Local demo intentionally runs auth-off + mock payments. The prod boot
+      # check only fires when NODE_ENV=production; this opt-in keeps the lean
+      # demo green even if someone flips NODE_ENV.
+      HAIP_ALLOW_INSECURE: 'true'
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: haip
       KEYCLOAK_CLIENT_ID: haip-api

--- a/render.yaml
+++ b/render.yaml
@@ -33,6 +33,12 @@ services:
         value: 'false'
       - key: STRIPE_MODE
         value: mock
+      # This is the intentional public demo: it runs with auth off and mock
+      # payments. The API refuses to boot in production with that config UNLESS
+      # this opt-in is set — which prevents an accidental insecure real deployment
+      # while keeping the demo green.
+      - key: HAIP_ALLOW_INSECURE
+        value: 'true'
       - key: DATABASE_URL
         fromDatabase:
           name: haip-postgres


### PR DESCRIPTION
Second of the two security-remediation PRs. **PR2 = deployment & input hardening.** Independent of PR1 (#115); both branch off `main`.

**Dependency-free:** network installs aren't available in this environment, so the three "library" items are implemented without deps — manual security headers (helmet-equivalent), an in-memory rate-limit guard (throttler-equivalent), and inline image **magic-byte** checks (file-type-equivalent). Same protection, guaranteed to build.

## What's in here
- **Fail closed in production** — refuses to boot when `NODE_ENV=production` and `AUTH_ENABLED=false` or `STRIPE_MODE=mock`, unless `HAIP_ALLOW_INSECURE=true`. Closes the #1 real-world breach (accidental auth-off prod). Wired the opt-in into `render.yaml` + `docker-compose.yml` so the intentional demo still boots. (Pure, unit-tested `assert-secure-config.ts`.)
- **CORS allowlist** from `CORS_ORIGINS` (was wide-open `enableCors()`).
- **Security headers** — nosniff, frame DENY, no-referrer, HSTS in prod; `X-Powered-By` removed.
- **Global exception filter** — non-`HttpException` → generic 500, full detail logged server-side only (no stack/SQL leak). Payment `amount` DTOs validated as numeric strings (400 not 500).
- **Rate limiting** — in-memory per-IP guard (interim brute-force mitigation pending C2).
- **Media upload hardening** — 15 MB cap + image-only `fileFilter` + **magic-byte sniff**; the stored content-type is the *sniffed* type, so a forged `Content-Type` can't smuggle HTML/SVG (stored-XSS).
- **SSRF guard** (`url-guard.ts`) — webhook `callbackUrl` validated at create (`IsSafeHttpUrl`) and **re-checked with DNS resolution before delivery**; rejects loopback / RFC1918 / link-local / metadata. `create-media` url restricted to http(s).
- **Constant-time API key compare** (`timingSafeEqual`).
- **Audit actor threading** — who + IP recorded on admin user/role mutations and guest GDPR erasure (null in the auth-off demo); `users.update`/`disable` made transactional. **Stripe webhook writes now propertyId-scoped.**

## Verification
- API suite **810** green (+ new specs: url-guard, rate-limit, api-key timing, fail-closed boot, exception filter).
- `typecheck` + `lint` clean (0 errors).
- Demo stays green: guard fixes no-op when `AUTH_ENABLED=false`; the prod boot check honors `HAIP_ALLOW_INSECURE` (set in render/compose).

## Noted fast-follow
Media-mutation audit-actor threading (lowest-sensitivity surface) left for a follow-up to keep this PR bounded. Design items **C1** (inbound webhook auth) and **C2** (Connect confirmation-number credential) remain separate, as planned.

https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt)_