### PR TITLE
Fix folio payment ledger (refunds and corrections)

### DIFF
--- a/apps/api/src/modules/folio/folio-routing.service.spec.ts
+++ b/apps/api/src/modules/folio/folio-routing.service.spec.ts
@@ -49,15 +49,15 @@ const mockFolioService = {
 };
 
 function createMockDb(returnData: any[] = [mockReservation]) {
+  const whereResult = {
+    orderBy: vi.fn().mockResolvedValue([]),
+    for: vi.fn().mockResolvedValue(returnData),
+    then: (resolve: any) => resolve(returnData),
+  };
   const db: any = {
     select: vi.fn().mockImplementation(() => ({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockReturnValue({
-          // Routing-rule lookups call .orderBy() and resolve to [] (no rules);
-          // other lookups are awaited directly via .then().
-          orderBy: vi.fn().mockResolvedValue([]),
-          then: (resolve: any) => resolve(returnData),
-        }),
+        where: vi.fn().mockReturnValue(whereResult),
       }),
     })),
     insert: vi.fn().mockReturnValue({
@@ -380,7 +380,18 @@ describe('FolioRoutingService', () => {
 
   describe('transferToCityLedger', () => {
     it('should create city ledger folio and record payment on source', async () => {
-      const result = await service.transferToCityLedger('folio-001', 'prop-001', {
+      mockDb = createMockDb([mockFolio]);
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioRoutingService,
+          { provide: DRIZZLE, useValue: mockDb },
+          { provide: FolioService, useValue: mockFolioService },
+          { provide: WebhookService, useValue: mockWebhookService },
+        ],
+      }).compile();
+      const svc = module.get<FolioRoutingService>(FolioRoutingService);
+
+      const result = await svc.transferToCityLedger('folio-001', 'prop-001', {
         companyName: 'Acme Corp',
         paymentTermsDays: 'NET30',
       });
@@ -391,8 +402,9 @@ describe('FolioRoutingService', () => {
           companyName: 'Acme Corp',
           paymentTermsDays: 'NET30',
         }),
-        expect.anything(), // Bug 3: now called inside db.transaction with tx
+        expect.anything(),
       );
+      expect(mockFolioService.recalculateBalance).toHaveBeenCalled();
       expect(result.transferredAmount).toBe('300.00');
       expect(result.cityLedgerFolioId).toBe('folio-cl-001');
     });

--- a/apps/api/src/modules/folio/folio-routing.service.ts
+++ b/apps/api/src/modules/folio/folio-routing.service.ts
@@ -265,21 +265,32 @@ export class FolioRoutingService {
     propertyId: string,
     dto: TransferCityLedgerDto,
   ) {
-    const sourceFolio = await this.folioService.findById(folioId, propertyId);
-    // Monetary compare on string representation via decimal.js (numeric-as-string).
-    const remainingBalance = new Decimal(sourceFolio.balance);
+    const result = await this.db.transaction(async (tx: any) => {
+      const [sourceFolio] = await tx
+        .select()
+        .from(folios)
+        .where(and(eq(folios.id, folioId), eq(folios.propertyId, propertyId)))
+        .for('update');
 
-    if (remainingBalance.lte(0)) {
-      return { message: 'No outstanding balance to transfer' };
-    }
+      if (!sourceFolio) {
+        throw new NotFoundException(`Folio ${folioId} not found`);
+      }
 
-    const amountStr = remainingBalance.toFixed(2);
+      await this.folioService.recalculateBalance(folioId, propertyId, tx);
 
-    // Bug 3: wrap all mutating steps in a single transaction so partial failure
-    // (e.g. CL folio created but payment insert fails) is impossible.
-    // Idempotency-by-transferId is out of scope for this PR.
-    const { cityLedgerFolio } = await this.db.transaction(async (tx: any) => {
-      // Create city ledger folio
+      const [refreshed] = await tx
+        .select()
+        .from(folios)
+        .where(and(eq(folios.id, folioId), eq(folios.propertyId, propertyId)));
+
+      const remainingBalance = new Decimal(refreshed?.balance ?? '0');
+
+      if (remainingBalance.lte(0)) {
+        return { message: 'No outstanding balance to transfer' as const };
+      }
+
+      const amountStr = remainingBalance.toFixed(2);
+
       const cityLedgerFolio = await this.folioService.create(
         {
           propertyId,
@@ -293,7 +304,6 @@ export class FolioRoutingService {
         tx,
       );
 
-      // Record city_ledger payment on the source folio (zeroes out the guest folio)
       await tx
         .insert(payments)
         .values({
@@ -309,7 +319,6 @@ export class FolioRoutingService {
 
       await this.folioService.recalculateBalance(folioId, propertyId, tx);
 
-      // Post matching charge on the city ledger folio
       await this.folioService.postCharge(
         cityLedgerFolio.id,
         {
@@ -323,13 +332,21 @@ export class FolioRoutingService {
         tx,
       );
 
-      return { cityLedgerFolio };
+      return {
+        cityLedgerFolio,
+        amountStr,
+        sourceFolioId: folioId,
+      };
     });
 
+    if ('message' in result) {
+      return result;
+    }
+
     return {
-      sourceFolioId: folioId,
-      cityLedgerFolioId: cityLedgerFolio.id,
-      transferredAmount: amountStr,
+      sourceFolioId: result.sourceFolioId,
+      cityLedgerFolioId: result.cityLedgerFolio.id,
+      transferredAmount: result.amountStr,
     };
   }
 }

--- a/apps/api/src/modules/folio/folio.service.spec.ts
+++ b/apps/api/src/modules/folio/folio.service.spec.ts
@@ -400,4 +400,44 @@ describe('FolioService', () => {
       expect(parseFloat(result.amount)).toBeLessThan(0);
     });
   });
+
+  describe('recalculateBalance', () => {
+    it('nets a captured parent with a negative refund child', async () => {
+      let selectCall = 0;
+      const db = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => {
+                selectCall++;
+                if (selectCall === 1) resolve([{ total: '100.00' }]);
+                else resolve([{ total: '50.00' }]);
+              },
+            }),
+          }),
+        })),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      await svc.recalculateBalance('folio-001', 'prop-001');
+
+      const setCall = db.update.mock.results[0].value.set.mock.calls[0][0];
+      expect(setCall.totalPayments).toBe('50.00');
+      expect(setCall.balance).toBe('50.00');
+    });
+  });
 });

--- a/apps/api/src/modules/folio/folio.service.ts
+++ b/apps/api/src/modules/folio/folio.service.ts
@@ -8,6 +8,7 @@ import { eq, and, sql, gte, lte } from 'drizzle-orm';
 import Decimal from 'decimal.js';
 import { folios, charges, payments, reservations, bookings } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
+import { folioPaymentSumWhere } from '../payment/payment-ledger';
 import { WebhookService } from '../webhook/webhook.service';
 import { TaxService } from '../tax/tax.service';
 import { CreateFolioDto } from './dto/create-folio.dto';
@@ -265,13 +266,7 @@ export class FolioService {
         total: sql<string>`coalesce(sum(${payments.amount}::numeric), 0)`,
       })
       .from(payments)
-      .where(
-        and(
-          eq(payments.folioId, folioId),
-          eq(payments.propertyId, propertyId),
-          eq(payments.status, 'captured'),
-        ),
-      );
+      .where(folioPaymentSumWhere(folioId, propertyId));
 
     // Monetary math: operate on string representations via decimal.js to
     // preserve precision (postgres numeric returns strings).

