### PR TITLE
feat(booking): embed-time theming so the widget blends into any host site

### DIFF
--- a/apps/booking/README.md
+++ b/apps/booking/README.md
@@ -49,6 +49,26 @@ Branding (display name, primary/accent colors, logo) is read from `/config`
 (and the `/search` `branding` block) and applied via CSS variables, so each
 property is themed.
 
+### Theming it into a host site
+
+For embeds where the widget must match the surrounding site (a Remy/v0-generated
+page, a Webflow site, any custom site), pass **theme tokens** on the mount
+element. They take precedence over `/config` branding and apply as scoped CSS
+variables on the widget container (never on the host page). Tokens: `primary`,
+`accent`, `onPrimary`, `font`, `radius`, `text`, `surface`.
+
+```html
+<!-- JSON blob (what Remy injects) -->
+<div id="haip-booking" data-booking-key="pk_live_XXX"
+     data-theme='{"primary":"#0a7d6b","font":"Inter, sans-serif","radius":"14px"}'></div>
+
+<!-- or individual attributes -->
+<div id="haip-booking" data-booking-key="pk_live_XXX"
+     data-theme-primary="#0a7d6b" data-theme-font="Inter, sans-serif" data-theme-radius="14px"></div>
+```
+
+Unknown tokens are ignored and values are sanitized (`src/lib/theme.ts`).
+
 ## Payment
 
 If `depositDue > 0` and `/config` returns a `stripePublishableKey`, the Payment

--- a/apps/booking/src/components/Button.tsx
+++ b/apps/booking/src/components/Button.tsx
@@ -2,17 +2,26 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'ghost';
 }
 
