### PR TITLE
fix(security): financial input validation (positive amounts, mass-assignment, confirmation entropy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,10 @@ NODE_ENV=development
 # RATE_LIMIT_MAX=300
 # RATE_LIMIT_WINDOW_MS=60000
 # RATE_LIMIT_DISABLED=false
+# Only set true when running behind a trusted proxy/load balancer that sets
+# X-Forwarded-For. Off by default so a client can't spoof the header to dodge
+# the limit (uses the real socket IP).
+# RATE_LIMIT_TRUST_PROXY=false
 
 # Authentication (Keycloak OIDC)
 # AUTH_ENABLED controls whether JWT auth is enforced:

--- a/apps/api/src/common/security/rate-limit.guard.spec.ts
+++ b/apps/api/src/common/security/rate-limit.guard.spec.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from 'vitest';
 import { HttpException, type ExecutionContext } from '@nestjs/common';
 import { RateLimitGuard } from './rate-limit.guard';
 
-function ctx(ip: string): ExecutionContext {
+function ctx(ip: string, xff?: string): ExecutionContext {
+  const headers: Record<string, string> = {};
+  if (xff !== undefined) headers['x-forwarded-for'] = xff;
   return {
-    switchToHttp: () => ({ getRequest: () => ({ ip, headers: {} }) }),
+    switchToHttp: () => ({ getRequest: () => ({ ip, headers }) }),
   } as unknown as ExecutionContext;
 }
 
@@ -35,5 +37,20 @@ describe('RateLimitGuard', () => {
   it('is a no-op when disabled', () => {
     const g = guard({ RATE_LIMIT_MAX: '1', DISABLED: 'true' });
     for (let i = 0; i < 10; i++) expect(g.canActivate(ctx('9.9.9.9'))).toBe(true);
+  });
+
+  it('IGNORES X-Forwarded-For by default — a rotating header cannot dodge the limit', () => {
+    const g = guard({ RATE_LIMIT_MAX: '1' });
+    // Same socket IP, attacker rotates XFF every request; must still be throttled.
+    expect(g.canActivate(ctx('5.5.5.5', '1.1.1.1'))).toBe(true);
+    expect(() => g.canActivate(ctx('5.5.5.5', '2.2.2.2'))).toThrow(HttpException);
+  });
+
+  it('honors X-Forwarded-For only when RATE_LIMIT_TRUST_PROXY=true', () => {
+    const g = guard({ RATE_LIMIT_MAX: '1', RATE_LIMIT_TRUST_PROXY: 'true' });
+    // Behind a trusted proxy, the forwarded client IP is the key, so distinct
+    // forwarded IPs get distinct budgets.
+    expect(g.canActivate(ctx('5.5.5.5', '1.1.1.1'))).toBe(true);
+    expect(g.canActivate(ctx('5.5.5.5', '2.2.2.2'))).toBe(true);
   });
 });

--- a/apps/api/src/common/security/rate-limit.guard.ts
+++ b/apps/api/src/common/security/rate-limit.guard.ts
@@ -24,6 +24,7 @@ export class RateLimitGuard implements CanActivate {
   private readonly max: number;
   private readonly windowMs: number;
   private readonly disabled: boolean;
+  private readonly trustProxy: boolean;
 
   constructor(private readonly configService: ConfigService) {
     this.max = Number(this.configService.get('RATE_LIMIT_MAX', '300')) || 300;
@@ -31,6 +32,11 @@ export class RateLimitGuard implements CanActivate {
     this.disabled =
       process.env['NODE_ENV'] === 'test' ||
       this.configService.get<string>('RATE_LIMIT_DISABLED', 'false') === 'true';
+    // Only honor X-Forwarded-For behind a trusted proxy. Default OFF: otherwise a
+    // client rotates the header to get a fresh window every request and the limit
+    // is meaningless (it's the only brake on confirmation-number brute force).
+    this.trustProxy =
+      this.configService.get<string>('RATE_LIMIT_TRUST_PROXY', 'false') === 'true';
   }
 
   canActivate(context: ExecutionContext): boolean {
@@ -54,8 +60,11 @@ export class RateLimitGuard implements CanActivate {
   }
 
   private clientIp(req: any): string {
-    const fwd = req.headers?.['x-forwarded-for'];
-    if (typeof fwd === 'string' && fwd.length > 0) return fwd.split(',')[0]!.trim();
+    if (this.trustProxy) {
+      const fwd = req.headers?.['x-forwarded-for'];
+      if (typeof fwd === 'string' && fwd.length > 0) return fwd.split(',')[0]!.trim();
+    }
+    // Untrusted by default: use the real socket peer, which a client can't spoof.
     return req.ip ?? req.socket?.remoteAddress ?? 'unknown';
   }
 

--- a/apps/api/src/common/validation/is-money-string.validator.spec.ts
+++ b/apps/api/src/common/validation/is-money-string.validator.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { validate } from 'class-validator';
+import { IsMoneyString } from './is-money-string.validator';
+
+class Positive {
+  @IsMoneyString()
+  amount!: string;
+}
+class NonNeg {
+  @IsMoneyString({ allowZero: true })
+  amount!: string;
+}
+class Signed {
+  @IsMoneyString({ allowNegative: true })
+  amount!: string;
+}
+
+async function fails(obj: any): Promise<boolean> {
+  const errors = await validate(obj);
+  return errors.length > 0;
+}
+
+describe('IsMoneyString', () => {
+  it('positive (default): accepts a positive decimal string', async () => {
+    expect(await fails(Object.assign(new Positive(), { amount: '150.00' }))).toBe(false);
+  });
+
+  it('positive (default): rejects negative, zero, NaN, empty, and non-numeric', async () => {
+    for (const v of ['-1.00', '0', '0.00', 'abc', '', '   ', 'Infinity', '1,234.50']) {
+      expect(await fails(Object.assign(new Positive(), { amount: v }))).toBe(true);
+    }
+  });
+
+  it('allowZero: accepts 0 and positive, still rejects negative', async () => {
+    expect(await fails(Object.assign(new NonNeg(), { amount: '0' }))).toBe(false);
+    expect(await fails(Object.assign(new NonNeg(), { amount: '12.50' }))).toBe(false);
+    expect(await fails(Object.assign(new NonNeg(), { amount: '-0.01' }))).toBe(true);
+  });
+
+  it('allowNegative: accepts negatives (credits) but still rejects garbage', async () => {
+    expect(await fails(Object.assign(new Signed(), { amount: '-50.00' }))).toBe(false);
+    expect(await fails(Object.assign(new Signed(), { amount: '50.00' }))).toBe(false);
+    expect(await fails(Object.assign(new Signed(), { amount: 'nope' }))).toBe(true);
+  });
+});

--- a/apps/api/src/common/validation/is-money-string.validator.ts
+++ b/apps/api/src/common/validation/is-money-string.validator.ts
@@ -1,0 +1,64 @@
+import {
+  registerDecorator,
+  type ValidationOptions,
+  ValidatorConstraint,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+import Decimal from 'decimal.js';
+
+export interface MoneyStringOptions {
+  /** Allow exactly zero (default false → must be strictly positive). */
+  allowZero?: boolean;
+  /** Allow negative amounts (default false). Use for credit/adjustment fields. */
+  allowNegative?: boolean;
+}
+
+@ValidatorConstraint({ name: 'isMoneyString', async: false })
+class MoneyStringConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: any): boolean {
+    if (typeof value !== 'string' || value.trim() === '') return false;
+    let d: Decimal;
+    try {
+      d = new Decimal(value);
+    } catch {
+      return false;
+    }
+    if (!d.isFinite()) return false;
+    const opts: MoneyStringOptions = args?.constraints?.[0] ?? {};
+    if (!opts.allowNegative && d.isNegative()) return false;
+    if (!opts.allowZero && !opts.allowNegative && d.isZero()) return false;
+    return true;
+  }
+
+  defaultMessage(args: any): string {
+    const opts: MoneyStringOptions = args?.constraints?.[0] ?? {};
+    const bound = opts.allowNegative
+      ? 'a numeric decimal string'
+      : opts.allowZero
+        ? 'a non-negative numeric decimal string'
+        : 'a positive numeric decimal string';
+    return `${args?.property} must be ${bound}`;
+  }
+}
+
+/**
+ * Validates a monetary value supplied as a decimal STRING (amounts are stored as
+ * numeric strings to avoid float drift). Rejects NaN/Infinity and — by default —
+ * zero and negatives, closing the "negative amount inverts the folio balance"
+ * class of bug. Pass `{ allowNegative: true }` for legitimate credit/adjustment
+ * fields, `{ allowZero: true }` where zero is meaningful (e.g. comp rooms).
+ */
+export function IsMoneyString(
+  opts: MoneyStringOptions = {},
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [opts],
+      validator: MoneyStringConstraint,
+    });
+  };
+}

--- a/apps/api/src/modules/channel/channel.controller.ts
+++ b/apps/api/src/modules/channel/channel.controller.ts
@@ -18,6 +18,7 @@ import { InboundReservationService } from './inbound-reservation.service';
 import { RateParityService } from './rate-parity.service';
 import { CreateChannelConnectionDto } from './dto/create-channel-connection.dto';
 import { UpdateChannelConnectionDto } from './dto/update-channel-connection.dto';
+import { SetRateOverrideDto } from './dto/set-rate-override.dto';
 import { PushAriDto } from './dto/push-ari.dto';
 import { PushContentDto } from './dto/push-content.dto';
 import { InboundReservationDto } from './dto/inbound-reservation.dto';
@@ -252,11 +253,16 @@ export class ChannelController {
   async setRateOverride(
     @Query('channelConnectionId', ParseUUIDPipe) channelConnectionId: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
-    @Body() override: any,
+    @Body() override: SetRateOverrideDto,
   ) {
     return this.rateParityService.setRateOverride(channelConnectionId, propertyId, {
       channelConnectionId,
-      ...override,
+      ratePlanId: override.ratePlanId,
+      adjustmentType: override.adjustmentType,
+      adjustmentValue: override.adjustmentValue,
+      startDate: override.startDate,
+      endDate: override.endDate,
+      reason: override.reason,
     });
   }
 

--- a/apps/api/src/modules/channel/dto/set-rate-override.dto.ts
+++ b/apps/api/src/modules/channel/dto/set-rate-override.dto.ts
@@ -1,0 +1,54 @@
+import {
+  IsUUID,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsDateString,
+  IsString,
+  MaxLength,
+  Min,
+  Max,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Body for POST /channels/rate-parity/override. Replaces the previous
+ * `@Body() override: any`, which spread arbitrary attacker-controlled keys into
+ * the persisted `config.rateOverrides` JSON and left `adjustmentValue` unbounded.
+ * With this DTO the global ValidationPipe (whitelist + forbidNonWhitelisted)
+ * strips unknown keys and bounds the values.
+ */
+export class SetRateOverrideDto {
+  @ApiProperty({ format: 'uuid', description: 'Rate plan the override applies to' })
+  @IsUUID()
+  ratePlanId!: string;
+
+  @ApiProperty({ enum: ['percentage', 'fixed'] })
+  @IsEnum(['percentage', 'fixed'])
+  adjustmentType!: 'percentage' | 'fixed';
+
+  @ApiProperty({
+    example: -10,
+    description: 'Percentage (e.g. -10 = 10% lower) or fixed amount. Bounded to sane limits.',
+  })
+  @IsNumber()
+  @Min(-100000)
+  @Max(100000)
+  adjustmentValue!: number;
+
+  @ApiPropertyOptional({ example: '2026-07-01' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ example: '2026-07-31' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ example: 'Summer parity correction' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500)
+  reason?: string;
+}

--- a/apps/api/src/modules/connect/confirmation-token.spec.ts
+++ b/apps/api/src/modules/connect/confirmation-token.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { generateConfirmationToken } from './connect-booking.service';
+
+describe('generateConfirmationToken', () => {
+  it('is high-entropy Crockford base32 (no ambiguous chars), fixed length', () => {
+    const t = generateConfirmationToken();
+    // 16 random bytes → 32 base32 chars; no I, L, O, U (Crockford).
+    expect(t).toMatch(/^[0-9A-HJKMNP-TV-Z]{32}$/);
+  });
+
+  it('is non-enumerable: no collisions across many generations', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 5000; i++) seen.add(generateConfirmationToken());
+    expect(seen.size).toBe(5000);
+  });
+
+  it('does not embed a guessable timestamp prefix (unlike the old format)', () => {
+    // The old form started with a base36 Date.now(); two tokens generated back to
+    // back must not share a long common prefix.
+    const a = generateConfirmationToken();
+    const b = generateConfirmationToken();
+    let common = 0;
+    while (common < a.length && a[common] === b[common]) common++;
+    expect(common).toBeLessThan(6);
+  });
+});

--- a/apps/api/src/modules/connect/connect-booking.service.ts
+++ b/apps/api/src/modules/connect/connect-booking.service.ts
@@ -7,7 +7,7 @@ import { AvailabilityService } from '../reservation/availability.service';
 import { WebhookService } from '../webhook/webhook.service';
 import type { AgentBookDto } from './dto/agent-book.dto';
 import type { AgentModifyDto } from './dto/agent-modify.dto';
-import { randomUUID } from 'crypto';
+import { randomBytes } from 'crypto';
 
 @Injectable()
 export class ConnectBookingService {
@@ -67,8 +67,10 @@ export class ConnectBookingService {
     const baseAmount = baseAmountDec.toNumber();
     const totalAmount = totalAmountDec.toNumber();
 
-    // 5. Generate confirmation number
-    const confirmationNumber = `HAIP-${Date.now().toString(36).toUpperCase()}-${randomUUID().slice(0, 4).toUpperCase()}`;
+    // 5. Generate confirmation number. High-entropy (128 bits from randomBytes,
+    // Crockford base32, no ambiguous chars) so it can't be enumerated/guessed —
+    // the confirmation number is itself a bearer credential for the booking.
+    const confirmationNumber = `HAIP-${generateConfirmationToken()}`;
 
     // 6. Create booking
     const [booking] = await this.db
@@ -532,4 +534,23 @@ export class ConnectBookingService {
       policyDescription: 'First night charge applies — cancelled within 24 hours of check-in.',
     };
   }
+}
+
+// Crockford base32 alphabet (no I/L/O/U — unambiguous when read/typed).
+const CROCKFORD = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+/**
+ * 128 bits of cryptographic randomness (16 random bytes) rendered in Crockford
+ * base32. Unguessable — the confirmation number is a bearer credential for the
+ * booking, so it must not be enumerable (the old `timestamp-4hex` form had only
+ * ~16 bits of randomness).
+ */
+export function generateConfirmationToken(): string {
+  const bytes = randomBytes(16);
+  let out = '';
+  for (let i = 0; i < bytes.length; i++) {
+    out += CROCKFORD[bytes[i]! & 0x1f];
+    out += CROCKFORD[(bytes[i]! >> 5) & 0x1f];
+  }
+  return out;
 }

--- a/apps/api/src/modules/folio/dto/create-charge.dto.ts
+++ b/apps/api/src/modules/folio/dto/create-charge.dto.ts
@@ -10,6 +10,7 @@ import {
   ValidateIf,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsMoneyString } from '../../../common/validation/is-money-string.validator';
 
 export class CreateChargeDto {
   @ApiProperty({ description: 'Property ID' })
@@ -30,8 +31,10 @@ export class CreateChargeDto {
   description!: string;
 
   @ApiProperty({ example: '150.00', description: 'Charge amount (positive for charges, negative for credits)' })
-  @IsString()
-  @IsNotEmpty()
+  // Must be a valid numeric decimal; negatives are allowed here at the DTO layer
+  // because credits/adjustments are legitimate — the service restricts WHEN a
+  // negative is permitted (only type='adjustment' or reversals).
+  @IsMoneyString({ allowNegative: true })
   amount!: string;
 
   @ApiProperty({ example: 'USD' })
@@ -42,7 +45,7 @@ export class CreateChargeDto {
 
   @ApiPropertyOptional({ example: '13.13', description: 'Tax amount' })
   @IsOptional()
-  @IsString()
+  @IsMoneyString({ allowZero: true }) // tax can be 0 but never negative
   taxAmount?: string;
 
   @ApiPropertyOptional({ example: '0.0875', description: 'Tax rate (e.g., 0.0875 for 8.75%)' })

--- a/apps/api/src/modules/folio/folio-charge-validation.spec.ts
+++ b/apps/api/src/modules/folio/folio-charge-validation.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BadRequestException } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { FolioService } from './folio.service';
+import { DRIZZLE } from '../../database/database.module';
+import { WebhookService } from '../webhook/webhook.service';
+import { TaxService } from '../tax/tax.service';
+
+const A = 'aaaaaaaa-0000-4000-a000-000000000001';
+
+/** db whose first select (findById) returns an open folio. */
+function mkDb() {
+  return {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: 'f-1', propertyId: A, status: 'open' }]),
+      }),
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({ returning: vi.fn().mockResolvedValue([{ id: 'c-1' }]) }),
+    }),
+    // recalculateBalance() runs after a successful post.
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    }),
+  };
+}
+
+async function mkSvc(db: any) {
+  const mod = await Test.createTestingModule({
+    providers: [
+      FolioService,
+      { provide: DRIZZLE, useValue: db },
+      { provide: WebhookService, useValue: { emit: vi.fn() } },
+      { provide: TaxService, useValue: { calculateTaxes: vi.fn().mockResolvedValue([]) } },
+    ],
+  }).compile();
+  return mod.get(FolioService);
+}
+
+const baseCharge = {
+  propertyId: A,
+  description: 'x',
+  currencyCode: 'USD',
+  serviceDate: '2026-07-01',
+};
+
+describe('FolioService.postCharge — amount sign rules', () => {
+  it('rejects a negative amount on a normal (non-adjustment, non-reversal) charge', async () => {
+    const svc = await mkSvc(mkDb());
+    await expect(
+      svc.postCharge('f-1', { ...baseCharge, type: 'room', amount: '-50.00' } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects a zero amount on a normal charge', async () => {
+    const svc = await mkSvc(mkDb());
+    await expect(
+      svc.postCharge('f-1', { ...baseCharge, type: 'minibar', amount: '0' } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('ALLOWS a negative amount when type=adjustment (legitimate credit)', async () => {
+    const db = mkDb();
+    const svc = await mkSvc(db);
+    await svc.postCharge('f-1', { ...baseCharge, type: 'adjustment', amount: '-50.00' } as any);
+    expect(db.insert).toHaveBeenCalled();
+  });
+
+  it('ALLOWS a positive normal charge', async () => {
+    const db = mkDb();
+    const svc = await mkSvc(db);
+    await svc.postCharge('f-1', { ...baseCharge, type: 'room', amount: '150.00' } as any);
+    expect(db.insert).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/folio/folio.service.ts
+++ b/apps/api/src/modules/folio/folio.service.ts
@@ -292,7 +292,22 @@ export class FolioService {
       throw new BadRequestException('Cannot post charge to a folio that is not open');
     }
 
-    if (dto.isReversal && dto.originalChargeId) {
+    // A negative/zero amount inverts or zeroes the folio balance. Only legitimate
+    // credit paths may go non-positive: an explicit `adjustment` charge or a
+    // reversal. Everything else must be strictly positive.
+    if (
+      new Decimal(dto.amount).lessThanOrEqualTo(0) &&
+      dto.type !== 'adjustment' &&
+      !dto.isReversal
+    ) {
+      throw new BadRequestException(
+        'Charge amount must be positive (negatives are only allowed for adjustments or reversals)',
+      );
+    }
+
+    // Validate originalChargeId WHENEVER supplied (not only for reversals) so a
+    // caller can't attach a dangling reference to another property's charge.
+    if (dto.originalChargeId) {
       const [original] = await db
         .select()
         .from(charges)
@@ -306,7 +321,7 @@ export class FolioService {
       if (!original) {
         throw new NotFoundException(`Original charge ${dto.originalChargeId} not found`);
       }
-      if (original.isLocked) {
+      if (dto.isReversal && original.isLocked) {
         throw new BadRequestException('Cannot reverse a locked charge');
       }
     }

--- a/apps/api/src/modules/payment/dto/authorize-payment.dto.ts
+++ b/apps/api/src/modules/payment/dto/authorize-payment.dto.ts
@@ -4,10 +4,10 @@ import {
   IsOptional,
   IsUUID,
   IsDateString,
-  IsNumberString,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsMoneyString } from '../../../common/validation/is-money-string.validator';
 
 export class AuthorizePaymentDto {
   @ApiProperty({ description: 'Folio ID' })
@@ -21,8 +21,7 @@ export class AuthorizePaymentDto {
   propertyId!: string;
 
   @ApiProperty({ example: '500.00' })
-  @IsNumberString({}, { message: 'amount must be a numeric decimal string' })
-  @IsNotEmpty()
+  @IsMoneyString() // must be a positive decimal string
   amount!: string;
 
   @ApiProperty({ example: 'USD' })

--- a/apps/api/src/modules/payment/dto/create-payment.dto.ts
+++ b/apps/api/src/modules/payment/dto/create-payment.dto.ts
@@ -4,10 +4,10 @@ import {
   IsOptional,
   IsUUID,
   IsEnum,
-  IsNumberString,
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsMoneyString } from '../../../common/validation/is-money-string.validator';
 
 export class CreatePaymentDto {
   @ApiProperty({ description: 'Folio ID' })
@@ -25,8 +25,7 @@ export class CreatePaymentDto {
   method!: string;
 
   @ApiProperty({ example: '150.00' })
-  @IsNumberString({}, { message: 'amount must be a numeric decimal string' })
-  @IsNotEmpty()
+  @IsMoneyString() // must be a positive decimal string
   amount!: string;
 
   @ApiProperty({ example: 'USD' })

--- a/apps/api/src/modules/reservation/dto/create-reservation.dto.ts
+++ b/apps/api/src/modules/reservation/dto/create-reservation.dto.ts
@@ -9,6 +9,7 @@ import {
   MaxLength,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsMoneyString } from '../../../common/validation/is-money-string.validator';
 
 export class CreateReservationDto {
   @ApiProperty()
@@ -36,7 +37,7 @@ export class CreateReservationDto {
   ratePlanId!: string;
 
   @ApiProperty({ example: '799.96' })
-  @IsString()
+  @IsMoneyString({ allowZero: true }) // non-negative; 0 allowed for comp rooms
   totalAmount!: string;
 
   @ApiProperty({ example: 'USD' })

--- a/apps/api/src/modules/tax/tax.controller.ts
+++ b/apps/api/src/modules/tax/tax.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Param,
   Query,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
@@ -26,7 +27,7 @@ export class TaxController {
 
   @Get('profiles')
   @ApiOperation({ summary: 'List tax profiles for a property' })
-  listProfiles(@Query('propertyId') propertyId: string) {
+  listProfiles(@Query('propertyId', ParseUUIDPipe) propertyId: string) {
     return this.taxService.listProfiles(propertyId);
   }
 
@@ -39,7 +40,10 @@ export class TaxController {
 
   @Get('profiles/:id')
   @ApiOperation({ summary: 'Get tax profile with rules' })
-  getProfile(@Param('id') id: string, @Query('propertyId') propertyId: string) {
+  getProfile(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
     return this.taxService.findProfileWithRules(id, propertyId);
   }
 
@@ -47,8 +51,8 @@ export class TaxController {
   @Roles('admin')
   @ApiOperation({ summary: 'Update a tax profile' })
   updateProfile(
-    @Param('id') id: string,
-    @Query('propertyId') propertyId: string,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateTaxProfileDto,
   ) {
     return this.taxService.updateProfile(id, propertyId, dto);
@@ -60,8 +64,8 @@ export class TaxController {
   @Roles('admin')
   @ApiOperation({ summary: 'Add a tax rule to a profile' })
   createRule(
-    @Param('profileId') profileId: string,
-    @Query('propertyId') propertyId: string,
+    @Param('profileId', ParseUUIDPipe) profileId: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: CreateTaxRuleDto,
   ) {
     return this.taxService.createRule(profileId, propertyId, dto);
@@ -71,9 +75,9 @@ export class TaxController {
   @Roles('admin')
   @ApiOperation({ summary: 'Update a tax rule' })
   updateRule(
-    @Param('profileId') profileId: string,
-    @Param('ruleId') ruleId: string,
-    @Query('propertyId') propertyId: string,
+    @Param('profileId', ParseUUIDPipe) profileId: string,
+    @Param('ruleId', ParseUUIDPipe) ruleId: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
     @Body() dto: UpdateTaxRuleDto,
   ) {
     return this.taxService.updateRule(ruleId, profileId, propertyId, dto);
@@ -83,9 +87,9 @@ export class TaxController {
   @Roles('admin')
   @ApiOperation({ summary: 'Delete a tax rule' })
   deleteRule(
-    @Param('profileId') profileId: string,
-    @Param('ruleId') ruleId: string,
-    @Query('propertyId') propertyId: string,
+    @Param('profileId', ParseUUIDPipe) profileId: string,
+    @Param('ruleId', ParseUUIDPipe) ruleId: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
   ) {
     return this.taxService.deleteRule(ruleId, profileId, propertyId);
   }


### PR DESCRIPTION
Closes the **financial input-validation cluster** the 5-reviewer adversarial pass found after confirming tenant isolation is solid. These are real, exploitable *within-tenant* integrity bugs (not cross-tenant). One bounded PR — no loop.

## HIGH
- **Positive-amount validation.** New shared `@IsMoneyString` validator (parses via `decimal.js`, rejects NaN/Infinity and — by default — zero/negatives).
  - `payment` create + authorize `amount` → must be **> 0**.
  - `reservation.totalAmount` → **≥ 0** (comp rooms allowed).
  - `folio` charge `amount`: still a valid decimal at the DTO layer (credits are legit), but the **service** now rejects a non-positive amount unless `type='adjustment'` or a reversal. *(Negatives previously inverted folio balances / manufactured credit; the refund path was already guarded, these weren't.)* `taxAmount` ≥ 0.
- **Kill `setRateOverride` mass-assignment.** Real `SetRateOverrideDto` replaces `@Body() override: any`, so the global ValidationPipe strips unknown keys and bounds `adjustmentValue` (was spread verbatim into the `config` JSON column).

## MEDIUM
- **Confirmation numbers are now 128-bit random** (Crockford base32) instead of `HAIP-{timestamp}-{4hex}` (~16 bits) — closes within-tenant booking enumeration. Generation-only change; existing rows still resolve.
- **Rate limiter ignores `X-Forwarded-For`** unless `RATE_LIMIT_TRUST_PROXY=true` (default off) — a client can't rotate the header to dodge the limit.
- **TaxController** now uses `ParseUUIDPipe` on every id/`propertyId` param (malformed → 400, not a 500).

## LOW
- `folio.postCharge` validates `originalChargeId` whenever present (not only on reversals) — removes a dangling cross-tenant soft reference.

## Out of scope (noted)
Guest email-oracle on `/connect/book` (guests are cross-property by design — product call), connect-gpt guest-address log redaction (separate tool).

## Verify
New specs: `is-money-string.validator`, `confirmation-token` (entropy/format/no-collision), rate-limit XFF default-ignore, folio charge sign rules. **913 api tests green**, typecheck + lint clean. Demo unaffected (validation only tightens inputs; AUTH-off paths unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq85xVJDW1NpvxQrnEdFdt)_