### PR TITLE
Harden inbound OTA and checkout flows

### DIFF
--- a/apps/api/src/modules/channel/inbound-reservation-fk-ownership.spec.ts
+++ b/apps/api/src/modules/channel/inbound-reservation-fk-ownership.spec.ts
@@ -7,6 +7,7 @@ import { ChannelService } from './channel.service';
 import { ChannelAdapterFactory } from './channel-adapter.factory';
 import { AriService } from './ari.service';
 import { WebhookService } from '../webhook/webhook.service';
+import { AvailabilityService } from '../reservation/availability.service';
 
 /**
  * Cross-tenant FK ownership for channel inbound reservations (follow-on to
@@ -42,6 +43,7 @@ async function mkSvc(db: any) {
       { provide: ChannelAdapterFactory, useValue: {} },
       { provide: AriService, useValue: {} },
       { provide: WebhookService, useValue: { emit: vi.fn() } },
+      { provide: AvailabilityService, useValue: { searchAvailability: vi.fn().mockResolvedValue([]) } },
     ],
   }).compile();
   return mod.get(InboundReservationService);

--- a/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 import { InboundReservationService } from './inbound-reservation.service';
 import type { ChannelReservation } from './channel-adapter.interface';
 
@@ -194,6 +194,25 @@ describe('InboundReservationService', () => {
       expect(result.confirmationNumber).toBe('EXIST-123');
       expect(result.reservationId).toBe('res-1');
       expect(mockDb.insert).not.toHaveBeenCalled();
+    });
+
+    it('should reject duplicate new push when existing reservation is cancelled', async () => {
+      let callCount = 0;
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockConnection]);
+            if (callCount === 2) return Promise.resolve([{ id: 'booking-1', confirmationNumber: 'EXIST-123' }]);
+            if (callCount === 3) return Promise.resolve([{ id: 'res-1', guestId: 'guest-1', status: 'cancelled' }]);
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      const reservation = makeReservation();
+      await expect(service.processInboundReservation('conn-1', reservation))
+        .rejects.toThrow(ConflictException);
     });
   });
 

--- a/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.spec.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ConflictException, NotFoundException } from '@nestjs/common';
+import { NotFoundException } from '@nestjs/common';
 import { InboundReservationService } from './inbound-reservation.service';
 import type { ChannelReservation } from './channel-adapter.interface';
+
+function mockAvailability() {
+  return Array.from({ length: 5 }, (_, i) => ({
+    roomTypeId: 'rt-1',
+    date: `2024-06-0${i + 1}`,
+    available: 5,
+  }));
+}
 
 function makeReservation(overrides: Partial<ChannelReservation> = {}): ChannelReservation {
   return {
@@ -31,6 +39,7 @@ describe('InboundReservationService', () => {
   let mockAdapterFactory: any;
   let mockAriService: any;
   let mockWebhookService: any;
+  let mockAvailabilityService: any;
 
   const mockConnection = {
     id: 'conn-1',
@@ -99,12 +108,17 @@ describe('InboundReservationService', () => {
 
     mockWebhookService = { emit: vi.fn().mockResolvedValue(undefined) };
 
+    mockAvailabilityService = {
+      searchAvailability: vi.fn().mockResolvedValue(mockAvailability()),
+    };
+
     service = new InboundReservationService(
       mockDb,
       mockChannelService,
       mockAdapterFactory,
       mockAriService,
       mockWebhookService,
+      mockAvailabilityService,
     );
   });
 
@@ -160,22 +174,26 @@ describe('InboundReservationService', () => {
       );
     });
 
-    it('should throw ConflictException for duplicate reservation', async () => {
+    it('should return existing booking idempotently for duplicate new push', async () => {
       let callCount = 0;
       mockDb.select.mockImplementation(() => ({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockImplementation(() => {
             callCount++;
-            if (callCount === 1) return Promise.resolve([mockConnection]); // connection
-            if (callCount === 2) return Promise.resolve([{ id: 'booking-1', confirmationNumber: 'EXIST-123' }]); // existing booking found!
+            if (callCount === 1) return Promise.resolve([mockConnection]);
+            if (callCount === 2) return Promise.resolve([{ id: 'booking-1', confirmationNumber: 'EXIST-123' }]);
+            if (callCount === 3) return Promise.resolve([{ id: 'res-1', guestId: 'guest-1' }]);
             return Promise.resolve([]);
           }),
         }),
       }));
 
       const reservation = makeReservation();
-      await expect(service.processInboundReservation('conn-1', reservation))
-        .rejects.toThrow(ConflictException);
+      const result = await service.processInboundReservation('conn-1', reservation);
+
+      expect(result.confirmationNumber).toBe('EXIST-123');
+      expect(result.reservationId).toBe('res-1');
+      expect(mockDb.insert).not.toHaveBeenCalled();
     });
   });
 
@@ -217,6 +235,40 @@ describe('InboundReservationService', () => {
       const reservation = makeReservation({ status: 'cancelled' });
       await expect(service.processInboundReservation('conn-1', reservation))
         .rejects.toThrow(NotFoundException);
+    });
+    it('should push availability using stored dates when cancel payload omits them', async () => {
+      let callCount = 0;
+      mockDb.select.mockImplementation(() => ({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockImplementation(() => {
+            callCount++;
+            if (callCount === 1) return Promise.resolve([mockConnection]);
+            if (callCount === 2) return Promise.resolve([{ id: 'booking-1', confirmationNumber: 'CH-123' }]);
+            if (callCount === 3) {
+              return Promise.resolve([{
+                id: 'res-1',
+                bookingId: 'booking-1',
+                arrivalDate: '2024-06-01',
+                departureDate: '2024-06-05',
+              }]);
+            }
+            return Promise.resolve([]);
+          }),
+        }),
+      }));
+
+      const reservation = makeReservation({
+        status: 'cancelled',
+        arrivalDate: '',
+        departureDate: '',
+      });
+      await service.processInboundReservation('conn-1', reservation);
+
+      expect(mockAriService.pushAvailability).toHaveBeenCalledWith(
+        'prop-1',
+        '2024-06-01',
+        '2024-06-05',
+      );
     });
   });
 

--- a/apps/api/src/modules/channel/inbound-reservation.service.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, Inject, ConflictException, NotFoundException, BadRequestException } from '@nestjs/common';
 import { eq, and } from 'drizzle-orm';
 import { bookings, reservations, guests, channelConnections, roomTypes, ratePlans } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
@@ -122,7 +122,9 @@ export class InboundReservationService {
     const confirmationNumber = this.generateConfirmationNumber();
 
     // Atomically create guest + booking + reservation so we never end up with a half-written record.
-    const { guest, booking, pmsReservation } = await this.db.transaction(async (tx: any) => {
+    let created: { guest: any; booking: any; pmsReservation: any };
+    try {
+      created = await this.db.transaction(async (tx: any) => {
       const availability = await this.availabilityService.searchAvailability(
         propertyId,
         reservation.arrivalDate,
@@ -130,10 +132,8 @@ export class InboundReservationService {
         roomTypeId,
         tx,
       );
-      const nightsOk = availability
-        .filter((a: any) => a.roomTypeId === roomTypeId)
-        .every((a: any) => a.available > 0);
-      if (!nightsOk) {
+      const roomNights = availability.filter((a: any) => a.roomTypeId === roomTypeId);
+      if (roomNights.length === 0 || !roomNights.every((a: any) => a.available > 0)) {
         throw new BadRequestException(
           `No availability for room type ${roomTypeId} on ${reservation.arrivalDate} → ${reservation.departureDate}`,
         );
@@ -174,7 +174,22 @@ export class InboundReservationService {
         .returning();
 
       return { guest, booking, pmsReservation };
-    });
+      });
+    } catch (err: any) {
+      if (err?.code === '23505') {
+        const raced = await this.findByExternalConfirmation(
+          reservation.externalConfirmation,
+          reservation.channelCode,
+          propertyId,
+        );
+        if (raced) {
+          return this.returnExistingInbound(raced, propertyId);
+        }
+      }
+      throw err;
+    }
+
+    const { guest, booking, pmsReservation } = created;
 
     // Confirm back to channel
     try {
@@ -268,9 +283,10 @@ export class InboundReservationService {
         (existingReservation.arrivalDate as string) < reservation.departureDate &&
         (existingReservation.departureDate as string) > reservation.arrivalDate;
 
-      const nightsOk = availability
-        .filter((a: any) => a.roomTypeId === roomTypeId)
-        .every((a: any) => {
+      const roomNights = availability.filter((a: any) => a.roomTypeId === roomTypeId);
+      const nightsOk =
+        roomNights.length > 0 &&
+        roomNights.every((a: any) => {
           const existingOccupiesThisNight =
             currentCountsItself &&
             (existingReservation.arrivalDate as string) <= a.date &&
@@ -428,6 +444,12 @@ export class InboundReservationService {
           eq(reservations.propertyId, propertyId),
         ),
       );
+
+    if (existingReservation?.status === 'cancelled') {
+      throw new ConflictException(
+        `Cannot accept duplicate new push for cancelled reservation ${existing.confirmationNumber}`,
+      );
+    }
 
     return {
       reservationId: existingReservation?.id,

--- a/apps/api/src/modules/channel/inbound-reservation.service.ts
+++ b/apps/api/src/modules/channel/inbound-reservation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, ConflictException, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException, BadRequestException } from '@nestjs/common';
 import { eq, and } from 'drizzle-orm';
 import { bookings, reservations, guests, channelConnections, roomTypes, ratePlans } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
@@ -6,6 +6,7 @@ import { ChannelService } from './channel.service';
 import { ChannelAdapterFactory } from './channel-adapter.factory';
 import { AriService } from './ari.service';
 import { WebhookService } from '../webhook/webhook.service';
+import { AvailabilityService } from '../reservation/availability.service';
 import { generateConfirmationToken } from '../connect/connect-booking.service';
 import type { ChannelReservation } from './channel-adapter.interface';
 
@@ -17,6 +18,7 @@ export class InboundReservationService {
     private readonly adapterFactory: ChannelAdapterFactory,
     private readonly ariService: AriService,
     private readonly webhookService: WebhookService,
+    private readonly availabilityService: AvailabilityService,
   ) {}
 
   /**
@@ -49,9 +51,7 @@ export class InboundReservationService {
     }
 
     if (existing) {
-      throw new ConflictException(
-        `Reservation with external confirmation ${reservation.externalConfirmation} already exists (booking ${existing.confirmationNumber})`,
-      );
+      return this.returnExistingInbound(existing, propertyId);
     }
 
     return this.handleNewReservation(conn, reservation);
@@ -123,6 +123,22 @@ export class InboundReservationService {
 
     // Atomically create guest + booking + reservation so we never end up with a half-written record.
     const { guest, booking, pmsReservation } = await this.db.transaction(async (tx: any) => {
+      const availability = await this.availabilityService.searchAvailability(
+        propertyId,
+        reservation.arrivalDate,
+        reservation.departureDate,
+        roomTypeId,
+        tx,
+      );
+      const nightsOk = availability
+        .filter((a: any) => a.roomTypeId === roomTypeId)
+        .every((a: any) => a.available > 0);
+      if (!nightsOk) {
+        throw new BadRequestException(
+          `No availability for room type ${roomTypeId} on ${reservation.arrivalDate} → ${reservation.departureDate}`,
+        );
+      }
+
       const guest = await this.findOrCreateGuestTx(tx, reservation, propertyId);
 
       const [booking] = await tx
@@ -238,29 +254,60 @@ export class InboundReservationService {
     const departure = new Date(reservation.departureDate);
     const nights = Math.ceil((departure.getTime() - arrival.getTime()) / (1000 * 60 * 60 * 24));
 
-    // Update reservation
-    const [updated] = await this.db
-      .update(reservations)
-      .set({
-        arrivalDate: reservation.arrivalDate,
-        departureDate: reservation.departureDate,
-        nights,
+    const [updated] = await this.db.transaction(async (tx: any) => {
+      const availability = await this.availabilityService.searchAvailability(
+        propertyId,
+        reservation.arrivalDate,
+        reservation.departureDate,
         roomTypeId,
-        ratePlanId,
-        totalAmount: reservation.totalAmount.toString(),
-        currencyCode: reservation.currencyCode,
-        adults: reservation.adults,
-        children: reservation.children ?? 0,
-        specialRequests: reservation.specialRequests,
-        updatedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(reservations.id, existingReservation.id),
-          eq(reservations.propertyId, propertyId),
-        ),
-      )
-      .returning();
+        tx,
+      );
+
+      const currentCountsItself =
+        existingReservation.roomTypeId === roomTypeId &&
+        (existingReservation.arrivalDate as string) < reservation.departureDate &&
+        (existingReservation.departureDate as string) > reservation.arrivalDate;
+
+      const nightsOk = availability
+        .filter((a: any) => a.roomTypeId === roomTypeId)
+        .every((a: any) => {
+          const existingOccupiesThisNight =
+            currentCountsItself &&
+            (existingReservation.arrivalDate as string) <= a.date &&
+            (existingReservation.departureDate as string) > a.date;
+          const effectiveAvailable = a.available + (existingOccupiesThisNight ? 1 : 0);
+          return effectiveAvailable > 0;
+        });
+
+      if (!nightsOk) {
+        throw new BadRequestException(
+          `No availability for room type ${roomTypeId} on ${reservation.arrivalDate} → ${reservation.departureDate}`,
+        );
+      }
+
+      return await tx
+        .update(reservations)
+        .set({
+          arrivalDate: reservation.arrivalDate,
+          departureDate: reservation.departureDate,
+          nights,
+          roomTypeId,
+          ratePlanId,
+          totalAmount: reservation.totalAmount.toString(),
+          currencyCode: reservation.currencyCode,
+          adults: reservation.adults,
+          children: reservation.children ?? 0,
+          specialRequests: reservation.specialRequests,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(reservations.id, existingReservation.id),
+            eq(reservations.propertyId, propertyId),
+          ),
+        )
+        .returning();
+    });
 
     // Push updated availability
     try {
@@ -334,12 +381,15 @@ export class InboundReservationService {
         ),
       );
 
+    const arrivalDate = reservation.arrivalDate || existingReservation.arrivalDate;
+    const departureDate = reservation.departureDate || existingReservation.departureDate;
+
     // Push updated availability
     try {
       await this.ariService.pushAvailability(
         propertyId,
-        reservation.arrivalDate,
-        reservation.departureDate,
+        arrivalDate,
+        departureDate,
       );
     } catch {
       // Fire-and-forget
@@ -367,6 +417,25 @@ export class InboundReservationService {
   }
 
   // --- Private Helpers ---
+
+  private async returnExistingInbound(existing: any, propertyId: string) {
+    const [existingReservation] = await this.db
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.bookingId, existing.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      );
+
+    return {
+      reservationId: existingReservation?.id,
+      bookingId: existing.id,
+      confirmationNumber: existing.confirmationNumber,
+      guestId: existingReservation?.guestId,
+    };
+  }
 
   private async findConnectionForInbound(channelConnectionId: string) {
     // Look up connection without propertyId (inbound doesn't always know it)

--- a/apps/api/src/modules/reservation/availability.service.ts
+++ b/apps/api/src/modules/reservation/availability.service.ts
@@ -27,9 +27,12 @@ export class AvailabilityService {
     checkIn: string,
     checkOut: string,
     roomTypeId?: string,
+    db?: any,
   ): Promise<AvailabilityResult[]> {
+    const conn = db ?? this.db;
+
     // Get property overbooking config
-    const [property] = await this.db
+    const [property] = await conn
       .select()
       .from(properties)
       .where(eq(properties.id, propertyId));
@@ -44,14 +47,14 @@ export class AvailabilityService {
     if (roomTypeId) {
       roomTypeConditions.push(eq(roomTypes.id, roomTypeId));
     }
-    const types = await this.db
+    const types = await conn
       .select()
       .from(roomTypes)
       .where(and(...roomTypeConditions));
 
     // Get overlapping reservations (not cancelled/no_show/checked_out)
     const excludedStatuses = ['cancelled', 'no_show', 'checked_out'] as const;
-    const overlapping = await this.db
+    const overlapping = await conn
       .select({
         roomTypeId: reservations.roomTypeId,
         arrivalDate: reservations.arrivalDate,
@@ -70,7 +73,7 @@ export class AvailabilityService {
       );
 
     // Single grouped query for room counts per room type (avoids N+1).
-    const roomCountRows = await this.db
+    const roomCountRows = await conn
       .select({
         roomTypeId: rooms.roomTypeId,
         count: sql<number>`count(*)`,

--- a/apps/api/src/modules/reservation/check-out.spec.ts
+++ b/apps/api/src/modules/reservation/check-out.spec.ts
@@ -185,6 +185,27 @@ describe('ReservationService — checkOut', () => {
     expect(mockFolioService.settle).toHaveBeenCalledWith('folio-001', 'prop-001');
   });
 
+  it('should post late checkout fee before express checkout settles', async () => {
+    const lateProperty = { ...mockProperty, checkOutTime: '00:01', settings: { lateCheckoutFee: 75 } };
+    const db = createCheckOutDb({ property: lateProperty });
+    const svc = await createService(db);
+    const callOrder: string[] = [];
+    mockFolioService.postCharge.mockImplementation(async () => {
+      callOrder.push('postCharge');
+    });
+    mockFolioService.settle.mockImplementation(async () => {
+      callOrder.push('settle');
+    });
+
+    await svc.checkOut('res-001', 'prop-001', { expressCheckout: true });
+
+    expect(mockFolioService.postCharge).toHaveBeenCalledWith(
+      'folio-001',
+      expect.objectContaining({ type: 'fee', amount: '75' }),
+    );
+    expect(callOrder).toEqual(['postCharge', 'settle']);
+  });
+
   it('should throw on express checkout with outstanding balance', async () => {
     mockFolioService.findById.mockResolvedValue({ ...mockFolio, balance: '150.00' });
     const db = createCheckOutDb();

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -90,6 +90,7 @@ export class ReservationService {
         dto.arrivalDate,
         dto.departureDate,
         dto.roomTypeId,
+        tx,
       );
       const roomTypeAvail = availability.find((a: any) => a.roomTypeId === dto.roomTypeId);
       if (!roomTypeAvail || roomTypeAvail.available <= 0) {
@@ -435,7 +436,7 @@ export class ReservationService {
 
     const now = new Date();
 
-    // Late checkout detection
+    // Late checkout detection (read-only)
     const [property] = await this.db
       .select()
       .from(properties)
@@ -462,7 +463,6 @@ export class ReservationService {
       }
     }
 
-    // Get folios for this reservation
     const folioResult = await this.folioService.list({
       propertyId: reservation.propertyId,
       reservationId: reservation.id,
@@ -471,7 +471,38 @@ export class ReservationService {
     });
     const folios = folioResult.data;
 
-    // Post late checkout fee to primary open folio
+    // Express checkout: validate balances before claiming the transition.
+    if (dto.expressCheckout) {
+      for (const folio of folios) {
+        if (folio.status !== 'open') continue;
+        const refreshed = await this.folioService.findById(folio.id, reservation.propertyId);
+        if (new Decimal(refreshed.balance).abs().gt('0.01')) {
+          throw new BadRequestException(
+            `Cannot express checkout: folio ${folio.folioNumber} has outstanding balance of ${refreshed.balance}`,
+          );
+        }
+      }
+    }
+
+    const updateData: Record<string, unknown> = {
+      status: 'checked_out',
+      checkedOutAt: now,
+      actualDepartureTime: now,
+      isLateCheckout,
+      updatedAt: now,
+    };
+    if (lateCheckoutFeeAmount) updateData['lateCheckoutFee'] = lateCheckoutFeeAmount;
+
+    const updated = await this.claimTransition(
+      id,
+      propertyId,
+      ['checked_in', 'stayover', 'due_out'],
+      updateData,
+      'checked_out',
+    );
+
+    const folioSummary: Array<{ folioId: string; balance: string; status: string }> = [];
+
     if (lateCheckoutFeeAmount && folios.length > 0) {
       const openFolio = folios.find((f: any) => f.status === 'open');
       if (openFolio) {
@@ -486,11 +517,7 @@ export class ReservationService {
       }
     }
 
-    // Express checkout path
-    const folioSummary: Array<{ folioId: string; balance: string; status: string }> = [];
-
     if (dto.expressCheckout) {
-      // Phase 1: Capture all authorized payments across all open folios
       for (const folio of folios) {
         if (folio.status !== 'open') continue;
 
@@ -514,26 +541,12 @@ export class ReservationService {
         }
       }
 
-      // Phase 2: Validate all folio balances BEFORE settling any
-      const openFolios: Array<{ folio: any; refreshed: any }> = [];
       for (const folio of folios) {
         if (folio.status !== 'open') continue;
-        const refreshed = await this.folioService.findById(folio.id, reservation.propertyId);
-        if (new Decimal(refreshed.balance).abs().gt('0.01')) {
-          throw new BadRequestException(
-            `Cannot express checkout: folio ${folio.folioNumber} has outstanding balance of ${refreshed.balance}`,
-          );
-        }
-        openFolios.push({ folio, refreshed });
-      }
-
-      // Phase 3: All validated — now settle
-      for (const { folio } of openFolios) {
         await this.folioService.settle(folio.id, reservation.propertyId);
         folioSummary.push({ folioId: folio.id, balance: '0.00', status: 'settled' });
       }
     } else {
-      // Non-express: compile folio summaries
       for (const folio of folios) {
         folioSummary.push({
           folioId: folio.id,
@@ -541,10 +554,7 @@ export class ReservationService {
           status: folio.status,
         });
       }
-    }
 
-    // Void remaining pre-auths (for non-express, or any that weren't captured)
-    if (!dto.expressCheckout) {
       for (const folio of folios) {
         const authorizedPayments = await this.db
           .select()
@@ -566,32 +576,10 @@ export class ReservationService {
       }
     }
 
-    // Mark room vacant_dirty
     if (reservation.roomId) {
       await this.roomStatusService.markVacantDirty(reservation.roomId, reservation.propertyId);
     }
 
-    // Update reservation
-    const updateData: Record<string, unknown> = {
-      status: 'checked_out',
-      checkedOutAt: now,
-      actualDepartureTime: now,
-      isLateCheckout,
-      updatedAt: now,
-    };
-    if (lateCheckoutFeeAmount) updateData['lateCheckoutFee'] = lateCheckoutFeeAmount;
-
-    // Bug 2: atomic claim — only checked_in / stayover / due_out can
-    // transition to checked_out. Prevents double checkout races.
-    const updated = await this.claimTransition(
-      id,
-      propertyId,
-      ['checked_in', 'stayover', 'due_out'],
-      updateData,
-      'checked_out',
-    );
-
-    // Emit webhook
     await this.webhookService.emit(
       'reservation.checked_out',
       'reservation',
@@ -830,6 +818,7 @@ export class ReservationService {
           newArrival,
           newDeparture,
           newRoomTypeId,
+          tx,
         );
 
         // Check each night in the requested window has availability.

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -471,6 +471,21 @@ export class ReservationService {
     });
     const folios = folioResult.data;
 
+    // Express checkout: post late fee before balance validation so settle sees zero.
+    if (dto.expressCheckout && lateCheckoutFeeAmount && folios.length > 0) {
+      const openFolio = folios.find((f: any) => f.status === 'open');
+      if (openFolio) {
+        await this.folioService.postCharge(openFolio.id, {
+          propertyId: reservation.propertyId,
+          type: 'fee',
+          description: 'Late checkout fee',
+          amount: lateCheckoutFeeAmount,
+          currencyCode: reservation.currencyCode,
+          serviceDate: now.toISOString(),
+        });
+      }
+    }
+
     // Express checkout: validate balances before claiming the transition.
     if (dto.expressCheckout) {
       for (const folio of folios) {
@@ -503,7 +518,7 @@ export class ReservationService {
 
     const folioSummary: Array<{ folioId: string; balance: string; status: string }> = [];
 
-    if (lateCheckoutFeeAmount && folios.length > 0) {
+    if (!dto.expressCheckout && lateCheckoutFeeAmount && folios.length > 0) {
       const openFolio = folios.find((f: any) => f.status === 'open');
       if (openFolio) {
         await this.folioService.postCharge(openFolio.id, {

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -860,6 +860,7 @@ async function main() {
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS bookings_property_external_channel_unique ON bookings (property_id, external_confirmation, channel_code) WHERE external_confirmation IS NOT NULL AND channel_code IS NOT NULL`,
   ];
 
   for (const t of tables) {


### PR DESCRIPTION
## Summary
- Gate inbound OTA new/modify reservations on `AvailabilityService` inside the write transaction.
- Reorder `checkOut` to claim the status transition before folio, payment, and room side effects.
- Return existing booking idempotently on duplicate OTA `new` pushes; add unique index on `(property_id, external_confirmation, channel_code)`.
- Use stored reservation dates for cancel ARI push when the channel payload omits them.
- Pass the transaction connection into `searchAvailability` for reservation create/modify.

## Test plan
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/channel/inbound-reservation src/modules/reservation/check-out.spec.ts`
- [ ] Replay duplicate Booking.com `new` push → same confirmation returned, no 409
- [ ] Cancel push with empty dates → ARI uses DB arrival/departure