-export function Button({ variant = 'primary', className = '', ...rest }: ButtonProps) {
+export function Button({ variant = 'primary', className = '', style, ...rest }: ButtonProps) {
+  // Radius is themeable on every variant; the primary variant also takes its background and text
+  // color from the theme so it matches the host site.
   const base =
-    'inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed';
+    'inline-flex items-center justify-center rounded-brand px-4 py-2 text-sm font-semibold transition disabled:opacity-50 disabled:cursor-not-allowed';
   const styles = {
-    primary: 'text-white hover:opacity-90',
+    primary: 'hover:opacity-90',
     secondary: 'border border-gray-300 text-gray-800 hover:bg-gray-50',
     ghost: 'text-gray-600 hover:text-gray-900',
   }[variant];
 
-  const inlineStyle =
-    variant === 'primary' ? { backgroundColor: 'var(--haip-primary, #06bdb4)' } : undefined;
+  const themeStyle =
+    variant === 'primary'
+      ? {
+          backgroundColor: 'var(--haip-primary, #06bdb4)',
+          color: 'var(--haip-on-primary, #ffffff)',
+        }
+      : undefined;
 
-  return <button className={`${base} ${styles} ${className}`} style={inlineStyle} {...rest} />;
+  return (
+    <button className={`${base} ${styles} ${className}`} style={{ ...themeStyle, ...style }} {...rest} />
+  );
 }

--- a/apps/booking/src/index.css
+++ b/apps/booking/src/index.css
@@ -2,9 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Contain the widget so an embedding host page styles it predictably. */
+/*
+ * Theme contract. Every themeable value is a CSS variable with a sensible fallback, so the
+ * widget renders before /config loads and an embedding site can override any token at mount
+ * time (see lib/theme.ts: data-theme / data-theme-*). Tokens:
+ *   --haip-primary     brand / primary button background
+ *   --haip-accent      secondary accents
+ *   --haip-on-primary  text/icon color on the primary button
+ *   --haip-font        font-family stack
+ *   --haip-radius      corner radius
+ *   --haip-text        body text color
+ *   --haip-surface     card / panel background
+ */
 .haip-booking {
-  font-family: 'Montserrat', Arial, Helvetica, sans-serif;
-  color: #23273d;
+  --haip-primary: #06bdb4;
+  --haip-accent: #f2641b;
+  --haip-on-primary: #ffffff;
+  --haip-font: 'Montserrat', Arial, Helvetica, sans-serif;
+  --haip-radius: 0.375rem;
+  --haip-text: #23273d;
+  --haip-surface: #ffffff;
+
+  font-family: var(--haip-font);
+  color: var(--haip-text);
   line-height: 1.5;
 }

--- a/apps/booking/src/lib/theme.test.ts
+++ b/apps/booking/src/lib/theme.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { resolveTheme, applyTheme, THEME_TOKENS } from './theme';
+
+function el(attrs: Record<string, string>): HTMLElement {
+  const d = document.createElement('div');
+  for (const [k, v] of Object.entries(attrs)) d.setAttribute(k, v);
+  return d;
+}
+
+describe('resolveTheme', () => {
+  it('maps a data-theme JSON blob to the right CSS variables', () => {
+    const t = resolveTheme(
+      el({ 'data-theme': '{"primary":"#0a7","font":"Inter, sans-serif","radius":"14px"}' }),
+    );
+    expect(t['--haip-primary']).toBe('#0a7');
+    expect(t['--haip-font']).toBe('Inter, sans-serif');
+    expect(t['--haip-radius']).toBe('14px');
+  });
+
+  it('reads individual data-theme-* attributes', () => {
+    const t = resolveTheme(el({ 'data-theme-primary': '#123456', 'data-theme-on-primary': '#000' }));
+    expect(t['--haip-primary']).toBe('#123456');
+    expect(t['--haip-on-primary']).toBe('#000');
+  });
+
+  it('individual attributes override the JSON blob on the same element', () => {
+    const t = resolveTheme(el({ 'data-theme': '{"primary":"#aaa"}', 'data-theme-primary': '#bbb' }));
+    expect(t['--haip-primary']).toBe('#bbb');
+  });
+
+  it('ignores unknown tokens', () => {
+    const t = resolveTheme(el({ 'data-theme': '{"evil":"x","primary":"#0a7"}' }));
+    expect(t['--haip-primary']).toBe('#0a7');
+    expect(Object.keys(t)).toEqual(['--haip-primary']);
+  });
+
+  it('sanitizes values that try to break out of the CSS value', () => {
+    const t = resolveTheme(el({ 'data-theme-primary': 'red; } body { display:none' }));
+    // `;` and `}` stripped → a harmless (if odd) value, never a CSS escape
+    expect(t['--haip-primary']).toBeDefined();
+    expect(t['--haip-primary']).not.toContain(';');
+    expect(t['--haip-primary']).not.toContain('}');
+  });
+
+  it('falls back to individual attrs when JSON is malformed', () => {
+    const t = resolveTheme(el({ 'data-theme': '{not json', 'data-theme-accent': '#f00' }));
+    expect(t['--haip-accent']).toBe('#f00');
+  });
+
+  it('returns empty for an element with no theme attrs', () => {
+    expect(resolveTheme(el({}))).toEqual({});
+    expect(resolveTheme(null)).toEqual({});
+  });
+});
+
+describe('applyTheme', () => {
+  it('sets each variable as a scoped inline CSS property on the element', () => {
+    const d = document.createElement('div');
+    applyTheme(d, { '--haip-primary': '#0a7', '--haip-radius': '14px' });
+    expect(d.style.getPropertyValue('--haip-primary')).toBe('#0a7');
+    expect(d.style.getPropertyValue('--haip-radius')).toBe('14px');
+  });
+});
+
+describe('THEME_TOKENS', () => {
+  it('every token maps to a --haip- CSS variable', () => {
+    for (const cssVar of Object.values(THEME_TOKENS)) expect(cssVar).toMatch(/^--haip-/);
+  });
+});

--- a/apps/booking/src/lib/theme.ts
+++ b/apps/booking/src/lib/theme.ts
@@ -1,0 +1,88 @@
+/**
+ * Embed-time theming. A host site (a Remy/v0-generated page, a Webflow site, or any
+ * hand-built site) can pass brand tokens on the mount element so the widget blends in —
+ * independent of, and taking precedence over, the per-property branding from `/config`.
+ *
+ * Two ways to pass a theme on the mount element (or the embed <script>):
+ *
+ *   1. A JSON blob (what Remy injects):
+ *      <div id="haip-booking" data-booking-key="pk_live_…"
+ *           data-theme='{"primary":"#0a7","font":"Inter, sans-serif","radius":"14px"}'></div>
+ *
+ *   2. Individual attributes (hand-authoring convenience):
+ *      <div … data-theme-primary="#0a7" data-theme-font="Inter, sans-serif" data-theme-radius="14px"></div>
+ *
+ * Only known tokens are honored; values are sanitized before they reach CSS variables.
+ */
+
+/** Public theme token → the CSS variable the widget reads. Whitelist (nothing else is applied). */
+export const THEME_TOKENS: Record<string, string> = {
+  primary: '--haip-primary', // brand / primary button background
+  accent: '--haip-accent', // secondary accents
+  onPrimary: '--haip-on-primary', // text/icon color on the primary button
+  font: '--haip-font', // font-family stack
+  radius: '--haip-radius', // corner radius (e.g. 14px, 0.5rem)
+  text: '--haip-text', // body text color
+  surface: '--haip-surface', // card/panel background
+};
+
+/** Strip characters that could break out of a CSS value. setProperty already rejects invalid
+ *  values, but we defensively drop `;`, braces, and control chars and cap length. */
+function sanitize(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = value.replace(/[;{}<>]/g, '').trim();
+  if (!cleaned || cleaned.length > 200) return null;
+  return cleaned;
+}
+
+const kebab = (s: string) => s.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+
+/**
+ * Resolve a theme from the mount element + the current embed <script>, returning a map of
+ * CSS-variable → value for the known, sanitized tokens. Element attributes win over the script's.
+ */
+export function resolveTheme(mountEl?: Element | null): Record<string, string> {
+  const out: Record<string, string> = {};
+
+  const sources: Array<Element | null> = [];
+  // Lower priority first; later sources override earlier.
+  if (typeof document !== 'undefined') {
+    sources.push((document.currentScript as HTMLScriptElement | null) ?? null);
+  }
+  sources.push(mountEl ?? null);
+
+  for (const el of sources) {
+    if (!el) continue;
+
+    // 1. JSON blob
+    const json = el.getAttribute?.('data-theme');
+    if (json) {
+      try {
+        const obj = JSON.parse(json) as Record<string, unknown>;
+        for (const [token, cssVar] of Object.entries(THEME_TOKENS)) {
+          const v = sanitize(obj[token]);
+          if (v) out[cssVar] = v;
+        }
+      } catch {
+        /* malformed JSON → ignore, fall through to individual attrs */
+      }
+    }
+
+    // 2. Individual data-theme-<token> attributes (override the JSON for the same source)
+    for (const [token, cssVar] of Object.entries(THEME_TOKENS)) {
+      const v = sanitize(el.getAttribute?.(`data-theme-${kebab(token)}`));
+      if (v) out[cssVar] = v;
+    }
+  }
+
+  return out;
+}
+
+/** Apply resolved CSS variables onto the widget's container (scoped — never the host page). */
+export function applyTheme(el: Element, vars: Record<string, string>): void {
+  const style = (el as HTMLElement).style;
+  if (!style) return;
+  for (const [cssVar, value] of Object.entries(vars)) {
+    style.setProperty(cssVar, value);
+  }
+}

--- a/apps/booking/src/mount.tsx
+++ b/apps/booking/src/mount.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from './lib/queryClient';
 import { setBookingKey } from './api/client';
 import { resolveBookingKey } from './lib/bookingKey';
+import { resolveTheme, applyTheme } from './lib/theme';
 import { ConfigProvider } from './context/ConfigContext';
 import { BookingFlowProvider } from './context/BookingFlowContext';
 import App from './App';
@@ -23,6 +24,11 @@ export function mountBooking(el: Element) {
 
   // Ensure the Tailwind important-scope class is present on the container.
   el.classList.add('haip-booking');
+
+  // Apply embed-time theme tokens (data-theme / data-theme-*) onto the container as scoped CSS
+  // variables, so the widget matches the host site. These take precedence over /config branding
+  // (set on :root) because the container is a closer ancestor of the widget's elements.
+  applyTheme(el, resolveTheme(el));
 
   createRoot(el).render(
     <StrictMode>

--- a/apps/booking/tailwind.config.ts
+++ b/apps/booking/tailwind.config.ts
@@ -15,15 +15,22 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Branding comes from /config at runtime via CSS variables; these are
-        // sensible fallbacks so the widget renders before config loads.
+        // Branding/theme comes from CSS variables at runtime (lib/theme.ts embed override +
+        // /config branding); these fallbacks let the widget render before either loads.
         brand: {
           primary: 'var(--haip-primary, #06bdb4)',
           accent: 'var(--haip-accent, #f2641b)',
+          'on-primary': 'var(--haip-on-primary, #ffffff)',
+          surface: 'var(--haip-surface, #ffffff)',
         },
       },
+      borderRadius: {
+        brand: 'var(--haip-radius, 0.375rem)',
+      },
       fontFamily: {
-        sans: ['Montserrat', 'Arial', 'Helvetica', 'sans-serif'],
+        // The widget's font is driven by --haip-font on .haip-booking; this keeps `font-sans`
+        // consistent for any explicit uses.
+        sans: ['var(--haip-font)', 'Montserrat', 'Arial', 'Helvetica', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
Remy Web foundation B1. The apps/booking widget already had the full search→quote→book flow, publishable-key auth, Stripe, embed script, and .haip-booking style scoping, but was themeable only by two colors (primary/accent) from /config. This adds an embed-time theme override so it matches any host site (Remy/v0 page, Webflow, custom).

- src/lib/theme.ts: resolveTheme() reads a data-theme JSON blob and/or data-theme-* attrs (whitelisted tokens: primary, accent, onPrimary, font, radius, text, surface; values sanitized). applyTheme() sets scoped CSS vars on the container (never the host page), taking precedence over /config branding.
- mount.tsx applies the theme at mount.
- index.css declares the full token contract with fallbacks; font + text color now variable-driven.
- tailwind: rounded-brand + brand.on-primary/surface; font-sans uses --haip-font.
- Button: radius + on-primary themeable.
- README: documents tokens + both embed forms.

Booking/payment logic untouched (trusted, never AI-generated). Tests: lib/theme.test.ts (9). Booking suite 13/13, typecheck + build green.

🤖 Generated with Claude Code