--- a/apps/api/src/modules/payment/payment-correction.spec.ts
+++ b/apps/api/src/modules/payment/payment-correction.spec.ts
@@ -116,28 +116,30 @@ describe('PaymentService.correctPayment (correction matrix, KB 14.1)', () => {
 
   it('refunds a captured card payment', async () => {
     const payment = { ...basePayment, status: 'captured', method: 'credit_card' };
-    let selectCall = 0;
-    const tx = {
-      select: vi.fn().mockImplementation(() => ({
-        from: vi.fn().mockReturnValue({
-          where: vi.fn().mockImplementation(() => {
-            selectCall++;
-            if (selectCall === 1) {
-              return { for: vi.fn().mockResolvedValue([payment]) };
-            }
-            return { then: (resolve: any) => resolve([]) };
+    const makeTx = () => {
+      let selectCall = 0;
+      return {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              selectCall++;
+              if (selectCall === 1) {
+                return { for: vi.fn().mockResolvedValue([payment]) };
+              }
+              return { then: (resolve: any) => resolve([]) };
+            }),
+          }),
+        })),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([{ id: 'rfd-row', status: 'captured' }]),
           }),
         }),
-      })),
+      };
     };
     const db = {
       select: vi.fn().mockImplementation(chainResolving([payment])),
-      transaction: vi.fn(async (fn: any) => fn(tx)),
-      insert: vi.fn().mockReturnValue({
-        values: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([{ id: 'rfd-row', status: 'captured' }]),
-        }),
-      }),
+      transaction: vi.fn(async (fn: any) => fn(makeTx())),
       update: vi.fn(),
       delete: vi.fn(),
     };

--- a/apps/api/src/modules/payment/payment-correction.spec.ts
+++ b/apps/api/src/modules/payment/payment-correction.spec.ts
@@ -116,28 +116,29 @@ describe('PaymentService.correctPayment (correction matrix, KB 14.1)', () => {
 
   it('refunds a captured card payment', async () => {
     const payment = { ...basePayment, status: 'captured', method: 'credit_card' };
-    // refundPayment loads original (select), computes existing refunds (select -> []),
-    // claims (update returning), then gateway.refund, then insert refund row.
-    const selectImpls = [
-      chainResolving([payment])(), // correctPayment.findById
-      chainResolving([payment])(), // refundPayment load original
-      chainResolving([])(), // existing refunds
-    ];
-    let call = 0;
+    let selectCall = 0;
+    const tx = {
+      select: vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            selectCall++;
+            if (selectCall === 1) {
+              return { for: vi.fn().mockResolvedValue([payment]) };
+            }
+            return { then: (resolve: any) => resolve([]) };
+          }),
+        }),
+      })),
+    };
     const db = {
-      select: vi.fn().mockImplementation(() => selectImpls[call++] ?? chainResolving([])()),
+      select: vi.fn().mockImplementation(chainResolving([payment])),
+      transaction: vi.fn(async (fn: any) => fn(tx)),
       insert: vi.fn().mockReturnValue({
         values: vi.fn().mockReturnValue({
           returning: vi.fn().mockResolvedValue([{ id: 'rfd-row', status: 'captured' }]),
         }),
       }),
-      update: vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([{ ...payment, status: 'refunded' }]),
-          }),
-        }),
-      }),
+      update: vi.fn(),
       delete: vi.fn(),
     };
     const svc = await buildService(db);
@@ -146,26 +147,52 @@ describe('PaymentService.correctPayment (correction matrix, KB 14.1)', () => {
     expect(mockGateway.refund).toHaveBeenCalled();
   });
 
-  it('adjusts an old cash payment via a compensating negative charge', async () => {
+  it('adjusts an old cash payment via a negative payment child', async () => {
     const payment = {
       ...basePayment,
       method: 'cash',
       status: 'captured',
       gatewayTransactionId: null,
-      createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000), // 48h ago, past window
+      createdAt: new Date(Date.now() - 48 * 60 * 60 * 1000),
     };
-    const svc = await buildService(buildDb(payment));
+    const adjustmentRow = {
+      id: 'adj-pay-001',
+      amount: '-100.00',
+      originalPaymentId: 'pay-001',
+      status: 'captured',
+    };
+    const tx = {
+      select: vi.fn().mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            for: vi.fn().mockResolvedValue([payment]),
+          }),
+        }),
+      })),
+      insert: vi.fn().mockReturnValue({
+        values: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([adjustmentRow]),
+        }),
+      }),
+    };
+    const db = {
+      select: vi.fn().mockImplementation(chainResolving([payment])),
+      transaction: vi.fn(async (fn: any) => fn(tx)),
+      insert: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    };
+    const svc = await buildService(db);
     const result = await svc.correctPayment('pay-001', 'prop-001');
     expect(result.op).toBe('adjust');
-    expect(mockFolioService.postCharge).toHaveBeenCalledWith(
-      'folio-001',
-      expect.objectContaining({ type: 'adjustment', amount: '-100.00', skipTaxCalculation: true }),
-    );
+    expect(tx.insert).toHaveBeenCalled();
+    expect(mockFolioService.postCharge).not.toHaveBeenCalled();
+    expect(mockFolioService.recalculateBalance).toHaveBeenCalledWith('folio-001', 'prop-001', tx);
     expect(mockWebhookService.emit).toHaveBeenCalledWith(
       'payment.corrected',
       'payment',
       'pay-001',
-      expect.objectContaining({ op: 'adjust' }),
+      expect.objectContaining({ op: 'adjust', adjustmentAmount: '-100.00' }),
       'prop-001',
     );
   });

--- a/apps/api/src/modules/payment/payment-ledger.spec.ts
+++ b/apps/api/src/modules/payment/payment-ledger.spec.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { sumRefundChildren } from './payment-ledger';
+
+describe('payment-ledger', () => {
+  describe('sumRefundChildren', () => {
+    it('sums absolute values of refund child amounts', () => {
+      const total = sumRefundChildren([
+        { amount: '-50.00' },
+        { amount: '-30.00' },
+      ]);
+      expect(total.toFixed(2)).toBe('80.00');
+    });
+
+    it('returns zero when there are no children', () => {
+      expect(sumRefundChildren([]).toFixed(2)).toBe('0.00');
+    });
+  });
+});

--- a/apps/api/src/modules/payment/payment-ledger.ts
+++ b/apps/api/src/modules/payment/payment-ledger.ts
@@ -19,6 +19,11 @@ export const FOLIO_PARENT_PAYMENT_STATUSES = [
   'refunded',
 ] as const;
 
