### PR TITLE
fix(auth): tenant-bind Connect API + authenticate OTA inbound (CRITICAL #2, #3)

### DIFF
--- a/apps/api/src/modules/auth/api-key.guard.spec.ts
+++ b/apps/api/src/modules/auth/api-key.guard.spec.ts
@@ -54,8 +54,11 @@ describe('ApiKeyGuard', () => {
     expect(req.connect).toEqual({ scope: 'property', propertyId: 'prop-A', credentialId: 'cred-1' });
   });
 
-  it('rejects a revoked credential and falls through (then 401 if no env match)', async () => {
-    const raw = 'rk_revoked';
+  it('TERMINAL-rejects a revoked credential — env fallback must NOT reauthorize as platform', async () => {
+    // The footgun Codex flagged: a revoked per-property key whose RAW value also
+    // happens to equal CONNECT_API_KEY used to silently re-auth as platform. It
+    // must now fail hard regardless of env.
+    const raw = 'rk_revoked_and_also_in_env';
     db.select.mockReturnValue({
       from: () => ({
         where: () =>
@@ -70,8 +73,36 @@ describe('ApiKeyGuard', () => {
           ]),
       }),
     });
+    config.get = vi.fn().mockImplementation((k: string, def?: string) =>
+      k === 'AUTH_ENABLED' ? 'true' : k === 'CONNECT_API_KEY' ? raw : def,
+    );
     const req: any = { headers: { 'x-api-key': raw } };
     await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(req.connect).toBeUndefined();
+  });
+
+  it('TERMINAL-rejects an inactive (isActive=false) credential — env fallback must NOT reauthorize', async () => {
+    const raw = 'rk_inactive';
+    db.select.mockReturnValue({
+      from: () => ({
+        where: () =>
+          Promise.resolve([
+            {
+              id: 'cred-i',
+              propertyId: 'prop-A',
+              keyHash: hashConnectKey(raw),
+              isActive: false,
+              revokedAt: null,
+            },
+          ]),
+      }),
+    });
+    config.get = vi.fn().mockImplementation((k: string, def?: string) =>
+      k === 'AUTH_ENABLED' ? 'true' : k === 'CONNECT_API_KEY' ? raw : def,
+    );
+    const req: any = { headers: { 'x-api-key': raw } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
+    expect(req.connect).toBeUndefined();
   });
 
   it('falls back to CONNECT_API_KEY (platform) when no DB row matches', async () => {

--- a/apps/api/src/modules/auth/api-key.guard.spec.ts
+++ b/apps/api/src/modules/auth/api-key.guard.spec.ts
@@ -1,36 +1,101 @@
-import { describe, it, expect } from 'vitest';
-import { UnauthorizedException, InternalServerErrorException, type ExecutionContext } from '@nestjs/common';
-import { ApiKeyGuard } from './api-key.guard';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UnauthorizedException } from '@nestjs/common';
+import { ApiKeyGuard, hashConnectKey } from './api-key.guard';
 
-function ctx(apiKey?: string): ExecutionContext {
+function ctx(req: any) {
   return {
-    switchToHttp: () => ({ getRequest: () => ({ headers: apiKey ? { 'x-api-key': apiKey } : {} }) }),
-  } as unknown as ExecutionContext;
-}
-
-function guard(env: Record<string, string | undefined>) {
-  const cfg = { get: (k: string, d?: string) => env[k] ?? d } as any;
-  return new ApiKeyGuard(cfg);
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as any;
 }
 
 describe('ApiKeyGuard', () => {
-  it('bypasses when AUTH_ENABLED=false', () => {
-    expect(guard({ AUTH_ENABLED: 'false' }).canActivate(ctx())).toBe(true);
+  let config: any;
+  let db: any;
+  let guard: ApiKeyGuard;
+
+  beforeEach(() => {
+    config = { get: vi.fn().mockReturnValue('true') }; // AUTH_ENABLED=true
+    db = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+    guard = new ApiKeyGuard(config, db);
   });
 
-  it('fails closed when no key is configured', () => {
-    expect(() => guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: '' }).canActivate(ctx('x'))).toThrow(
-      InternalServerErrorException,
+  it('AUTH_ENABLED=false → no-op allow, attaches platform principal', async () => {
+    config.get.mockReturnValue('false');
+    const req: any = { headers: {} };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+    expect(req.connect).toEqual({ scope: 'platform' });
+  });
+
+  it('rejects when no x-api-key header is provided', async () => {
+    const req = { headers: {} };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('attaches scope=property when key matches a connect_credentials row', async () => {
+    const raw = 'rk_secret_AAA';
+    const cred = {
+      id: 'cred-1',
+      propertyId: 'prop-A',
+      keyHash: hashConnectKey(raw),
+      isActive: true,
+      revokedAt: null,
+    };
+    db.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([cred]) }),
+    });
+    const req: any = { headers: { 'x-api-key': raw } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+    expect(req.connect).toEqual({ scope: 'property', propertyId: 'prop-A', credentialId: 'cred-1' });
+  });
+
+  it('rejects a revoked credential and falls through (then 401 if no env match)', async () => {
+    const raw = 'rk_revoked';
+    db.select.mockReturnValue({
+      from: () => ({
+        where: () =>
+          Promise.resolve([
+            {
+              id: 'cred-r',
+              propertyId: 'prop-A',
+              keyHash: hashConnectKey(raw),
+              isActive: true,
+              revokedAt: new Date(),
+            },
+          ]),
+      }),
+    });
+    const req: any = { headers: { 'x-api-key': raw } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('falls back to CONNECT_API_KEY (platform) when no DB row matches', async () => {
+    config.get = vi.fn().mockImplementation((k: string, def?: string) =>
+      k === 'AUTH_ENABLED' ? 'true' : k === 'CONNECT_API_KEY' ? 'platform-key-xyz' : def,
     );
+    const req: any = { headers: { 'x-api-key': 'platform-key-xyz' } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+    expect(req.connect).toEqual({ scope: 'platform' });
   });
 
-  it('accepts a valid key (constant-time compare)', () => {
-    expect(guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: 'k1,k2' }).canActivate(ctx('k2'))).toBe(true);
+  it('rejects an unknown key (no DB row, no env match)', async () => {
+    config.get = vi.fn().mockImplementation((k: string, def?: string) =>
+      k === 'AUTH_ENABLED' ? 'true' : k === 'CONNECT_API_KEY' ? 'platform-key-xyz' : def,
+    );
+    const req: any = { headers: { 'x-api-key': 'totally-wrong' } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
-  it('rejects an invalid or missing key', () => {
-    const g = guard({ AUTH_ENABLED: 'true', CONNECT_API_KEY: 'k1' });
-    expect(() => g.canActivate(ctx('nope'))).toThrow(UnauthorizedException);
-    expect(() => g.canActivate(ctx())).toThrow(UnauthorizedException);
+  it('rejects when DB has no match and CONNECT_API_KEY env is unset (fail closed)', async () => {
+    config.get = vi.fn().mockImplementation((k: string, def?: string) =>
+      k === 'AUTH_ENABLED' ? 'true' : k === 'CONNECT_API_KEY' ? undefined : def,
+    );
+    const req: any = { headers: { 'x-api-key': 'anything' } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
   });
 });

--- a/apps/api/src/modules/auth/api-key.guard.ts
+++ b/apps/api/src/modules/auth/api-key.guard.ts
@@ -1,12 +1,16 @@
 import {
   Injectable,
+  Inject,
   CanActivate,
   ExecutionContext,
   UnauthorizedException,
-  InternalServerErrorException,
+  Optional,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { eq, and } from 'drizzle-orm';
+import { connectCredentials } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
 
 /** Constant-time string compare (avoids leaking the key via response timing). */
 function safeEqual(a: string, b: string): boolean {
@@ -16,52 +20,103 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb);
 }
 
+/** sha256(rawKey) → 64-char hex digest (matches `connect_credentials.key_hash`). */
+export function hashConnectKey(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
 /**
- * API-key guard for agent-facing endpoints (e.g. Connect API).
+ * Authenticated principal attached to the request by the Connect API key guard.
  *
- * Reads `x-api-key` from the request headers and validates it against the
- * comma-separated list in `CONNECT_API_KEY`. Pairs with `@Public()` on the
- * controller so JWT is skipped but the API key is still required.
+ * - `scope='property'`: a tenant-bound credential from `connect_credentials`. The
+ *   caller may ONLY act on `propertyId`; `ConnectScopeGuard` enforces that.
+ * - `scope='platform'`: the legacy `CONNECT_API_KEY` env value (trusted server-side
+ *   key, e.g. the demo gateway). Cross-tenant by design — bypasses scope checks.
+ */
+export interface ConnectPrincipal {
+  scope: 'property' | 'platform';
+  propertyId?: string;
+  credentialId?: string;
+}
+
+/**
+ * API-key guard for agent-facing endpoints (`/api/v1/connect/*`).
  *
- * Fail-closed semantics:
- *  - When `AUTH_ENABLED !== 'false'` (prod/default) and `CONNECT_API_KEY` is
- *    missing or empty, requests are rejected with 500 rather than silently
- *    letting everyone in.
- *  - When `AUTH_ENABLED === 'false'` (dev/test), the guard is a no-op so
- *    existing dev workflows and tests are not broken.
+ * Resolves the `x-api-key` header to a `ConnectPrincipal` and attaches it to
+ * `req.connect`. Lookup order:
+ *   1. sha256(key) matches a `connect_credentials.key_hash` (active, not revoked)
+ *      → `{ scope:'property', propertyId, credentialId }`.
+ *   2. Constant-time match against the comma-separated env `CONNECT_API_KEY`
+ *      → `{ scope:'platform' }`.
+ *   3. Otherwise → 401.
+ *
+ * Fail-closed: when `AUTH_ENABLED!=='false'` and there is no DB row AND no env
+ * value, the request is rejected. `AUTH_ENABLED='false'` is a no-op (dev/demo).
+ *
+ * Closes CRITICAL #2 from the security audit (was: single global key, no tenant
+ * binding — any key holder could read/write any tenant's Connect data).
  */
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() @Inject(DRIZZLE) private readonly db?: any,
+  ) {}
 
-  canActivate(context: ExecutionContext): boolean {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const authEnabled = this.configService.get<string>('AUTH_ENABLED', 'true');
     if (authEnabled === 'false') {
+      // Sandbox/demo parity with the other guards — also attach a platform
+      // principal so downstream code that reads req.connect doesn't NPE.
+      const req = context.switchToHttp().getRequest<any>();
+      req.connect = { scope: 'platform' } as ConnectPrincipal;
       return true;
     }
 
+    const req = context.switchToHttp().getRequest<{ headers: Record<string, string | string[] | undefined>; connect?: ConnectPrincipal }>();
+    const headerValue = req.headers['x-api-key'] ?? req.headers['X-API-Key' as any];
+    const provided = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (!provided || typeof provided !== 'string') {
+      throw new UnauthorizedException('Invalid or missing API key');
+    }
+
+    // 1) Per-property credential lookup (sha256 hash compare via DB).
+    if (this.db) {
+      const keyHash = hashConnectKey(provided);
+      const rows = await this.db
+        .select()
+        .from(connectCredentials)
+        .where(
+          and(
+            eq(connectCredentials.keyHash, keyHash),
+            eq(connectCredentials.isActive, true),
+          ),
+        );
+      const cred = rows?.[0];
+      if (cred && !cred.revokedAt) {
+        req.connect = {
+          scope: 'property',
+          propertyId: cred.propertyId,
+          credentialId: cred.id,
+        };
+        return true;
+      }
+    }
+
+    // 2) Legacy platform key (cross-tenant, trusted server-side caller).
     const configured = this.configService.get<string>('CONNECT_API_KEY');
-    const validKeys = (configured ?? '')
+    const platformKeys = (configured ?? '')
       .split(',')
       .map((k) => k.trim())
       .filter((k) => k.length > 0);
 
-    if (validKeys.length === 0) {
-      // Fail closed — don't let requests through just because the operator
-      // forgot to set a key. Matches the AUTH_ENABLED secure-by-default pattern.
-      throw new InternalServerErrorException(
-        'CONNECT_API_KEY is not configured — refusing to accept Connect API requests',
-      );
+    if (platformKeys.some((k) => safeEqual(k, provided))) {
+      req.connect = { scope: 'platform' };
+      return true;
     }
 
-    const req = context.switchToHttp().getRequest<{ headers: Record<string, string | string[] | undefined> }>();
-    const headerValue = req.headers['x-api-key'] ?? req.headers['X-API-Key' as any];
-    const provided = Array.isArray(headerValue) ? headerValue[0] : headerValue;
-
-    if (!provided || !validKeys.some((k) => safeEqual(k, provided))) {
-      throw new UnauthorizedException('Invalid or missing API key');
-    }
-
-    return true;
+    // 3) No match anywhere → fail closed.
+    throw new UnauthorizedException('Invalid or missing API key');
   }
 }

--- a/apps/api/src/modules/auth/api-key.guard.ts
+++ b/apps/api/src/modules/auth/api-key.guard.ts
@@ -82,19 +82,24 @@ export class ApiKeyGuard implements CanActivate {
     }
 
     // 1) Per-property credential lookup (sha256 hash compare via DB).
+    //    NB: the lookup is NOT pre-filtered by `is_active=true` so we can
+    //    distinguish "no such credential" (fall through to env) from "credential
+    //    exists but revoked" (TERMINAL reject — must not be silently re-
+    //    authorized by a matching `CONNECT_API_KEY`). Closes a misconfiguration
+    //    footgun flagged in the security re-audit.
     if (this.db) {
       const keyHash = hashConnectKey(provided);
       const rows = await this.db
         .select()
         .from(connectCredentials)
-        .where(
-          and(
-            eq(connectCredentials.keyHash, keyHash),
-            eq(connectCredentials.isActive, true),
-          ),
-        );
+        .where(eq(connectCredentials.keyHash, keyHash));
       const cred = rows?.[0];
-      if (cred && !cred.revokedAt) {
+      if (cred) {
+        if (cred.isActive === false || cred.revokedAt) {
+          // The operator KNOWS this key — and revoked it. Don't let any other
+          // path (platform env) reauthorize it.
+          throw new UnauthorizedException('API key has been revoked');
+        }
         req.connect = {
           scope: 'property',
           propertyId: cred.propertyId,

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { PropertyScopeGuard } from './property-scope.guard';
 import { PermissionsGuard } from './permissions.guard';
 import { PermissionsService } from './permissions.service';
 import { ApiKeyGuard } from './api-key.guard';
+import { ConnectScopeGuard } from './connect-scope.guard';
 import { WsAuthService } from './ws-auth.service';
 
 /**
@@ -65,7 +66,8 @@ import { WsAuthService } from './ws-auth.service';
     // gateway itself honours AUTH_ENABLED=false as a dev bypass.
     WsAuthService,
     ApiKeyGuard,
+    ConnectScopeGuard,
   ],
-  exports: [WsAuthService, ApiKeyGuard, PermissionsService],
+  exports: [WsAuthService, ApiKeyGuard, ConnectScopeGuard, PermissionsService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/connect-scope.guard.spec.ts
+++ b/apps/api/src/modules/auth/connect-scope.guard.spec.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { ConnectScopeGuard } from './connect-scope.guard';
+
+function ctx(req: any) {
+  return {
+    switchToHttp: () => ({ getRequest: () => req }),
+  } as any;
+}
+
+const A = 'aaaaaaaa-0000-4000-a000-000000000001';
+const B = 'bbbbbbbb-0000-4000-b000-000000000002';
+
+describe('ConnectScopeGuard', () => {
+  let config: any;
+  let db: any;
+  let guard: ConnectScopeGuard;
+
+  beforeEach(() => {
+    config = { get: vi.fn().mockReturnValue('true') };
+    db = {
+      select: vi.fn().mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]),
+        }),
+      }),
+    };
+    guard = new ConnectScopeGuard(config, db);
+  });
+
+  it('AUTH_ENABLED=false → no-op allow', async () => {
+    config.get.mockReturnValue('false');
+    const req: any = { connect: { scope: 'property', propertyId: A }, query: { propertyId: B } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+
+  it('platform scope bypasses all checks', async () => {
+    const req: any = { connect: { scope: 'platform' }, query: { propertyId: B }, params: { id: B } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+
+  it('throws 401 when ApiKeyGuard did not attach a principal', async () => {
+    const req: any = { query: { propertyId: A } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  // The headline cross-tenant denial: a property-A credential MUST NOT touch B.
+  it('DENIES a tenant-A credential requesting tenant-B data via ?propertyId', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, query: { propertyId: B } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows a tenant-A credential requesting tenant-A data', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, query: { propertyId: A } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+
+  it('DENIES a tenant-A credential POSTing to tenant-B via body.propertyId', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, body: { propertyId: B } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('DENIES non-string propertyId (array bypass) outright', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, query: { propertyId: [A, B] } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('DENIES /connect/properties/:id when :id is a foreign tenant UUID', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, params: { id: B } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows /connect/properties/:id when :id is the scoped tenant', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A }, params: { id: A } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+
+  it('DENIES a confirmationNumber that resolves to a foreign tenant', async () => {
+    db.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([{ propertyId: B }]) }),
+    });
+    const req: any = { connect: { scope: 'property', propertyId: A }, params: { confirmationNumber: 'HAIP-XYZ' } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows a confirmationNumber that resolves to the scoped tenant', async () => {
+    db.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([{ propertyId: A }]) }),
+    });
+    const req: any = { connect: { scope: 'property', propertyId: A }, params: { confirmationNumber: 'HAIP-XYZ' } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+
+  it('DENIES an unknown confirmationNumber (no leak via existence)', async () => {
+    db.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([]) }),
+    });
+    const req: any = { connect: { scope: 'property', propertyId: A }, params: { confirmationNumber: 'NOPE' } };
+    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows routes that carry no scoping inputs at all (controller will use principal.propertyId)', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
+  });
+});

--- a/apps/api/src/modules/auth/connect-scope.guard.spec.ts
+++ b/apps/api/src/modules/auth/connect-scope.guard.spec.ts
@@ -65,13 +65,16 @@ describe('ConnectScopeGuard', () => {
     await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
   });
 
-  it('DENIES /connect/properties/:id when :id is a foreign tenant UUID', async () => {
-    const req: any = { connect: { scope: 'property', propertyId: A }, params: { id: B } };
-    await expect(guard.canActivate(ctx(req))).rejects.toBeInstanceOf(ForbiddenException);
-  });
-
-  it('allows /connect/properties/:id when :id is the scoped tenant', async () => {
-    const req: any = { connect: { scope: 'property', propertyId: A }, params: { id: A } };
+  // The guard intentionally does NOT enforce `params.id` (it would over-deny on
+  // /subscriptions/:id where `:id` is a subscription UUID, not a propertyId).
+  // The /connect/properties/:id check lives in the controller method instead.
+  it('does NOT block on params.id alone — subscription :id is allowed through', async () => {
+    const subscriptionId = 'cccccccc-0000-4000-c000-000000000003';
+    const req: any = {
+      connect: { scope: 'property', propertyId: A },
+      params: { id: subscriptionId },
+      query: { propertyId: A },
+    };
     await expect(guard.canActivate(ctx(req))).resolves.toBe(true);
   });
 

--- a/apps/api/src/modules/auth/connect-scope.guard.ts
+++ b/apps/api/src/modules/auth/connect-scope.guard.ts
@@ -5,7 +5,7 @@ import {
   ExecutionContext,
   ForbiddenException,
   UnauthorizedException,
-  Optional,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { eq } from 'drizzle-orm';
@@ -31,9 +31,13 @@ import type { ConnectPrincipal } from './api-key.guard';
  */
 @Injectable()
 export class ConnectScopeGuard implements CanActivate {
+  // `db` is required: the booking-by-confirmation ownership check would otherwise
+  // silently degrade to "allow" if DRIZZLE went missing — that would not be
+  // fail-closed. DatabaseModule is @Global() so this resolves in every prod wiring;
+  // tests inject an explicit mock.
   constructor(
     private readonly configService: ConfigService,
-    @Optional() @Inject(DRIZZLE) private readonly db?: any,
+    @Inject(DRIZZLE) private readonly db: any,
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
@@ -54,11 +58,13 @@ export class ConnectScopeGuard implements CanActivate {
       throw new ForbiddenException('Property-scoped credential is missing a propertyId');
     }
 
-    // params.id is used by /connect/properties/:id (where :id IS the propertyId).
-    const paramId = req.params?.id;
-    if (typeof paramId === 'string' && this.looksLikeUuid(paramId) && paramId !== scopedPropertyId) {
-      throw new ForbiddenException('Credential is not scoped to this property');
-    }
+    // NB: `params.id` is intentionally NOT enforced as a propertyId here. Several
+    // routes share a `:id` segment with completely different semantics — e.g.
+    // `/connect/subscriptions/:id` (subscription UUID) and `/connect/properties/:id`
+    // (property UUID). The `/connect/properties/:id` membership check is enforced
+    // INSIDE that controller method via `userCanAccessConnectProperty`, where the
+    // route semantics are known. Subscription routes already carry `?propertyId=`
+    // which IS enforced below.
 
     const qProp = req.query?.propertyId;
     if (typeof qProp === 'string' && qProp !== scopedPropertyId) {
@@ -77,27 +83,24 @@ export class ConnectScopeGuard implements CanActivate {
       throw new ForbiddenException('Invalid propertyId');
     }
 
-    // Booking-by-confirmation routes — resolve and verify.
+    // Booking-by-confirmation routes — resolve and verify ownership. Fails
+    // closed: if DRIZZLE is somehow not wired, refuse rather than allow.
     const confirmation = req.params?.confirmationNumber;
-    if (typeof confirmation === 'string' && confirmation.length > 0 && this.db) {
+    if (typeof confirmation === 'string' && confirmation.length > 0) {
+      if (!this.db) {
+        throw new InternalServerErrorException('Database not wired — refusing to validate booking ownership');
+      }
       const rows = await this.db
         .select({ propertyId: bookings.propertyId })
         .from(bookings)
         .where(eq(bookings.confirmationNumber, confirmation));
       const booking = rows?.[0];
-      if (!booking) {
-        // Don't leak existence; treat as forbidden.
-        throw new ForbiddenException('Credential is not scoped to this booking');
-      }
-      if (booking.propertyId !== scopedPropertyId) {
+      if (!booking || booking.propertyId !== scopedPropertyId) {
+        // Don't leak existence — same error in both cases.
         throw new ForbiddenException('Credential is not scoped to this booking');
       }
     }
 
     return true;
-  }
-
-  private looksLikeUuid(s: string): boolean {
-    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
   }
 }

--- a/apps/api/src/modules/auth/connect-scope.guard.ts
+++ b/apps/api/src/modules/auth/connect-scope.guard.ts
@@ -1,0 +1,103 @@
+import {
+  Injectable,
+  Inject,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+  Optional,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { eq } from 'drizzle-orm';
+import { bookings } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import type { ConnectPrincipal } from './api-key.guard';
+
+/**
+ * Enforces tenant isolation for the Connect API once `ApiKeyGuard` has attached
+ * a `ConnectPrincipal` to the request.
+ *
+ * Runs AFTER `ApiKeyGuard` on `ConnectController`. Decision logic, fail-closed:
+ *   1. `scope='platform'` (or `AUTH_ENABLED=false`) → allow (cross-tenant by design).
+ *   2. `scope='property'`:
+ *      - any `params.id` (the `/connect/properties/:id` route) must equal `propertyId`,
+ *      - any `query.propertyId` or `body.propertyId` must equal `propertyId`,
+ *      - any `params.confirmationNumber` must resolve to a booking with that `propertyId`.
+ *      Else → 403.
+ *
+ * Closes the residual cross-tenant hole in CRITICAL #2: previously a holder of any
+ * valid API key could pass any `propertyId` (or any `confirmationNumber`) and reach
+ * cross-tenant data. Now per-property credentials are pinned to their tenant.
+ */
+@Injectable()
+export class ConnectScopeGuard implements CanActivate {
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() @Inject(DRIZZLE) private readonly db?: any,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    if (this.configService.get<string>('AUTH_ENABLED', 'true') === 'false') {
+      return true;
+    }
+
+    const req = context.switchToHttp().getRequest<any>();
+    const principal: ConnectPrincipal | undefined = req.connect;
+    if (!principal) {
+      // ApiKeyGuard should have set this — defensive 401.
+      throw new UnauthorizedException('Connect principal not resolved');
+    }
+    if (principal.scope === 'platform') return true;
+
+    const scopedPropertyId = principal.propertyId;
+    if (!scopedPropertyId) {
+      throw new ForbiddenException('Property-scoped credential is missing a propertyId');
+    }
+
+    // params.id is used by /connect/properties/:id (where :id IS the propertyId).
+    const paramId = req.params?.id;
+    if (typeof paramId === 'string' && this.looksLikeUuid(paramId) && paramId !== scopedPropertyId) {
+      throw new ForbiddenException('Credential is not scoped to this property');
+    }
+
+    const qProp = req.query?.propertyId;
+    if (typeof qProp === 'string' && qProp !== scopedPropertyId) {
+      throw new ForbiddenException('Credential is not scoped to this property');
+    }
+    if (qProp !== undefined && typeof qProp !== 'string') {
+      // Array / non-scalar — anomalous, fail closed (matches PropertyAccessGuard behavior).
+      throw new ForbiddenException('Invalid propertyId');
+    }
+
+    const bProp = req.body?.propertyId;
+    if (typeof bProp === 'string' && bProp !== scopedPropertyId) {
+      throw new ForbiddenException('Credential is not scoped to this property');
+    }
+    if (bProp !== undefined && typeof bProp !== 'string') {
+      throw new ForbiddenException('Invalid propertyId');
+    }
+
+    // Booking-by-confirmation routes — resolve and verify.
+    const confirmation = req.params?.confirmationNumber;
+    if (typeof confirmation === 'string' && confirmation.length > 0 && this.db) {
+      const rows = await this.db
+        .select({ propertyId: bookings.propertyId })
+        .from(bookings)
+        .where(eq(bookings.confirmationNumber, confirmation));
+      const booking = rows?.[0];
+      if (!booking) {
+        // Don't leak existence; treat as forbidden.
+        throw new ForbiddenException('Credential is not scoped to this booking');
+      }
+      if (booking.propertyId !== scopedPropertyId) {
+        throw new ForbiddenException('Credential is not scoped to this booking');
+      }
+    }
+
+    return true;
+  }
+
+  private looksLikeUuid(s: string): boolean {
+    return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+  }
+}

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound-auth.controller.spec.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound-auth.controller.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BookingComInboundController } from './booking-com-inbound.controller';
+
+/**
+ * Controller-level Basic-Auth tests (Codex flagged that Expedia tests ran with
+ * AUTH_ENABLED=false and Booking.com had no controller-level auth tests at all).
+ * These exercise the actual `isAuthorizedFor` path with AUTH_ENABLED=true.
+ */
+
+function res() {
+  const r: any = { status: vi.fn(), set: vi.fn(), send: vi.fn() };
+  r.status.mockReturnValue(r);
+  r.set.mockReturnValue(r);
+  r.send.mockReturnValue(r);
+  return r;
+}
+
+function makeReq(authHeader: string | undefined, rawBody = '<x/>') {
+  const headers: Record<string, string> = {};
+  if (authHeader !== undefined) headers['authorization'] = authHeader;
+  return { headers, rawBody };
+}
+
+const connectionA = {
+  id: 'conn-A',
+  config: { hotelId: 'HOTEL_A', inboundAuth: { username: 'bc_user', password: 'bc_pass' } },
+};
+
+const goodAuth = `Basic ${Buffer.from('bc_user:bc_pass').toString('base64')}`;
+const wrongAuth = `Basic ${Buffer.from('bc_user:wrong').toString('base64')}`;
+
+describe('BookingComInboundController — Basic Auth (AUTH_ENABLED=true)', () => {
+  let inboundResv: any;
+  let channel: any;
+  let controller: BookingComInboundController;
+
+  beforeEach(() => {
+    inboundResv = { processInboundReservation: vi.fn().mockResolvedValue({ confirmationNumber: 'PMS1' }) };
+    channel = { findByAdapterType: vi.fn().mockResolvedValue([connectionA]) };
+    const config = { get: vi.fn().mockReturnValue('true') } as any;
+    controller = new BookingComInboundController(inboundResv as any, channel as any, config);
+  });
+
+  it('isAuthorizedFor returns true with the correct Basic-Auth header', () => {
+    expect((controller as any).isAuthorizedFor(connectionA, goodAuth)).toBe(true);
+  });
+
+  it('isAuthorizedFor returns false with a wrong password', () => {
+    expect((controller as any).isAuthorizedFor(connectionA, wrongAuth)).toBe(false);
+  });
+
+  it('isAuthorizedFor returns false when the Authorization header is missing', () => {
+    expect((controller as any).isAuthorizedFor(connectionA, undefined)).toBe(false);
+  });
+
+  it('isAuthorizedFor returns false when the connection has no stored inboundAuth (fail closed)', () => {
+    const noAuthConn = { id: 'c', config: { hotelId: 'HOTEL_A' } };
+    expect((controller as any).isAuthorizedFor(noAuthConn, goodAuth)).toBe(false);
+  });
+
+  it('isAuthorizedFor returns false when Basic auth was tampered with (sha256 of decoded mismatch)', () => {
+    const longPad = `Basic ${Buffer.from('bc_user:bc_pass_with_extra_bytes_to_test_length').toString('base64')}`;
+    expect((controller as any).isAuthorizedFor(connectionA, longPad)).toBe(false);
+  });
+
+  it('AUTH_ENABLED=false bypasses (sandbox/demo parity)', () => {
+    const offConfig = { get: vi.fn().mockReturnValue('false') } as any;
+    const offCtrl = new BookingComInboundController(inboundResv as any, channel as any, offConfig);
+    expect((offCtrl as any).isAuthorizedFor(connectionA, undefined)).toBe(true);
+  });
+});

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
@@ -103,6 +103,7 @@ export class BookingComInboundController {
       // hotel code.
       const authHeader = (req.headers?.['authorization'] ?? req.headers?.['Authorization']) as string | undefined;
       const results = [];
+      let authFailures = 0;
       for (const reservation of reservations) {
         const connection = await this.findBookingComConnection(reservation.channelHotelId);
         if (!connection) {
@@ -120,6 +121,7 @@ export class BookingComInboundController {
           this.logger.warn(
             `Booking.com reservation ${reservation.externalConfirmation}: Basic-Auth verification failed for connection ${connection.id} — rejected`,
           );
+          authFailures++;
           results.push({
             externalConfirmation: reservation.externalConfirmation,
             error: 'Unauthorized — caller credentials did not match channel connection',
@@ -161,6 +163,11 @@ export class BookingComInboundController {
         return res.status(200).send(responseXml);
       }
 
+      // If every failure was an auth failure, surface that cleanly as 401 so
+      // the caller (and ops dashboards) see the real cause, not a generic 500.
+      if (authFailures > 0 && authFailures === results.length) {
+        return this.sendErrorXml(res, '401', 'Unauthorized — caller credentials did not match channel connection');
+      }
       return this.sendErrorXml(res, '500', 'Failed to process all reservations');
     } catch (error: any) {
       this.logger.error(`Booking.com inbound error: ${error.message}`, error.stack);

--- a/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/booking-com/booking-com-inbound.controller.ts
@@ -5,6 +5,7 @@ import {
   Res,
   Logger,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Public } from '../../../auth/public.decorator';
 import { InboundReservationService } from '../../inbound-reservation.service';
@@ -14,6 +15,11 @@ import {
   mapOtaReservationToHaip,
   buildReservationConfirmation,
 } from './booking-com.mapper';
+import {
+  verifyBasicAuth,
+  getInboundAuth,
+  type InboundBasicAuth,
+} from '../inbound-auth.util';
 
 /**
  * Inbound webhook receiver for Booking.com push notifications.
@@ -21,10 +27,12 @@ import {
  *
  * @Public() — no JWT required (Booking.com can't authenticate to our IdP).
  *
- * NOTE: caller authentication for this webhook is design item C1 (per-OTA
- * signature / Basic-Auth / IP-allowlist) and is NOT yet implemented — the
- * endpoint is currently unauthenticated. Tenant ROUTING is enforced here by
- * matching the OTA hotel code to a channel connection's config.hotelId.
+ * Caller authentication: Basic Auth verified against the resolved channel
+ * connection's `config.inboundAuth = { username, password }` (per-tenant). The
+ * routing is by `hotelId` and the auth is verified against that same connection,
+ * so a request authenticated for tenant A cannot inject reservations for tenant B
+ * even if it knows tenant B's hotel code. Closes CRITICAL #3 from the audit.
+ * `AUTH_ENABLED=false` is a no-op so the existing demo stack still works.
  */
 @ApiTags('Channel Manager — Booking.com')
 @Controller('channels/inbound/booking-com')
@@ -35,7 +43,23 @@ export class BookingComInboundController {
   constructor(
     private readonly inboundReservationService: InboundReservationService,
     private readonly channelService: ChannelService,
+    private readonly configService: ConfigService,
   ) {}
+
+  private get authEnabled(): boolean {
+    return this.configService.get<string>('AUTH_ENABLED', 'true') !== 'false';
+  }
+
+  /**
+   * Verify that the incoming request presents Basic-Auth credentials matching
+   * the resolved connection's stored `inboundAuth`. Fails closed when auth is
+   * required but creds are missing/invalid.
+   */
+  private isAuthorizedFor(connection: any, authHeader: string | undefined): boolean {
+    if (!this.authEnabled) return true;
+    const stored = getInboundAuth<InboundBasicAuth>(connection.config);
+    return verifyBasicAuth(authHeader, stored);
+  }
 
   /**
    * Receive reservation push from Booking.com (OTA_HotelResNotif).
@@ -73,8 +97,11 @@ export class BookingComInboundController {
       }
 
       // Process each reservation, routing each to the connection that matches its
-      // OTA hotel code. (Auth of the caller itself is tracked as design item C1 —
-      // this endpoint is not yet authenticated; see the class doc.)
+      // OTA hotel code AND verifying the caller's Basic-Auth against THAT
+      // connection's stored credentials. A request authenticated for tenant A
+      // therefore can't inject reservations for tenant B even if it knows B's
+      // hotel code.
+      const authHeader = (req.headers?.['authorization'] ?? req.headers?.['Authorization']) as string | undefined;
       const results = [];
       for (const reservation of reservations) {
         const connection = await this.findBookingComConnection(reservation.channelHotelId);
@@ -85,6 +112,17 @@ export class BookingComInboundController {
           results.push({
             externalConfirmation: reservation.externalConfirmation,
             error: 'No matching channel connection for hotel code',
+            success: false,
+          });
+          continue;
+        }
+        if (!this.isAuthorizedFor(connection, authHeader)) {
+          this.logger.warn(
+            `Booking.com reservation ${reservation.externalConfirmation}: Basic-Auth verification failed for connection ${connection.id} — rejected`,
+          );
+          results.push({
+            externalConfirmation: reservation.externalConfirmation,
+            error: 'Unauthorized — caller credentials did not match channel connection',
             success: false,
           });
           continue;
@@ -173,6 +211,15 @@ export class BookingComInboundController {
         return this.sendErrorXml(res, '400', 'No matching channel connection for hotel code');
       }
 
+      // Authenticate the caller against the resolved connection's stored creds.
+      const cancelAuthHeader = (req.headers?.['authorization'] ?? req.headers?.['Authorization']) as string | undefined;
+      if (!this.isAuthorizedFor(connection, cancelAuthHeader)) {
+        this.logger.warn(
+          `Booking.com cancellation ${externalConfirmation}: Basic-Auth verification failed for connection ${connection.id}`,
+        );
+        return this.sendErrorXml(res, '401', 'Unauthorized');
+      }
+
       // Process as cancellation through the standard flow
       await this.inboundReservationService.processInboundReservation(
         connection.id,
@@ -234,7 +281,9 @@ export class BookingComInboundController {
       },
     });
     res.set('Content-Type', 'application/xml');
-    return res.status(code === '400' ? 400 : 500).send(xml);
+    // Honor the actual code (401/400/500…) — previously 401 was silently downgraded to 500.
+    const httpStatus = /^[0-9]+$/.test(code) ? parseInt(code, 10) : 500;
+    return res.status(httpStatus).send(xml);
   }
 
   private readRawBody(req: any): Promise<string> {

--- a/apps/api/src/modules/channel/adapters/expedia/expedia-inbound-auth.controller.spec.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia-inbound-auth.controller.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { ExpediaInboundController } from './expedia-inbound.controller';
+
+/**
+ * Controller-level HMAC tests with AUTH_ENABLED=true. Complements the routing
+ * tests in `expedia-inbound.controller.spec.ts` (which intentionally turn auth
+ * off to focus on routing) and the util-level tests in `inbound-auth.util.spec.ts`.
+ */
+
+const connectionA = {
+  id: 'conn-A',
+  config: { hotelId: 'HOTEL_A', inboundAuth: { secret: 'expedia-shared-A' } },
+};
+
+describe('ExpediaInboundController — HMAC (AUTH_ENABLED=true)', () => {
+  let inbound: any;
+  let channel: any;
+  let controller: ExpediaInboundController;
+
+  beforeEach(() => {
+    inbound = { processInboundReservation: vi.fn() };
+    channel = { findByAdapterType: vi.fn() };
+    const config = { get: vi.fn().mockReturnValue('true') } as any;
+    controller = new ExpediaInboundController(inbound as any, channel as any, config);
+  });
+
+  it('isAuthorizedFor accepts a correct HMAC over the raw body', () => {
+    const body = '<BookingNotification id="abc"/>';
+    const sig = createHmac('sha256', 'expedia-shared-A').update(body).digest('hex');
+    expect((controller as any).isAuthorizedFor(connectionA, sig, body)).toBe(true);
+  });
+
+  it("isAuthorizedFor accepts a 'sha256=' prefixed signature", () => {
+    const body = '<BookingNotification id="abc"/>';
+    const sig = `sha256=${createHmac('sha256', 'expedia-shared-A').update(body).digest('hex')}`;
+    expect((controller as any).isAuthorizedFor(connectionA, sig, body)).toBe(true);
+  });
+
+  it('isAuthorizedFor rejects a tampered body', () => {
+    const body = '<BookingNotification id="abc"/>';
+    const sig = createHmac('sha256', 'expedia-shared-A').update(body).digest('hex');
+    expect((controller as any).isAuthorizedFor(connectionA, sig, body + 'tamper')).toBe(false);
+  });
+
+  it("isAuthorizedFor rejects a signature signed with another tenant's secret", () => {
+    const body = '<BookingNotification id="abc"/>';
+    const otherSig = createHmac('sha256', 'expedia-shared-B').update(body).digest('hex');
+    expect((controller as any).isAuthorizedFor(connectionA, otherSig, body)).toBe(false);
+  });
+
+  it('isAuthorizedFor fails closed when the connection has no stored secret', () => {
+    const noSecretConn = { id: 'c', config: { hotelId: 'HOTEL_A' } };
+    const body = '<BookingNotification id="abc"/>';
+    const sig = createHmac('sha256', 'expedia-shared-A').update(body).digest('hex');
+    expect((controller as any).isAuthorizedFor(noSecretConn, sig, body)).toBe(false);
+  });
+
+  it('AUTH_ENABLED=false bypasses (sandbox/demo parity)', () => {
+    const offConfig = { get: vi.fn().mockReturnValue('false') } as any;
+    const offCtrl = new ExpediaInboundController(inbound as any, channel as any, offConfig);
+    expect((offCtrl as any).isAuthorizedFor(connectionA, undefined, '')).toBe(true);
+  });
+});

--- a/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.spec.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.spec.ts
@@ -24,7 +24,10 @@ describe('ExpediaInboundController — tenant routing', () => {
   beforeEach(() => {
     inbound = { processInboundReservation: vi.fn().mockResolvedValue({ confirmationNumber: 'PMS1' }) };
     channel = { findByAdapterType: vi.fn() };
-    controller = new ExpediaInboundController(inbound as any, channel as any);
+    // AUTH_ENABLED=false keeps these routing tests focused on routing (the HMAC
+    // verification is exercised by inbound-auth.util.spec + new HMAC tests below).
+    const config = { get: vi.fn().mockReturnValue('false') } as any;
+    controller = new ExpediaInboundController(inbound as any, channel as any, config);
   });
 
   it('routes a booking to the connection whose config.hotelId matches', async () => {

--- a/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/expedia/expedia-inbound.controller.ts
@@ -1,14 +1,26 @@
 import { Controller, Post, Req, Res, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Public } from '../../../auth/public.decorator';
 import { InboundReservationService } from '../../inbound-reservation.service';
 import { ChannelService } from '../../channel.service';
 import { parseExpediaResponse } from './expedia.xml';
 import { mapExpediaBookingToHaip } from './expedia.reservation-mapper';
+import {
+  verifyHmacSignature,
+  getInboundAuth,
+  type InboundHmacAuth,
+} from '../inbound-auth.util';
 
 /**
- * Inbound receiver for Expedia Booking Notification pushes (new/modified/
- * cancelled bookings). @Public() — Expedia can't authenticate to our IdP.
+ * Inbound receiver for Expedia Booking Notification pushes. @Public() — Expedia
+ * can't authenticate to our IdP. Caller authentication is an HMAC-SHA256 over the
+ * raw body using the per-connection shared secret stored in
+ * `connection.config.inboundAuth.secret`. Header: `x-expedia-signature` (hex,
+ * optional `sha256=` prefix). Routing remains by `hotelId`, and the signature is
+ * verified against THAT connection's secret — so an attacker can't inject a
+ * booking for tenant B by sending tenant A's signed payload. Closes CRITICAL #3.
+ * `AUTH_ENABLED=false` is a no-op (demo parity).
  */
 @ApiTags('Channel Manager — Expedia')
 @Controller('channels/inbound/expedia')
@@ -19,7 +31,18 @@ export class ExpediaInboundController {
   constructor(
     private readonly inboundReservationService: InboundReservationService,
     private readonly channelService: ChannelService,
+    private readonly configService: ConfigService,
   ) {}
+
+  private get authEnabled(): boolean {
+    return this.configService.get<string>('AUTH_ENABLED', 'true') !== 'false';
+  }
+
+  private isAuthorizedFor(connection: any, signatureHeader: string | undefined, rawBody: string): boolean {
+    if (!this.authEnabled) return true;
+    const stored = getInboundAuth<InboundHmacAuth>(connection.config);
+    return verifyHmacSignature(signatureHeader, rawBody, stored);
+  }
 
   @Post('bookings')
   @ApiOperation({ summary: 'Receive an inbound booking notification from Expedia (XML)' })
@@ -42,6 +65,8 @@ export class ExpediaInboundController {
         return res.status(500).send('No active Expedia connection configured');
       }
 
+      const signatureHeader = (req.headers?.['x-expedia-signature'] ?? req.headers?.['X-Expedia-Signature']) as string | undefined;
+
       for (const reservation of reservations) {
         // Route to the connection whose config.hotelId matches the booking's hotel.
         // NEVER fall back to connections[0]: with two tenants on Expedia that would
@@ -55,6 +80,15 @@ export class ExpediaInboundController {
             `Expedia booking ${reservation.externalConfirmation}: no connection matches hotelId='${hotelId ?? '(missing)'}' — rejected`,
           );
           continue;
+        }
+        // Verify the HMAC signature against the resolved connection's stored secret.
+        if (!this.isAuthorizedFor(connection, signatureHeader, rawBody)) {
+          this.logger.warn(
+            `Expedia booking ${reservation.externalConfirmation}: HMAC signature verification failed for connection ${connection.id} — rejected`,
+          );
+          // 401 once on the response if any reservation fails auth — the whole
+          // request was forged or misconfigured.
+          return res.status(401).send('<BookingNotificationRS><Error>Unauthorized</Error></BookingNotificationRS>');
         }
         try {
           await this.inboundReservationService.processInboundReservation(connection.id, reservation);

--- a/apps/api/src/modules/channel/adapters/inbound-auth.util.spec.ts
+++ b/apps/api/src/modules/channel/adapters/inbound-auth.util.spec.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { verifyBasicAuth, verifyHmacSignature, getInboundAuth } from './inbound-auth.util';
+
+describe('inbound-auth.util — verifyBasicAuth', () => {
+  const stored = { username: 'bc_user', password: 'bc_pass' };
+  const goodHeader = `Basic ${Buffer.from('bc_user:bc_pass').toString('base64')}`;
+
+  it('accepts the correct username + password', () => {
+    expect(verifyBasicAuth(goodHeader, stored)).toBe(true);
+  });
+
+  it('rejects a wrong password', () => {
+    const bad = `Basic ${Buffer.from('bc_user:nope').toString('base64')}`;
+    expect(verifyBasicAuth(bad, stored)).toBe(false);
+  });
+
+  it('rejects a wrong username (auth for tenant A used against tenant B)', () => {
+    const other = `Basic ${Buffer.from('attacker_user:bc_pass').toString('base64')}`;
+    expect(verifyBasicAuth(other, stored)).toBe(false);
+  });
+
+  it('rejects a missing Authorization header', () => {
+    expect(verifyBasicAuth(undefined, stored)).toBe(false);
+  });
+
+  it('rejects when stored credentials are not configured (fail closed)', () => {
+    expect(verifyBasicAuth(goodHeader, undefined)).toBe(false);
+    expect(verifyBasicAuth(goodHeader, { username: '', password: '' })).toBe(false);
+  });
+
+  it('rejects non-Basic auth schemes', () => {
+    expect(verifyBasicAuth('Bearer something', stored)).toBe(false);
+  });
+});
+
+describe('inbound-auth.util — verifyHmacSignature', () => {
+  const stored = { secret: 'expedia-shared-secret' };
+  const body = '<BookingNotification>raw xml</BookingNotification>';
+  const goodSig = createHmac('sha256', stored.secret).update(body).digest('hex');
+
+  it('accepts a correct signature', () => {
+    expect(verifyHmacSignature(goodSig, body, stored)).toBe(true);
+  });
+
+  it("accepts a 'sha256=' prefix", () => {
+    expect(verifyHmacSignature(`sha256=${goodSig}`, body, stored)).toBe(true);
+  });
+
+  it('rejects a tampered body', () => {
+    expect(verifyHmacSignature(goodSig, body + 'tamper', stored)).toBe(false);
+  });
+
+  it('rejects when secret is wrong (auth for tenant A used against tenant B)', () => {
+    const otherSecret = { secret: 'other-tenant-secret' };
+    expect(verifyHmacSignature(goodSig, body, otherSecret)).toBe(false);
+  });
+
+  it('rejects missing signature / missing secret', () => {
+    expect(verifyHmacSignature(undefined, body, stored)).toBe(false);
+    expect(verifyHmacSignature(goodSig, body, undefined)).toBe(false);
+    expect(verifyHmacSignature(goodSig, body, { secret: '' })).toBe(false);
+  });
+
+  it('rejects a non-hex signature', () => {
+    expect(verifyHmacSignature('not-hex-!!!', body, stored)).toBe(false);
+  });
+});
+
+describe('inbound-auth.util — getInboundAuth', () => {
+  it('returns the embedded auth object when present', () => {
+    expect(getInboundAuth({ inboundAuth: { username: 'u', password: 'p' } })).toEqual({ username: 'u', password: 'p' });
+  });
+  it('returns undefined when missing or malformed', () => {
+    expect(getInboundAuth(undefined)).toBeUndefined();
+    expect(getInboundAuth({})).toBeUndefined();
+    expect(getInboundAuth({ inboundAuth: 'no' as any })).toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/channel/adapters/inbound-auth.util.ts
+++ b/apps/api/src/modules/channel/adapters/inbound-auth.util.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 
 /**
  * Per-connection inbound authentication (closes CRITICAL #3 from the security audit).
@@ -24,17 +24,16 @@ export interface InboundHmacAuth {
   secret: string;
 }
 
-/** Constant-time string compare — never short-circuit on length mismatch leak. */
-function safeEqualStr(a: string, b: string): boolean {
-  const ab = Buffer.from(a);
-  const bb = Buffer.from(b);
-  if (ab.length !== bb.length) return false;
-  return timingSafeEqual(ab, bb);
-}
-
-/** Constant-time hex compare. Used for HMAC signature comparison. */
-function safeEqualHex(a: string, b: string): boolean {
-  return safeEqualStr(a.toLowerCase(), b.toLowerCase());
+/**
+ * Constant-time string compare that does NOT leak the length difference.
+ * Hashes both sides with sha256 first, then compares the fixed-size digests
+ * with `timingSafeEqual`. (A naive `length` check before `timingSafeEqual`
+ * would let an attacker probe the secret length via response timing.)
+ */
+function constantTimeEqualStr(a: string, b: string): boolean {
+  const ha = createHash('sha256').update(a, 'utf8').digest();
+  const hb = createHash('sha256').update(b, 'utf8').digest();
+  return timingSafeEqual(ha, hb);
 }
 
 /**
@@ -60,7 +59,10 @@ export function verifyBasicAuth(
   if (idx < 0) return false;
   const user = decoded.slice(0, idx);
   const pass = decoded.slice(idx + 1);
-  return safeEqualStr(user, stored.username) && safeEqualStr(pass, stored.password);
+  // Evaluate BOTH comparisons so timing doesn't reveal whether username matched.
+  const userOk = constantTimeEqualStr(user, stored.username);
+  const passOk = constantTimeEqualStr(pass, stored.password);
+  return userOk && passOk;
 }
 
 /**
@@ -75,11 +77,11 @@ export function verifyHmacSignature(
 ): boolean {
   if (!stored?.secret) return false;
   if (typeof signatureHeader !== 'string' || !signatureHeader) return false;
-  const provided = signatureHeader.trim().replace(/^sha256=/i, '');
+  const provided = signatureHeader.trim().replace(/^sha256=/i, '').toLowerCase();
   if (!/^[0-9a-f]+$/i.test(provided)) return false;
   const expected = createHmac('sha256', stored.secret).update(rawBody).digest('hex');
-  if (provided.length !== expected.length) return false;
-  return safeEqualHex(provided, expected);
+  // Hash both sides to a fixed-size digest so a length difference doesn't leak via timing.
+  return constantTimeEqualStr(provided, expected);
 }
 
 /** Extract `inboundAuth` from a channel connection's `config` jsonb safely. */

--- a/apps/api/src/modules/channel/adapters/inbound-auth.util.ts
+++ b/apps/api/src/modules/channel/adapters/inbound-auth.util.ts
@@ -1,0 +1,94 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Per-connection inbound authentication (closes CRITICAL #3 from the security audit).
+ *
+ * Each `channelConnections.config.inboundAuth` carries the credentials a specific
+ * OTA must present when pushing into HAIP:
+ *
+ *   { username: '...', password: '...' }                  // Basic Auth (Booking.com)
+ *   { secret: '...' }                                     // HMAC-SHA256 (Expedia & similar)
+ *
+ * The previous code never validated the `Authorization` header at all, so anyone
+ * who reached the public webhook URL could inject reservations/cancellations.
+ *
+ * `config.inboundAuth` lives inside the existing encrypted-at-app `config` jsonb;
+ * no schema change required.
+ */
+export interface InboundBasicAuth {
+  username: string;
+  password: string;
+}
+export interface InboundHmacAuth {
+  /** Shared secret used as the HMAC-SHA256 key (raw, not hashed). */
+  secret: string;
+}
+
+/** Constant-time string compare — never short-circuit on length mismatch leak. */
+function safeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/** Constant-time hex compare. Used for HMAC signature comparison. */
+function safeEqualHex(a: string, b: string): boolean {
+  return safeEqualStr(a.toLowerCase(), b.toLowerCase());
+}
+
+/**
+ * Verify a `Authorization: Basic <base64(user:pass)>` header against the stored
+ * Basic-Auth credentials on a channel connection. Returns true iff both match in
+ * constant time. Missing creds → false (fail closed).
+ */
+export function verifyBasicAuth(
+  authHeader: string | undefined | null,
+  stored: InboundBasicAuth | undefined,
+): boolean {
+  if (!stored?.username || !stored?.password) return false;
+  if (typeof authHeader !== 'string' || !authHeader) return false;
+  const m = /^Basic\s+(.+)$/i.exec(authHeader.trim());
+  if (!m) return false;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(m[1]!, 'base64').toString('utf8');
+  } catch {
+    return false;
+  }
+  const idx = decoded.indexOf(':');
+  if (idx < 0) return false;
+  const user = decoded.slice(0, idx);
+  const pass = decoded.slice(idx + 1);
+  return safeEqualStr(user, stored.username) && safeEqualStr(pass, stored.password);
+}
+
+/**
+ * Verify an HMAC-SHA256 signature header against a shared secret over the raw
+ * request body. Header is the hex digest (most providers emit hex; some prefix
+ * `sha256=` which we strip). Constant-time compare; fail closed on missing input.
+ */
+export function verifyHmacSignature(
+  signatureHeader: string | undefined | null,
+  rawBody: string,
+  stored: InboundHmacAuth | undefined,
+): boolean {
+  if (!stored?.secret) return false;
+  if (typeof signatureHeader !== 'string' || !signatureHeader) return false;
+  const provided = signatureHeader.trim().replace(/^sha256=/i, '');
+  if (!/^[0-9a-f]+$/i.test(provided)) return false;
+  const expected = createHmac('sha256', stored.secret).update(rawBody).digest('hex');
+  if (provided.length !== expected.length) return false;
+  return safeEqualHex(provided, expected);
+}
+
+/** Extract `inboundAuth` from a channel connection's `config` jsonb safely. */
+export function getInboundAuth<T = InboundBasicAuth | InboundHmacAuth>(
+  config: unknown,
+): T | undefined {
+  if (!config || typeof config !== 'object') return undefined;
+  const cfg = config as Record<string, unknown>;
+  const ia = cfg['inboundAuth'];
+  if (!ia || typeof ia !== 'object') return undefined;
+  return ia as T;
+}

--- a/apps/api/src/modules/connect/connect.controller.spec.ts
+++ b/apps/api/src/modules/connect/connect.controller.spec.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ForbiddenException } from '@nestjs/common';
+import { ConnectController } from './connect.controller';
+
+/**
+ * Closes the last residual cross-tenant hole flagged by the Codex re-audit:
+ *   `POST /connect/search` has an OPTIONAL `propertyId` in AgentSearchDto.
+ *   A property-scoped credential could omit it and the search service would
+ *   enumerate availability across every active tenant.
+ * The controller now pins the DTO's propertyId to the credential's propertyId
+ * for property-scoped callers, regardless of what (if anything) was sent.
+ *
+ * Also asserts the /properties/:id membership check (moved here from the guard).
+ */
+
+const A = 'aaaaaaaa-0000-4000-a000-000000000001';
+const B = 'bbbbbbbb-0000-4000-b000-000000000002';
+
+function mkController() {
+  const search = { search: vi.fn().mockResolvedValue([]) };
+  const content = {
+    listProperties: vi.fn().mockResolvedValue([]),
+    getPropertyDetail: vi.fn().mockResolvedValue({ id: A }),
+  };
+  const booking = { book: vi.fn(), verify: vi.fn(), modify: vi.fn(), cancel: vi.fn() };
+  const events = {
+    createSubscription: vi.fn(),
+    listSubscriptions: vi.fn(),
+    deleteSubscription: vi.fn(),
+    testSubscription: vi.fn(),
+    listDeliveries: vi.fn(),
+    pollEvents: vi.fn(),
+  };
+  const insights = {
+    getRevenueInsights: vi.fn(),
+    getGuestTriggers: vi.fn(),
+    getHousekeepingInsights: vi.fn(),
+  };
+  const c = new ConnectController(
+    search as any,
+    content as any,
+    booking as any,
+    events as any,
+    insights as any,
+  );
+  return { c, search, content, booking, events, insights };
+}
+
+describe('ConnectController — search pinning', () => {
+  let h: ReturnType<typeof mkController>;
+  beforeEach(() => { h = mkController(); });
+
+  it('pins dto.propertyId to the credential when scope=property AND dto omits it', async () => {
+    const dto: any = { checkIn: '2026-07-01', checkOut: '2026-07-03' };
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    await h.c.search(dto, req);
+    expect(h.search.search).toHaveBeenCalledWith(expect.objectContaining({ propertyId: A }));
+  });
+
+  it('pins dto.propertyId to the credential even if the caller sent its OWN propertyId', async () => {
+    // The guard would already have allowed dto.propertyId === credential.propertyId,
+    // but we belt-and-brace it here so the service can't be tricked.
+    const dto: any = { propertyId: A, checkIn: '2026-07-01', checkOut: '2026-07-03' };
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    await h.c.search(dto, req);
+    expect(h.search.search).toHaveBeenCalledWith(expect.objectContaining({ propertyId: A }));
+  });
+
+  it('does NOT pin for scope=platform (the demo gateway / trusted server-side caller)', async () => {
+    const dto: any = { checkIn: '2026-07-01', checkOut: '2026-07-03' };
+    const req: any = { connect: { scope: 'platform' } };
+    await h.c.search(dto, req);
+    expect(h.search.search).toHaveBeenCalledWith(expect.not.objectContaining({ propertyId: expect.any(String) }));
+  });
+});
+
+describe('ConnectController — /connect/properties/:id', () => {
+  let h: ReturnType<typeof mkController>;
+  beforeEach(() => { h = mkController(); });
+
+  it('DENIES a property-A credential reading /connect/properties/B', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    await expect(h.c.getProperty(B, req)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it('allows a property-A credential reading /connect/properties/A', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    await expect(h.c.getProperty(A, req)).resolves.toEqual({ id: A });
+  });
+
+  it('allows scope=platform to read any property', async () => {
+    const req: any = { connect: { scope: 'platform' } };
+    await expect(h.c.getProperty(B, req)).resolves.toEqual({ id: A });
+  });
+});
+
+describe('ConnectController — /connect/properties list', () => {
+  let h: ReturnType<typeof mkController>;
+  beforeEach(() => { h = mkController(); });
+
+  it('property-scoped caller only sees their own tenant (no enumeration)', async () => {
+    const req: any = { connect: { scope: 'property', propertyId: A } };
+    const out = await h.c.listProperties({} as any, req);
+    expect(h.content.getPropertyDetail).toHaveBeenCalledWith(A);
+    expect(h.content.listProperties).not.toHaveBeenCalled();
+    expect(out).toEqual([{ id: A }]);
+  });
+
+  it('platform-scoped caller can list all properties', async () => {
+    const req: any = { connect: { scope: 'platform' } };
+    await h.c.listProperties({ limit: 50 } as any, req);
+    expect(h.content.listProperties).toHaveBeenCalled();
+    expect(h.content.getPropertyDetail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/connect/connect.controller.ts
+++ b/apps/api/src/modules/connect/connect.controller.ts
@@ -7,12 +7,14 @@ import {
   Body,
   Param,
   Query,
+  Req,
   ParseUUIDPipe,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
-import { ApiKeyGuard } from '../auth/api-key.guard';
+import { ApiKeyGuard, type ConnectPrincipal } from '../auth/api-key.guard';
+import { ConnectScopeGuard } from '../auth/connect-scope.guard';
 import { ConnectSearchService } from './connect-search.service';
 import { ConnectContentService } from './connect-content.service';
 import { ConnectBookingService } from './connect-booking.service';
@@ -31,10 +33,12 @@ import { ListPropertiesDto } from './dto/list-properties.dto';
 // /api/v1/api/v1/connect/* because main.ts sets a global prefix.
 @Controller('connect')
 // @Public() skips the global JWT guard — the Connect API uses an API key
-// (x-api-key header) validated by ApiKeyGuard instead. Without this, every
-// endpoint below would be reachable unauthenticated.
+// (x-api-key header) validated by ApiKeyGuard instead. ConnectScopeGuard then
+// enforces tenant isolation for property-scoped credentials (the platform
+// CONNECT_API_KEY env value is cross-tenant by design — used by the demo
+// gateway and other trusted server-side callers).
 @Public()
-@UseGuards(ApiKeyGuard)
+@UseGuards(ApiKeyGuard, ConnectScopeGuard)
 export class ConnectController {
   constructor(
     private readonly searchService: ConnectSearchService,
@@ -55,7 +59,13 @@ export class ConnectController {
 
   @Get('properties')
   @ApiOperation({ summary: 'List all properties (Agent 4.2 background sync)' })
-  async listProperties(@Query() dto: ListPropertiesDto) {
+  async listProperties(@Query() dto: ListPropertiesDto, @Req() req: any) {
+    const principal = req.connect as ConnectPrincipal | undefined;
+    if (principal?.scope === 'property' && principal.propertyId) {
+      // Property-scoped credentials only ever see their one tenant.
+      const detail = await this.contentService.getPropertyDetail(principal.propertyId);
+      return detail ? [detail] : [];
+    }
     return this.contentService.listProperties(dto.limit, dto.offset);
   }
 

--- a/apps/api/src/modules/connect/connect.controller.ts
+++ b/apps/api/src/modules/connect/connect.controller.ts
@@ -54,7 +54,15 @@ export class ConnectController {
   @Post('search')
   @ApiOperation({ summary: 'Search properties with availability and rates (Agent 4.1)' })
   @ApiResponse({ status: 200, description: 'Search results with room types, rates, and nightly breakdown' })
-  async search(@Body() dto: AgentSearchDto) {
+  async search(@Body() dto: AgentSearchDto, @Req() req: any) {
+    // `AgentSearchDto.propertyId` is optional, so a property-scoped credential
+    // could otherwise omit it and the search service would enumerate across
+    // ALL active tenants. Pin to the credential's propertyId. (If the DTO does
+    // carry a propertyId, ConnectScopeGuard has already verified it matches.)
+    const principal = req.connect as ConnectPrincipal | undefined;
+    if (principal?.scope === 'property' && principal.propertyId) {
+      dto.propertyId = principal.propertyId;
+    }
     return this.searchService.search(dto);
   }
 

--- a/apps/api/src/modules/connect/connect.controller.ts
+++ b/apps/api/src/modules/connect/connect.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   ParseUUIDPipe,
   UseGuards,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse, ApiSecurity } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
@@ -71,7 +72,15 @@ export class ConnectController {
 
   @Get('properties/:id')
   @ApiOperation({ summary: 'Get detailed property content (Agent 4.2, 4.3)' })
-  async getProperty(@Param('id', ParseUUIDPipe) id: string) {
+  async getProperty(@Param('id', ParseUUIDPipe) id: string, @Req() req: any) {
+    // `:id` IS the tenant on this route — ConnectScopeGuard intentionally does
+    // NOT enforce `params.id` (it would over-deny on /subscriptions/:id where
+    // `:id` is a subscription UUID). Enforce membership here where the route
+    // semantics are explicit.
+    const principal = req.connect as ConnectPrincipal | undefined;
+    if (principal?.scope === 'property' && principal.propertyId !== id) {
+      throw new ForbiddenException('Credential is not scoped to this property');
+    }
     return this.contentService.getPropertyDetail(id);
   }
 

--- a/packages/database/src/migrations/0002_connect_security.sql
+++ b/packages/database/src/migrations/0002_connect_security.sql
@@ -1,0 +1,17 @@
+-- Connect API tenant-bound credentials (closes CRITICAL #2 from the security audit).
+-- Each row binds an opaque API key (sha256-hashed, never plaintext) to a single propertyId.
+-- The legacy CONNECT_API_KEY env var stays valid as a cross-tenant 'platform' key.
+
+CREATE TABLE IF NOT EXISTS "connect_credentials" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "property_id" uuid NOT NULL REFERENCES "properties"("id"),
+  "label" varchar(200) NOT NULL,
+  "key_hash" varchar(64) NOT NULL UNIQUE,
+  "is_active" boolean NOT NULL DEFAULT true,
+  "last_used_at" timestamptz,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "revoked_at" timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS "connect_credentials_property_id_idx"
+  ON "connect_credentials" ("property_id");

--- a/packages/database/src/schema/connect.ts
+++ b/packages/database/src/schema/connect.ts
@@ -60,3 +60,24 @@ export const webhookDeliveries = pgTable('webhook_deliveries', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   deliveredAt: timestamp('delivered_at', { withTimezone: true }),
 });
+
+/**
+ * Connect API credentials — tenant-bound API keys for the /api/v1/connect/* surface.
+ *
+ * Each row binds an opaque API key (stored as sha256 hash — NEVER plaintext) to a
+ * single propertyId. The ApiKeyGuard hashes the presented key and looks it up here;
+ * if found the request runs in scope='property' (cross-tenant denied by ConnectScopeGuard).
+ * The legacy `CONNECT_API_KEY` env var is still accepted as scope='platform' for
+ * trusted server-side callers (the demo gateway) and may target any tenant by design.
+ */
+export const connectCredentials = pgTable('connect_credentials', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  propertyId: uuid('property_id').notNull().references(() => properties.id),
+  label: varchar('label', { length: 200 }).notNull(),
+  // sha256(raw key), hex-encoded. Raw key shown to the operator ONCE on creation.
+  keyHash: varchar('key_hash', { length: 64 }).notNull().unique(),
+  isActive: boolean('is_active').notNull().default(true),
+  lastUsedAt: timestamp('last_used_at', { withTimezone: true }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  revokedAt: timestamp('revoked_at', { withTimezone: true }),
+});

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -82,6 +82,7 @@ export {
   agentWebhookSubscriptions,
   webhookDeliveryStatusEnum,
   webhookDeliveries,
+  connectCredentials,
 } from './connect.js';
 
 // Tax


### PR DESCRIPTION
## What
Closes the two remaining CRITICALs from the independent Codex security audit (#116 closed #1). 850/850 api specs pass; pre-existing media `Express.Multer` + `property.content_updated` + S3 typecheck errors are on `main` (not from this diff).

## CRITICAL #2 — Connect API tenant-bound
- **New `connect_credentials` table** (sha256 hash, never plaintext) binds each opaque API key to a single `propertyId`.
- **Legacy `CONNECT_API_KEY` env stays valid** as a `scope='platform'` cross-tenant key (the demo gateway and other trusted server-side callers keep working).
- **`ApiKeyGuard`** is now async + DB-aware: resolves the key → `ConnectPrincipal` attached to `req.connect`.
- **New `ConnectScopeGuard`** (after ApiKeyGuard on `ConnectController`): for `scope='property'`, any `params.id` / `query.propertyId` / `body.propertyId` must equal the credential's `propertyId`; `/bookings/:confirmationNumber` routes resolve through `bookings` and reject if the booking belongs to another tenant. Non-scalar values rejected outright (matches `PropertyScopeGuard` hardening).
- **`GET /connect/properties`** scope-filters to the one tenant for property credentials.

## CRITICAL #3 — OTA inbound webhooks authenticated
Routing-by-hotelId was already done correctly on `main` (good). What was missing — caller authentication — is now closed:
- **Booking.com**: `Authorization: Basic` verified against the RESOLVED connection's `config.inboundAuth = { username, password }`. Tenant A's creds can't inject reservations for tenant B even if the attacker knows B's hotel code. Cancellations gated identically. Also fixed: `sendErrorXml` was silently downgrading 401→500.
- **Expedia**: HMAC-SHA256 of the raw body verified via `x-expedia-signature` against the resolved connection's shared secret.
- Shared util `channel/adapters/inbound-auth.util.ts` (constant-time compares, fail-closed on missing/malformed input).

## Demo parity
`AUTH_ENABLED=false` is a no-op in both new guards and both inbound controllers, so the existing demo stack is untouched.

## Tests (TDD)
- `api-key.guard.spec.ts` — 7 tests (property/platform/revoked/unknown/fail-closed)
- `connect-scope.guard.spec.ts` — 13 tests incl. headline **tenant-A-cred-denied-tenant-B-data** + confirmationNumber-route cross-tenant denial + array-bypass fail-closed
- `inbound-auth.util.spec.ts` — 14 tests (Basic Auth + HMAC, tamper + wrong-secret + missing creds)
- All existing channel specs still green (148/148)

## Deployment notes
- Run `packages/database/src/migrations/0002_connect_security.sql` on the Supabase twin (and prod) before this lands.
- Issue per-property Connect credentials for real subscribers (the demo gateway can keep using `CONNECT_API_KEY` as a platform-scope key — no change for the existing ChatGPT demo path).
- Real OTA partners must be configured with per-connection Basic-Auth (Booking.com) or shared-secret (Expedia) via the connection's `config.inboundAuth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)