+/** Parent payment statuses whose positive amount is included in folio net math. */
+export function parentCountsTowardFolioBalance(status: string): boolean {
+  return (FOLIO_PARENT_PAYMENT_STATUSES as readonly string[]).includes(status);
+}
+
 /** Payment rows that count toward a folio balance. */
 export function folioPaymentSumWhere(
   folioId: string,

--- a/apps/api/src/modules/payment/payment-ledger.ts
+++ b/apps/api/src/modules/payment/payment-ledger.ts
@@ -1,0 +1,62 @@
+import { and, eq, inArray, isNull, or, type SQL } from 'drizzle-orm';
+import { payments } from '@telivityhaip/database';
+import Decimal from 'decimal.js';
+
+/**
+ * Net folio / cash-report payment ledger:
+ *
+ * - Parent tenders stay `captured` (or `settled`); refunds and payment corrections
+ *   are negative child rows, also `captured`, linked via `originalPaymentId`.
+ * - Do not flip the parent to `refunded` / `partially_refunded` for balance math —
+ *   that drops the positive amount while the negative child remains.
+ * - Legacy parents still marked `partially_refunded` / `refunded` (pre-fix rows)
+ *   remain summable so recalculate heals existing data.
+ */
+export const FOLIO_PARENT_PAYMENT_STATUSES = [
+  'captured',
+  'settled',
+  'partially_refunded',
+  'refunded',
+] as const;
+
+/** Payment rows that count toward a folio balance. */
+export function folioPaymentSumWhere(
+  folioId: string,
+  propertyId: string,
+): SQL {
+  return and(
+    eq(payments.folioId, folioId),
+    eq(payments.propertyId, propertyId),
+    or(
+      eq(payments.status, 'captured'),
+      and(
+        isNull(payments.originalPaymentId),
+        inArray(payments.status, [...FOLIO_PARENT_PAYMENT_STATUSES]),
+      ),
+    ),
+  )!;
+}
+
+/** Payment rows that count toward property-scoped cash reports (same net model). */
+export function reportPaymentSumWhere(propertyId: string): SQL {
+  return and(
+    eq(payments.propertyId, propertyId),
+    or(
+      eq(payments.status, 'captured'),
+      and(
+        isNull(payments.originalPaymentId),
+        inArray(payments.status, [...FOLIO_PARENT_PAYMENT_STATUSES]),
+      ),
+    ),
+  )!;
+}
+
+/** Sum refund / correction child rows already posted against a parent payment. */
+export function sumRefundChildren(
+  rows: Array<{ amount: string | number }>,
+): Decimal {
+  return rows.reduce(
+    (sum, r) => sum.plus(new Decimal(r.amount).abs()),
+    new Decimal(0),
+  );
+}

--- a/apps/api/src/modules/payment/payment.service.spec.ts
+++ b/apps/api/src/modules/payment/payment.service.spec.ts
@@ -334,27 +334,31 @@ describe('PaymentService', () => {
     it('should create a negative refund child without flipping parent status', async () => {
       const capturedPayment = { ...mockPayment, status: 'captured' };
       const refundPayment = { ...mockPayment, id: 'pay-002', amount: '-150.00', originalPaymentId: 'pay-001' };
-      let selectCall = 0;
-      const tx = {
-        select: vi.fn().mockImplementation(() => ({
-          from: vi.fn().mockReturnValue({
-            where: vi.fn().mockImplementation(() => {
-              selectCall++;
-              if (selectCall === 1) {
-                return { for: vi.fn().mockResolvedValue([capturedPayment]) };
-              }
-              return { then: (resolve: any) => resolve([]) };
+      let txRound = 0;
+      const makeTx = () => {
+        txRound++;
+        let selectCall = 0;
+        return {
+          select: vi.fn().mockImplementation(() => ({
+            from: vi.fn().mockReturnValue({
+              where: vi.fn().mockImplementation(() => {
+                selectCall++;
+                if (selectCall === 1) {
+                  return { for: vi.fn().mockResolvedValue([capturedPayment]) };
+                }
+                return { then: (resolve: any) => resolve([]) };
+              }),
+            }),
+          })),
+          insert: vi.fn().mockReturnValue({
+            values: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([refundPayment]),
             }),
           }),
-        })),
+        };
       };
       const db = {
-        transaction: vi.fn(async (fn: any) => fn(tx)),
-        insert: vi.fn().mockReturnValue({
-          values: vi.fn().mockReturnValue({
-            returning: vi.fn().mockResolvedValue([refundPayment]),
-          }),
-        }),
+        transaction: vi.fn(async (fn: any) => fn(makeTx())),
         update: vi.fn(),
         delete: vi.fn(),
       };
@@ -391,31 +395,33 @@ describe('PaymentService', () => {
         priorRefunds: any[],
         insertedRefund: any,
       ) {
-        let selectCall = 0;
-        const tx = {
-          select: vi.fn().mockImplementation(() => ({
-            from: vi.fn().mockReturnValue({
-              where: vi.fn().mockImplementation(() => {
-                selectCall++;
-                if (selectCall === 1) {
+        const makeTx = () => {
+          let selectCall = 0;
+          return {
+            select: vi.fn().mockImplementation(() => ({
+              from: vi.fn().mockReturnValue({
+                where: vi.fn().mockImplementation(() => {
+                  selectCall++;
+                  if (selectCall === 1) {
+                    return {
+                      for: vi.fn().mockResolvedValue([original]),
+                    };
+                  }
                   return {
-                    for: vi.fn().mockResolvedValue([original]),
+                    then: (resolve: any) => resolve(priorRefunds),
                   };
-                }
-                return {
-                  then: (resolve: any) => resolve(priorRefunds),
-                };
+                }),
+              }),
+            })),
+            insert: vi.fn().mockReturnValue({
+              values: vi.fn().mockReturnValue({
+                returning: vi.fn().mockResolvedValue([insertedRefund]),
               }),
             }),
-          })),
+          };
         };
         return {
-          transaction: vi.fn(async (fn: any) => fn(tx)),
-          insert: vi.fn().mockReturnValue({
-            values: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([insertedRefund]),
-            }),
-          }),
+          transaction: vi.fn(async (fn: any) => fn(makeTx())),
           update: vi.fn(),
           delete: vi.fn(),
         };
@@ -446,7 +452,7 @@ describe('PaymentService', () => {
         const svc = await svcWith(db);
         await svc.refundPayment('pay-001', 'prop-001', '50.00');
         expect(db.update).not.toHaveBeenCalled();
-        expect(db.insert).toHaveBeenCalled();
+        expect(db.transaction).toHaveBeenCalled();
       });
 
       it('second partial refund on a legacy partially_refunded parent works', async () => {
@@ -471,7 +477,7 @@ describe('PaymentService', () => {
         );
         const svc = await svcWith(db);
         await svc.refundPayment('pay-001', 'prop-001', '20.00');
-        expect(db.insert).toHaveBeenCalled();
+        expect(db.transaction).toHaveBeenCalled();
       });
 
       it('rejects a refund that would exceed remaining refundable amount', async () => {

--- a/apps/api/src/modules/payment/payment.service.spec.ts
+++ b/apps/api/src/modules/payment/payment.service.spec.ts
@@ -331,33 +331,31 @@ describe('PaymentService', () => {
   });
 
   describe('refundPayment', () => {
-    it('should create refund record and update original payment', async () => {
+    it('should create a negative refund child without flipping parent status', async () => {
       const capturedPayment = { ...mockPayment, status: 'captured' };
       const refundPayment = { ...mockPayment, id: 'pay-002', amount: '-150.00', originalPaymentId: 'pay-001' };
-      let selectCallCount = 0;
-      const db = {
+      let selectCall = 0;
+      const tx = {
         select: vi.fn().mockImplementation(() => ({
           from: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              then: (resolve: any) => {
-                selectCallCount++;
-                resolve(selectCallCount === 1 ? [capturedPayment] : []);
-              },
+            where: vi.fn().mockImplementation(() => {
+              selectCall++;
+              if (selectCall === 1) {
+                return { for: vi.fn().mockResolvedValue([capturedPayment]) };
+              }
+              return { then: (resolve: any) => resolve([]) };
             }),
           }),
         })),
+      };
+      const db = {
+        transaction: vi.fn(async (fn: any) => fn(tx)),
         insert: vi.fn().mockReturnValue({
           values: vi.fn().mockReturnValue({
             returning: vi.fn().mockResolvedValue([refundPayment]),
           }),
         }),
-        update: vi.fn().mockReturnValue({
-          set: vi.fn().mockReturnValue({
-            where: vi.fn().mockReturnValue({
-              returning: vi.fn().mockResolvedValue([{ ...capturedPayment, status: 'refunded' }]),
-            }),
-          }),
-        }),
+        update: vi.fn(),
         delete: vi.fn(),
       };
 
@@ -373,6 +371,7 @@ describe('PaymentService', () => {
       const svc = module.get<PaymentService>(PaymentService);
 
       const result = await svc.refundPayment('pay-001', 'prop-001');
+      expect(db.update).not.toHaveBeenCalled();
       expect(mockGateway.refund).toHaveBeenCalled();
       expect(mockFolioService.recalculateBalance).toHaveBeenCalled();
       expect(mockWebhookService.emit).toHaveBeenCalledWith(
@@ -385,43 +384,39 @@ describe('PaymentService', () => {
       expect(result).toEqual(refundPayment);
     });
 
-    // Bug 3: partial refunds were one-shot only because:
-    //  1. Entry was restricted to captured/settled (partially_refunded couldn't refund)
-    //  2. Stripe idempotency key was `ref_${id}` — same for every partial
-    //  3. There was no remaining-amount check against prior refunds
-    describe('multi-refund partial scenario (Bug 3)', () => {
-      function buildRefundDb(
+    // Partial refunds: parent stays captured; negative children net the folio balance.
+    describe('multi-refund partial scenario', () => {
+      function buildRefundTxDb(
         original: any,
         priorRefunds: any[],
-        claimResult: any[],
         insertedRefund: any,
       ) {
         let selectCall = 0;
-        return {
+        const tx = {
           select: vi.fn().mockImplementation(() => ({
             from: vi.fn().mockReturnValue({
-              where: vi.fn().mockReturnValue({
-                then: (resolve: any) => {
-                  selectCall++;
-                  // Order: 1=original lookup, 2=prior refunds sum
-                  if (selectCall === 1) resolve([original]);
-                  else resolve(priorRefunds);
-                },
+              where: vi.fn().mockImplementation(() => {
+                selectCall++;
+                if (selectCall === 1) {
+                  return {
+                    for: vi.fn().mockResolvedValue([original]),
+                  };
+                }
+                return {
+                  then: (resolve: any) => resolve(priorRefunds),
+                };
               }),
             }),
           })),
+        };
+        return {
+          transaction: vi.fn(async (fn: any) => fn(tx)),
           insert: vi.fn().mockReturnValue({
             values: vi.fn().mockReturnValue({
               returning: vi.fn().mockResolvedValue([insertedRefund]),
             }),
           }),
-          update: vi.fn().mockReturnValue({
-            set: vi.fn().mockReturnValue({
-              where: vi.fn().mockReturnValue({
-                returning: vi.fn().mockResolvedValue(claimResult),
-              }),
-            }),
-          }),
+          update: vi.fn(),
           delete: vi.fn(),
         };
       }
@@ -442,25 +437,22 @@ describe('PaymentService', () => {
       const capturedOriginal = { ...mockPayment, amount: '100.00', status: 'captured' };
       const partialOriginal = { ...mockPayment, amount: '100.00', status: 'partially_refunded' };
 
-      it('first partial refund: $50 of $100 transitions to partially_refunded', async () => {
-        const db = buildRefundDb(
+      it('first partial refund inserts a negative child without flipping parent status', async () => {
+        const db = buildRefundTxDb(
           capturedOriginal,
-          [], // no prior refunds
-          [{ ...capturedOriginal, status: 'partially_refunded' }],
+          [],
           { id: 'refund-1', amount: '-50.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
         await svc.refundPayment('pay-001', 'prop-001', '50.00');
-        // UPDATE targeted partially_refunded
-        const setCall = db.update.mock.results[0].value.set.mock.calls[0][0];
-        expect(setCall.status).toBe('partially_refunded');
+        expect(db.update).not.toHaveBeenCalled();
+        expect(db.insert).toHaveBeenCalled();
       });
 
-      it('second partial refund: $30 on top of an existing $50 partial works', async () => {
-        const db = buildRefundDb(
-          partialOriginal, // already partially_refunded
+      it('second partial refund on a legacy partially_refunded parent works', async () => {
+        const db = buildRefundTxDb(
+          partialOriginal,
           [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
-          [{ ...partialOriginal, status: 'partially_refunded' }],
           { id: 'refund-2', amount: '-30.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
@@ -468,29 +460,24 @@ describe('PaymentService', () => {
         expect(mockGateway.refund).toHaveBeenCalled();
       });
 
-      it('final refund that closes the gap transitions to fully refunded', async () => {
-        // $100 - $50 - $30 = $20 remaining, refund $20 → status=refunded
-        const db = buildRefundDb(
+      it('final partial refund that closes the gap succeeds', async () => {
+        const db = buildRefundTxDb(
           partialOriginal,
           [
             { amount: '-50.00', originalPaymentId: 'pay-001' },
             { amount: '-30.00', originalPaymentId: 'pay-001' },
           ],
-          [{ ...partialOriginal, status: 'refunded' }],
           { id: 'refund-3', amount: '-20.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
         await svc.refundPayment('pay-001', 'prop-001', '20.00');
-        const setCall = db.update.mock.results[0].value.set.mock.calls[0][0];
-        expect(setCall.status).toBe('refunded');
+        expect(db.insert).toHaveBeenCalled();
       });
 
       it('rejects a refund that would exceed remaining refundable amount', async () => {
-        // $100 - $50 already = $50 remaining. Attempt $60 → BadRequest.
-        const db = buildRefundDb(
+        const db = buildRefundTxDb(
           partialOriginal,
           [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
-          [], // unreachable
           { id: 'unreachable' } as any,
         );
         const svc = await svcWith(db);
@@ -500,22 +487,18 @@ describe('PaymentService', () => {
       });
 
       it('uses a unique idempotency key per partial so Stripe does not dedupe different refunds', async () => {
-        // First partial
-        const db1 = buildRefundDb(
+        const db1 = buildRefundTxDb(
           capturedOriginal,
           [],
-          [{ ...capturedOriginal, status: 'partially_refunded' }],
           { id: 'refund-1', amount: '-50.00', originalPaymentId: 'pay-001' },
         );
         const svc1 = await svcWith(db1);
         await svc1.refundPayment('pay-001', 'prop-001', '50.00');
         const key1 = mockGateway.refund.mock.calls[mockGateway.refund.mock.calls.length - 1][2].idempotencyKey;
 
-        // Second partial on top — should use a different key
-        const db2 = buildRefundDb(
+        const db2 = buildRefundTxDb(
           partialOriginal,
           [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
-          [{ ...partialOriginal, status: 'partially_refunded' }],
           { id: 'refund-2', amount: '-30.00', originalPaymentId: 'pay-001' },
         );
         const svc2 = await svcWith(db2);

--- a/apps/api/src/modules/payment/payment.service.ts
+++ b/apps/api/src/modules/payment/payment.service.ts
@@ -15,7 +15,7 @@ import { PAYMENT_GATEWAY } from './interfaces/payment-gateway.interface';
 import type { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { AuthorizePaymentDto } from './dto/authorize-payment.dto';
-import { ListPaymentsDto } from './dto/list-payments.dto';
+import { sumRefundChildren } from './payment-ledger';
 
 const CARD_METHODS = ['credit_card', 'debit_card', 'vcc'];
 
@@ -273,115 +273,74 @@ export class PaymentService {
   /**
    * Refund a captured/settled payment.
    *
-   * Two-phase concurrency-safe flow:
-   *  1. Conditional UPDATE claims the original payment by transitioning its
-   *     status to `refunded` or `partially_refunded`. A status guard on
-   *     `captured`/`settled` ensures only one concurrent request succeeds.
-   *  2. Stripe call happens outside the DB tx with an idempotency key.
-   *     On failure, revert the status to what it was.
+   * Parent row stays `captured` (or `settled`); net folio effect comes from a
+   * negative child row. Row lock serializes concurrent partial refunds.
    */
   async refundPayment(id: string, propertyId: string, amount?: string) {
-    // Load the original payment to decide partial vs full and sanity check status
-    const [original] = await this.db
-      .select()
-      .from(payments)
-      .where(and(eq(payments.id, id), eq(payments.propertyId, propertyId)));
+    const prepared = await this.db.transaction(async (tx: any) => {
+      const [original] = await tx
+        .select()
+        .from(payments)
+        .where(and(eq(payments.id, id), eq(payments.propertyId, propertyId)))
+        .for('update');
 
-    if (!original) {
-      throw new NotFoundException(`Payment ${id} not found`);
-    }
-    // Bug 3: allow multiple partial refunds — entry from captured, settled,
-    // AND partially_refunded. Only `refunded` (fully refunded) is terminal.
-    if (!['captured', 'settled', 'partially_refunded'].includes(original.status)) {
-      throw new BadRequestException(
-        `Cannot refund payment with status '${original.status}'`,
-      );
-    }
+      if (!original) {
+        throw new NotFoundException(`Payment ${id} not found`);
+      }
 
-    const refundAmount = amount ?? original.amount;
-    // Money math via decimal.js — keep as strings everywhere
-    const refundAmountDec = new Decimal(refundAmount);
-    const originalAmountDec = new Decimal(original.amount);
-    if (refundAmountDec.lte(0)) {
-      throw new BadRequestException('Refund amount must be positive');
-    }
+      if (!['captured', 'settled', 'partially_refunded'].includes(original.status)) {
+        throw new BadRequestException(
+          `Cannot refund payment with status '${original.status}'`,
+        );
+      }
 
-    // Bug 3: sum existing refunds to compute remaining refundable amount.
-    // Refund rows live in the same `payments` table with originalPaymentId
-    // pointing back to the captured payment, stored as negative amounts.
-    const existingRefunds = await this.db
-      .select()
-      .from(payments)
-      .where(
-        and(
-          eq(payments.originalPaymentId, id),
-          eq(payments.propertyId, propertyId),
-        ),
-      );
-    const alreadyRefundedDec = (existingRefunds ?? []).reduce(
-      (sum: Decimal, r: any) => sum.plus(new Decimal(r.amount).abs()),
-      new Decimal(0),
-    );
-    const remainingDec = originalAmountDec.minus(alreadyRefundedDec);
+      const refundAmount = amount ?? original.amount;
+      const refundAmountInTx = new Decimal(refundAmount);
+      const originalAmountDec = new Decimal(original.amount);
+      if (refundAmountInTx.lte(0)) {
+        throw new BadRequestException('Refund amount must be positive');
+      }
 
-    if (refundAmountDec.gt(remainingDec)) {
-      throw new BadRequestException(
-        `Refund amount ${refundAmountDec.toFixed(2)} exceeds remaining refundable amount ${remainingDec.toFixed(2)}`,
-      );
-    }
+      const existingRefunds = await tx
+        .select()
+        .from(payments)
+        .where(
+          and(
+            eq(payments.originalPaymentId, id),
+            eq(payments.propertyId, propertyId),
+          ),
+        );
+      const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
+      const remainingDec = originalAmountDec.minus(alreadyRefundedDec);
 
-    // After this refund, will the total reach the original? If so, mark the
-    // original fully refunded; otherwise leave (or set) to partially_refunded.
-    const totalAfterDec = alreadyRefundedDec.plus(refundAmountDec);
-    const fullyRefundedAfter = totalAfterDec.gte(originalAmountDec);
-    const newStatus = fullyRefundedAfter ? 'refunded' : 'partially_refunded';
-    const prevStatus = original.status;
+      if (remainingDec.lte(0)) {
+        throw new BadRequestException(`Payment ${id} is already fully refunded`);
+      }
 
-    // Phase 1: atomically claim the original by transitioning its status.
-    // Accept prevStatus of captured/settled/partially_refunded. A second
-    // refund still races safely because the guard requires the exact
-    // prevStatus we read — if another refund just landed, our claim fails.
-    const [claimed] = await this.db
-      .update(payments)
-      .set({ status: newStatus, updatedAt: new Date() })
-      .where(
-        and(
-          eq(payments.id, id),
-          eq(payments.propertyId, propertyId),
-          eq(payments.status, prevStatus),
-        ),
-      )
-      .returning();
+      if (refundAmountInTx.gt(remainingDec)) {
+        throw new BadRequestException(
+          `Refund amount ${refundAmountInTx.toFixed(2)} exceeds remaining refundable amount ${remainingDec.toFixed(2)}`,
+        );
+      }
 
-    if (!claimed) {
-      throw new ConflictException(
-        `Payment ${id} is no longer in '${prevStatus}' state — concurrent refund?`,
-      );
-    }
+      const totalAfterDec = alreadyRefundedDec.plus(refundAmountInTx);
+      return { original, totalAfterDec, refundAmountDec: refundAmountInTx };
+    });
 
-    // Phase 2: call Stripe with a UNIQUE idempotency key per refund attempt.
-    // Bug 3: the previous `ref_${id}` key caused Stripe to dedupe the second
-    // partial refund against the first. Include the running total so each
-    // partial refund gets a distinct key while a retry of the same logical
-    // refund (same running total) is still deduped.
+    const { original, totalAfterDec, refundAmountDec: refundDec } = prepared;
+
     const idempotencyKey = `ref_${id}_${totalAfterDec.toFixed(2)}`;
     const result = await this.gateway.refund(
       original.gatewayTransactionId,
-      refundAmountDec.toNumber(),
+      refundDec.toNumber(),
       { idempotencyKey },
     );
 
     if (!result.success) {
-      // Revert status
-      await this.db
-        .update(payments)
-        .set({ status: prevStatus, updatedAt: new Date() })
-        .where(and(eq(payments.id, id), eq(payments.propertyId, propertyId)));
       throw new BadRequestException(`Refund failed: ${result.errorMessage}`);
     }
 
-    // Create refund payment record (negative amount via decimal.js)
-    const refundRowAmount = refundAmountDec.negated().toFixed(2);
+    const refundRowAmount = refundDec.negated().toFixed(2);
     const [refund] = await this.db
       .insert(payments)
       .values({
@@ -405,7 +364,7 @@ export class PaymentService {
       'payment.refunded',
       'payment',
       refund.id,
-      { folioId: original.folioId, originalPaymentId: id, refundAmount },
+      { folioId: original.folioId, originalPaymentId: id, refundAmount: refundDec.toFixed(2) },
       propertyId,
     );
 
@@ -420,7 +379,7 @@ export class PaymentService {
    *  - `cash` within 24h void window                     → VOID (no gateway call)
    *  - captured/settled/partially_refunded card payment  → REFUND only
    *  - otherwise (cash past window, record-only tenders)  → ADJUST
-   *    (compensating negative adjustment charge on the folio)
+   *    (negative payment child row on the folio, same ledger model as refunds)
    *
    * [ASSUMPTION KB 14.1] cash void window = 24h / same business day.
    */
@@ -526,30 +485,52 @@ export class PaymentService {
       return { op: 'refund', refund: result };
     }
 
-    // op === 'adjust': post a compensating negative adjustment charge to the folio.
+    // op === 'adjust': negative payment child (same ledger model as refunds).
     if (!payment.folioId) {
       throw new BadRequestException(
         `Cannot adjust payment ${id}: it is not linked to a folio`,
       );
     }
-    const adjustmentAmount = new Decimal(payment.amount).negated().toFixed(2);
-    const charge = await this.folioService.postCharge(payment.folioId, {
-      propertyId,
-      type: 'adjustment',
-      description: `Correction of payment ${id}`,
-      amount: adjustmentAmount,
-      currencyCode: payment.currencyCode,
-      serviceDate: new Date().toISOString(),
-      skipTaxCalculation: true,
+
+    const adjustment = await this.db.transaction(async (tx: any) => {
+      const [locked] = await tx
+        .select()
+        .from(payments)
+        .where(and(eq(payments.id, id), eq(payments.propertyId, propertyId)))
+        .for('update');
+
+      if (!locked) {
+        throw new NotFoundException(`Payment ${id} not found`);
+      }
+
+      const adjustmentAmount = new Decimal(locked.amount).negated().toFixed(2);
+      const [row] = await tx
+        .insert(payments)
+        .values({
+          folioId: locked.folioId,
+          propertyId,
+          method: locked.method,
+          amount: adjustmentAmount,
+          currencyCode: locked.currencyCode,
+          status: 'captured',
+          originalPaymentId: id,
+          processedAt: new Date(),
+          notes: `Correction of payment ${id}`,
+        })
+        .returning();
+
+      await this.folioService.recalculateBalance(locked.folioId!, propertyId, tx);
+      return { row, adjustmentAmount };
     });
+
     await this.webhookService.emit(
       'payment.corrected',
       'payment',
       id,
-      { op: 'adjust', method: payment.method, adjustmentAmount },
+      { op: 'adjust', method: payment.method, adjustmentAmount: adjustment.adjustmentAmount },
       propertyId,
     );
-    return { op: 'adjust', adjustment: charge };
+    return { op: 'adjust', adjustment: adjustment.row };
   }
 
   async findById(id: string, propertyId: string) {

--- a/apps/api/src/modules/payment/payment.service.ts
+++ b/apps/api/src/modules/payment/payment.service.ts
@@ -16,7 +16,7 @@ import type { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { AuthorizePaymentDto } from './dto/authorize-payment.dto';
 import { ListPaymentsDto } from './dto/list-payments.dto';
-import { sumRefundChildren } from './payment-ledger';
+import { sumRefundChildren, parentCountsTowardFolioBalance } from './payment-ledger';
 
 const CARD_METHODS = ['credit_card', 'debit_card', 'vcc'];
 
@@ -342,34 +342,90 @@ export class PaymentService {
     }
 
     const refundRowAmount = refundDec.negated().toFixed(2);
-    const [refund] = await this.db
-      .insert(payments)
-      .values({
-        folioId: original.folioId,
+    const refund = await this.db.transaction(async (tx: any) => {
+      const [locked] = await tx
+        .select()
+        .from(payments)
+        .where(and(eq(payments.id, id), eq(payments.propertyId, propertyId)))
+        .for('update');
+
+      if (!locked) {
+        throw new NotFoundException(`Payment ${id} not found`);
+      }
+
+      if (result.transactionId) {
+        const [existingByGateway] = await tx
+          .select()
+          .from(payments)
+          .where(
+            and(
+              eq(payments.gatewayTransactionId, result.transactionId),
+              eq(payments.propertyId, propertyId),
+            ),
+          );
+        if (existingByGateway) {
+          return { row: existingByGateway, isNew: false };
+        }
+      }
+
+      const existingRefunds = await tx
+        .select()
+        .from(payments)
+        .where(
+          and(
+            eq(payments.originalPaymentId, id),
+            eq(payments.propertyId, propertyId),
+          ),
+        );
+      const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
+      const remainingDec = new Decimal(locked.amount).minus(alreadyRefundedDec);
+
+      if (refundDec.gt(remainingDec)) {
+        // Stripe webhook may have recorded this refund between prepare and insert.
+        if (alreadyRefundedDec.gte(totalAfterDec)) {
+          const latest = existingRefunds[existingRefunds.length - 1];
+          if (latest) {
+            return { row: latest, isNew: false };
+          }
+        }
+        throw new ConflictException(
+          `Payment ${id} refundable amount changed during gateway refund`,
+        );
+      }
+
+      const [row] = await tx
+        .insert(payments)
+        .values({
+          folioId: locked.folioId,
+          propertyId,
+          method: locked.method,
+          amount: refundRowAmount,
+          currencyCode: locked.currencyCode,
+          status: 'captured',
+          originalPaymentId: id,
+          gatewayProvider: locked.gatewayProvider,
+          gatewayTransactionId: result.transactionId,
+          processedAt: new Date(),
+          notes: `Refund of payment ${id}`,
+        })
+        .returning();
+
+      return { row, isNew: true };
+    });
+
+    if (refund.isNew) {
+      await this.folioService.recalculateBalance(original.folioId, propertyId);
+
+      await this.webhookService.emit(
+        'payment.refunded',
+        'payment',
+        refund.row.id,
+        { folioId: original.folioId, originalPaymentId: id, refundAmount: refundDec.toFixed(2) },
         propertyId,
-        method: original.method,
-        amount: refundRowAmount,
-        currencyCode: original.currencyCode,
-        status: 'captured',
-        originalPaymentId: id,
-        gatewayProvider: original.gatewayProvider,
-        gatewayTransactionId: result.transactionId,
-        processedAt: new Date(),
-        notes: `Refund of payment ${id}`,
-      })
-      .returning();
+      );
+    }
 
-    await this.folioService.recalculateBalance(original.folioId, propertyId);
-
-    await this.webhookService.emit(
-      'payment.refunded',
-      'payment',
-      refund.id,
-      { folioId: original.folioId, originalPaymentId: id, refundAmount: refundDec.toFixed(2) },
-      propertyId,
-    );
-
-    return refund;
+    return refund.row;
   }
 
   /**
@@ -504,6 +560,12 @@ export class PaymentService {
         throw new NotFoundException(`Payment ${id} not found`);
       }
 
+      // When the parent is voided/failed/etc., it is excluded from folioPaymentSumWhere
+      // but a captured child would still net — use a compensating charge instead.
+      if (!parentCountsTowardFolioBalance(locked.status)) {
+        return { useCharge: true as const, locked };
+      }
+
       const adjustmentAmount = new Decimal(locked.amount).negated().toFixed(2);
       const [row] = await tx
         .insert(payments)
@@ -521,8 +583,29 @@ export class PaymentService {
         .returning();
 
       await this.folioService.recalculateBalance(locked.folioId!, propertyId, tx);
-      return { row, adjustmentAmount };
+      return { useCharge: false as const, row, adjustmentAmount };
     });
+
+    if (adjustment.useCharge) {
+      const adjustmentAmount = new Decimal(adjustment.locked.amount).negated().toFixed(2);
+      const charge = await this.folioService.postCharge(adjustment.locked.folioId!, {
+        propertyId,
+        type: 'adjustment',
+        description: `Correction of payment ${id}`,
+        amount: adjustmentAmount,
+        currencyCode: adjustment.locked.currencyCode,
+        serviceDate: new Date().toISOString(),
+        skipTaxCalculation: true,
+      });
+      await this.webhookService.emit(
+        'payment.corrected',
+        'payment',
+        id,
+        { op: 'adjust', method: payment.method, adjustmentAmount },
+        propertyId,
+      );
+      return { op: 'adjust', adjustment: charge };
+    }
 
     await this.webhookService.emit(
       'payment.corrected',

--- a/apps/api/src/modules/payment/payment.service.ts
+++ b/apps/api/src/modules/payment/payment.service.ts
@@ -15,6 +15,7 @@ import { PAYMENT_GATEWAY } from './interfaces/payment-gateway.interface';
 import type { PaymentGateway } from './interfaces/payment-gateway.interface';
 import { CreatePaymentDto } from './dto/create-payment.dto';
 import { AuthorizePaymentDto } from './dto/authorize-payment.dto';
+import { ListPaymentsDto } from './dto/list-payments.dto';
 import { sumRefundChildren } from './payment-ledger';
 
 const CARD_METHODS = ['credit_card', 'debit_card', 'vcc'];

--- a/apps/api/src/modules/payment/stripe-webhook.controller.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.controller.ts
@@ -11,10 +11,12 @@ import { ConfigService } from '@nestjs/config';
 import { ApiTags, ApiOperation, ApiExcludeEndpoint } from '@nestjs/swagger';
 import { Public } from '../auth/public.decorator';
 import { eq, and } from 'drizzle-orm';
+import { Decimal } from 'decimal.js';
 import { payments } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { WebhookService } from '../webhook/webhook.service';
 import { FolioService } from '../folio/folio.service';
+import { sumRefundChildren } from './payment-ledger';
 import Stripe from 'stripe';
 
 /**
@@ -216,27 +218,71 @@ export class StripeWebhookController {
     const payment = await this.findPaymentByGatewayTransactionId(piId);
     if (!payment) return;
 
-    if (['refunded', 'partially_refunded'].includes(payment.status)) return;
+    const existingRefunds = await this.db
+      .select()
+      .from(payments)
+      .where(
+        and(
+          eq(payments.originalPaymentId, payment.id),
+          eq(payments.propertyId, payment.propertyId),
+        ),
+      );
 
-    const status = charge.amount_refunded < charge.amount ? 'partially_refunded' : 'refunded';
+    const stripeRefundedDec = new Decimal(charge.amount_refunded).div(100);
+    const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
+    const deltaDec = stripeRefundedDec.minus(alreadyRefundedDec);
 
-    await this.db
-      .update(payments)
-      .set({ status, updatedAt: new Date() })
-      .where(and(eq(payments.id, payment.id), eq(payments.propertyId, payment.propertyId)));
+    if (deltaDec.lte(0)) {
+      this.logger.debug(
+        `Payment ${payment.id} Stripe refund already recorded (${stripeRefundedDec.toFixed(2)})`,
+      );
+      return;
+    }
 
-    // Recalculate folio balance after refund
+    const [existingForCharge] = await this.db
+      .select({ id: payments.id })
+      .from(payments)
+      .where(eq(payments.gatewayTransactionId, charge.id))
+      .limit(1);
+    if (existingForCharge) {
+      return;
+    }
+
+    const [refund] = await this.db
+      .insert(payments)
+      .values({
+        folioId: payment.folioId,
+        propertyId: payment.propertyId,
+        method: payment.method,
+        amount: deltaDec.negated().toFixed(2),
+        currencyCode: payment.currencyCode,
+        status: 'captured',
+        originalPaymentId: payment.id,
+        gatewayProvider: payment.gatewayProvider,
+        gatewayTransactionId: charge.id,
+        processedAt: new Date(),
+        notes: `Stripe refund ${charge.id}`,
+      })
+      .returning();
+
     await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
 
     await this.webhookService.emit(
       'payment.refunded',
       'payment',
-      payment.id,
-      { folioId: payment.folioId, status, stripeEvent: charge.id },
+      refund.id,
+      {
+        folioId: payment.folioId,
+        originalPaymentId: payment.id,
+        refundAmount: deltaDec.toFixed(2),
+        stripeEvent: charge.id,
+      },
       payment.propertyId,
     );
 
-    this.logger.log(`Payment ${payment.id} updated to ${status} via webhook`);
+    this.logger.log(
+      `Payment ${payment.id} refund child ${refund.id} recorded via webhook (${deltaDec.toFixed(2)})`,
+    );
   }
 
   private async findPaymentByGatewayTransactionId(transactionId: string) {

--- a/apps/api/src/modules/payment/stripe-webhook.controller.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.controller.ts
@@ -218,70 +218,90 @@ export class StripeWebhookController {
     const payment = await this.findPaymentByGatewayTransactionId(piId);
     if (!payment) return;
 
-    const existingRefunds = await this.db
-      .select()
-      .from(payments)
-      .where(
-        and(
-          eq(payments.originalPaymentId, payment.id),
-          eq(payments.propertyId, payment.propertyId),
-        ),
-      );
-
     const stripeRefundedDec = new Decimal(charge.amount_refunded).div(100);
-    const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
-    const deltaDec = stripeRefundedDec.minus(alreadyRefundedDec);
+    const ledgerKey = `stripe_refund:${charge.id}:${stripeRefundedDec.toFixed(2)}`;
 
-    if (deltaDec.lte(0)) {
-      this.logger.debug(
-        `Payment ${payment.id} Stripe refund already recorded (${stripeRefundedDec.toFixed(2)})`,
-      );
-      return;
-    }
+    const recorded = await this.db.transaction(async (tx: any) => {
+      const [parent] = await tx
+        .select()
+        .from(payments)
+        .where(
+          and(
+            eq(payments.id, payment.id),
+            eq(payments.propertyId, payment.propertyId),
+          ),
+        )
+        .for('update');
 
-    const [existingForCharge] = await this.db
-      .select({ id: payments.id })
-      .from(payments)
-      .where(eq(payments.gatewayTransactionId, charge.id))
-      .limit(1);
-    if (existingForCharge) {
-      return;
-    }
+      if (!parent) return null;
 
-    const [refund] = await this.db
-      .insert(payments)
-      .values({
-        folioId: payment.folioId,
-        propertyId: payment.propertyId,
-        method: payment.method,
-        amount: deltaDec.negated().toFixed(2),
-        currencyCode: payment.currencyCode,
-        status: 'captured',
-        originalPaymentId: payment.id,
-        gatewayProvider: payment.gatewayProvider,
-        gatewayTransactionId: charge.id,
-        processedAt: new Date(),
-        notes: `Stripe refund ${charge.id}`,
-      })
-      .returning();
+      const [existingForLedger] = await tx
+        .select({ id: payments.id })
+        .from(payments)
+        .where(eq(payments.gatewayTransactionId, ledgerKey))
+        .limit(1);
+      if (existingForLedger) {
+        return null;
+      }
 
-    await this.folioService.recalculateBalance(payment.folioId, payment.propertyId);
+      const existingRefunds = await tx
+        .select()
+        .from(payments)
+        .where(
+          and(
+            eq(payments.originalPaymentId, parent.id),
+            eq(payments.propertyId, parent.propertyId),
+          ),
+        );
+
+      const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
+      const deltaDec = stripeRefundedDec.minus(alreadyRefundedDec);
+
+      if (deltaDec.lte(0)) {
+        this.logger.debug(
+          `Payment ${parent.id} Stripe refund already recorded (${stripeRefundedDec.toFixed(2)})`,
+        );
+        return null;
+      }
+
+      const [row] = await tx
+        .insert(payments)
+        .values({
+          folioId: parent.folioId,
+          propertyId: parent.propertyId,
+          method: parent.method,
+          amount: deltaDec.negated().toFixed(2),
+          currencyCode: parent.currencyCode,
+          status: 'captured',
+          originalPaymentId: parent.id,
+          gatewayProvider: parent.gatewayProvider,
+          gatewayTransactionId: ledgerKey,
+          processedAt: new Date(),
+          notes: `Stripe refund ${charge.id}`,
+        })
+        .returning();
+
+      await this.folioService.recalculateBalance(parent.folioId, parent.propertyId, tx);
+      return { row, parent, deltaDec };
+    });
+
+    if (!recorded) return;
 
     await this.webhookService.emit(
       'payment.refunded',
       'payment',
-      refund.id,
+      recorded.row.id,
       {
-        folioId: payment.folioId,
-        originalPaymentId: payment.id,
-        refundAmount: deltaDec.toFixed(2),
+        folioId: recorded.parent.folioId,
+        originalPaymentId: recorded.parent.id,
+        refundAmount: recorded.deltaDec.toFixed(2),
         stripeEvent: charge.id,
       },
-      payment.propertyId,
+      recorded.parent.propertyId,
     );
 
     this.logger.log(
-      `Payment ${payment.id} refund child ${refund.id} recorded via webhook (${deltaDec.toFixed(2)})`,
+      `Payment ${recorded.parent.id} refund child ${recorded.row.id} recorded via webhook (${recorded.deltaDec.toFixed(2)})`,
     );
   }
 

--- a/apps/api/src/modules/payment/stripe-webhook.spec.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.spec.ts
@@ -14,6 +14,42 @@ const mockPayment = {
   gatewayTransactionId: 'pi_test_123',
 };
 
+function createRefundWebhookDb(
+  payment: any,
+  existingRefunds: any[] = [],
+  existingForCharge: any[] = [],
+) {
+  let selectCall = 0;
+  return {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(() => {
+          selectCall++;
+          if (selectCall === 1) {
+            return { then: (resolve: any) => resolve([payment]) };
+          }
+          if (selectCall === 2) {
+            return { then: (resolve: any) => resolve(existingRefunds) };
+          }
+          return {
+            limit: vi.fn().mockReturnValue({
+              then: (resolve: any) => resolve(existingForCharge),
+            }),
+          };
+        }),
+      }),
+    })),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([
+          { id: 'refund-webhook-1', folioId: payment.folioId, originalPaymentId: payment.id },
+        ]),
+      }),
+    }),
+    update: vi.fn(),
+  };
+}
+
 function createMockDb(returnData: any[] = [mockPayment]) {
   return {
     select: vi.fn().mockImplementation(() => ({
@@ -23,6 +59,11 @@ function createMockDb(returnData: any[] = [mockPayment]) {
         }),
       }),
     })),
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue(returnData),
+      }),
+    }),
     update: vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -143,8 +184,8 @@ describe('StripeWebhookController', () => {
       );
     });
 
-    it('should update payment to refunded on charge.refunded (full)', async () => {
-      const capturedDb = createMockDb([{ ...mockPayment, status: 'captured' }]);
+    it('should insert a refund child on charge.refunded (full)', async () => {
+      const capturedDb = createRefundWebhookDb({ ...mockPayment, status: 'captured', method: 'credit_card' });
       const module = await Test.createTestingModule({
         controllers: [StripeWebhookController],
         providers: [
@@ -160,21 +201,23 @@ describe('StripeWebhookController', () => {
         id: 'ch_test_123',
         payment_intent: 'pi_test_123',
         amount: 50000,
-        amount_refunded: 50000, // full refund
+        amount_refunded: 50000,
       });
 
-      expect(capturedDb.update).toHaveBeenCalled();
+      expect(capturedDb.insert).toHaveBeenCalled();
+      expect(capturedDb.update).not.toHaveBeenCalled();
+      expect(mockFolioService.recalculateBalance).toHaveBeenCalledWith('folio-001', 'prop-001');
       expect(mockWebhookService.emit).toHaveBeenCalledWith(
         'payment.refunded',
         'payment',
-        'pay-001',
-        expect.objectContaining({ status: 'refunded' }),
+        'refund-webhook-1',
+        expect.objectContaining({ refundAmount: '500.00', originalPaymentId: 'pay-001' }),
         'prop-001',
       );
     });
 
-    it('should update to partially_refunded for partial refund', async () => {
-      const capturedDb = createMockDb([{ ...mockPayment, status: 'captured' }]);
+    it('should insert a partial refund child on charge.refunded', async () => {
+      const capturedDb = createRefundWebhookDb({ ...mockPayment, status: 'captured', method: 'credit_card' });
       const module = await Test.createTestingModule({
         controllers: [StripeWebhookController],
         providers: [
@@ -190,14 +233,15 @@ describe('StripeWebhookController', () => {
         id: 'ch_test_123',
         payment_intent: 'pi_test_123',
         amount: 50000,
-        amount_refunded: 25000, // partial refund
+        amount_refunded: 25000,
       });
 
+      expect(capturedDb.insert).toHaveBeenCalled();
       expect(mockWebhookService.emit).toHaveBeenCalledWith(
         'payment.refunded',
         'payment',
-        'pay-001',
-        expect.objectContaining({ status: 'partially_refunded' }),
+        'refund-webhook-1',
+        expect.objectContaining({ refundAmount: '250.00' }),
         'prop-001',
       );
     });

--- a/apps/api/src/modules/payment/stripe-webhook.spec.ts
+++ b/apps/api/src/modules/payment/stripe-webhook.spec.ts
@@ -17,34 +17,46 @@ const mockPayment = {
 function createRefundWebhookDb(
   payment: any,
   existingRefunds: any[] = [],
-  existingForCharge: any[] = [],
+  existingForLedger: any[] = [],
 ) {
-  let selectCall = 0;
   return {
     select: vi.fn().mockImplementation(() => ({
       from: vi.fn().mockReturnValue({
-        where: vi.fn().mockImplementation(() => {
-          selectCall++;
-          if (selectCall === 1) {
-            return { then: (resolve: any) => resolve([payment]) };
-          }
-          if (selectCall === 2) {
-            return { then: (resolve: any) => resolve(existingRefunds) };
-          }
-          return {
-            limit: vi.fn().mockReturnValue({
-              then: (resolve: any) => resolve(existingForCharge),
-            }),
-          };
+        where: vi.fn().mockReturnValue({
+          then: (resolve: any) => resolve([payment]),
         }),
       }),
     })),
-    insert: vi.fn().mockReturnValue({
-      values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([
-          { id: 'refund-webhook-1', folioId: payment.folioId, originalPaymentId: payment.id },
-        ]),
-      }),
+    transaction: vi.fn(async (fn: any) => {
+      let selectCall = 0;
+      const tx = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockImplementation(() => {
+              selectCall++;
+              if (selectCall === 1) {
+                return { for: vi.fn().mockResolvedValue([payment]) };
+              }
+              if (selectCall === 2) {
+                return {
+                  limit: vi.fn().mockReturnValue({
+                    then: (resolve: any) => resolve(existingForLedger),
+                  }),
+                };
+              }
+              return { then: (resolve: any) => resolve(existingRefunds) };
+            }),
+          }),
+        })),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([
+              { id: 'refund-webhook-1', folioId: payment.folioId, originalPaymentId: payment.id },
+            ]),
+          }),
+        }),
+      };
+      return fn(tx);
     }),
     update: vi.fn(),
   };
@@ -204,9 +216,13 @@ describe('StripeWebhookController', () => {
         amount_refunded: 50000,
       });
 
-      expect(capturedDb.insert).toHaveBeenCalled();
+      expect(capturedDb.transaction).toHaveBeenCalled();
       expect(capturedDb.update).not.toHaveBeenCalled();
-      expect(mockFolioService.recalculateBalance).toHaveBeenCalledWith('folio-001', 'prop-001');
+      expect(mockFolioService.recalculateBalance).toHaveBeenCalledWith(
+        'folio-001',
+        'prop-001',
+        expect.anything(),
+      );
       expect(mockWebhookService.emit).toHaveBeenCalledWith(
         'payment.refunded',
         'payment',
@@ -236,7 +252,7 @@ describe('StripeWebhookController', () => {
         amount_refunded: 25000,
       });
 
-      expect(capturedDb.insert).toHaveBeenCalled();
+      expect(capturedDb.transaction).toHaveBeenCalled();
       expect(mockWebhookService.emit).toHaveBeenCalledWith(
         'payment.refunded',
         'payment',

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -14,6 +14,7 @@ import {
   arTransactions,
 } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
+import { reportPaymentSumWhere } from '../payment/payment-ledger';
 
 @Injectable()
 export class ReportsService {
@@ -62,8 +63,7 @@ export class ReportsService {
       .from(payments)
       .where(
         and(
-          eq(payments.propertyId, propertyId),
-          eq(payments.status, 'captured' as any),
+          reportPaymentSumWhere(propertyId),
           sql`${payments.processedAt}::date = ${date}`,
         ),
       )
@@ -289,8 +289,7 @@ export class ReportsService {
       .from(payments)
       .where(
         and(
-          eq(payments.propertyId, propertyId),
-          eq(payments.status, 'captured' as any),
+          reportPaymentSumWhere(propertyId),
           sql`${payments.processedAt}::date = ${date}`,
         ),
       )


### PR DESCRIPTION
## Summary
- Introduce a shared payment ledger model: parent tenders stay `captured`/`settled`; refunds and payment corrections post as negative `captured` child rows linked via `originalPaymentId`.
- Apply the net-sum logic in `recalculateBalance`, cash reports, Stripe `charge.refunded` webhooks, `refundPayment`, `correctPayment` adjust, and `transferToCityLedger` (with `FOR UPDATE` on the source folio).
- Legacy parents still marked `partially_refunded`/`refunded` remain summable so existing data heals on recalculate.

## Test plan
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/payment src/modules/folio/folio.service.spec.ts src/modules/folio/folio-routing.service.spec.ts`
- [ ] Manual: partial refund on a captured card payment → folio balance nets correctly
- [ ] Manual: Stripe webhook partial refund → negative child row inserted, parent stays captured


Made with [Cursor](https://cursor.com)