### PR TITLE
Refund row-lock and Connect property scoping (Tier 3)

### DIFF
--- a/apps/api/src/modules/connect/connect-booking.service.ts
+++ b/apps/api/src/modules/connect/connect-booking.service.ts
@@ -165,23 +165,8 @@ export class ConnectBookingService {
    * Verify booking — Agent 4.7 (Confirmation Verification).
    */
   async verify(confirmationNumber: string) {
-    const [booking] = await this.db
-      .select()
-      .from(bookings)
-      .where(eq(bookings.confirmationNumber, confirmationNumber));
-
-    if (!booking) {
-      throw new NotFoundException(`Booking ${confirmationNumber} not found`);
-    }
-
-    const [reservation] = await this.db
-      .select()
-      .from(reservations)
-      .where(eq(reservations.bookingId, booking.id));
-
-    if (!reservation) {
-      throw new NotFoundException('Reservation not found for this booking');
-    }
+    const { booking, reservation } = await this.loadBookingByConfirmation(confirmationNumber);
+    const propertyId = booking.propertyId;
 
     // Get guest name
     const [guest] = await this.db
@@ -193,7 +178,12 @@ export class ConnectBookingService {
     const [roomType] = await this.db
       .select()
       .from(roomTypes)
-      .where(eq(roomTypes.id, reservation.roomTypeId));
+      .where(
+        and(
+          eq(roomTypes.id, reservation.roomTypeId),
+          eq(roomTypes.propertyId, propertyId),
+        ),
+      );
 
     // Check room assignment
     let roomNumber: string | undefined;
@@ -201,7 +191,12 @@ export class ConnectBookingService {
       const [room] = await this.db
         .select()
         .from(rooms)
-        .where(eq(rooms.id, reservation.roomId));
+        .where(
+          and(
+            eq(rooms.id, reservation.roomId),
+            eq(rooms.propertyId, propertyId),
+          ),
+        );
       roomNumber = room?.number;
     }
 
@@ -209,7 +204,12 @@ export class ConnectBookingService {
     const folioList = await this.db
       .select()
       .from(folios)
-      .where(eq(folios.reservationId, reservation.id));
+      .where(
+        and(
+          eq(folios.reservationId, reservation.id),
+          eq(folios.propertyId, propertyId),
+        ),
+      );
 
     const folio = folioList[0];
 
@@ -236,23 +236,7 @@ export class ConnectBookingService {
    * Modify booking — Agent 4.6 (Modification & Cancellation).
    */
   async modify(confirmationNumber: string, dto: AgentModifyDto) {
-    const [booking] = await this.db
-      .select()
-      .from(bookings)
-      .where(eq(bookings.confirmationNumber, confirmationNumber));
-
-    if (!booking) {
-      throw new NotFoundException(`Booking ${confirmationNumber} not found`);
-    }
-
-    const [reservation] = await this.db
-      .select()
-      .from(reservations)
-      .where(eq(reservations.bookingId, booking.id));
-
-    if (!reservation) {
-      throw new NotFoundException('Reservation not found');
-    }
+    const { booking, reservation } = await this.loadBookingByConfirmation(confirmationNumber);
 
     if (['cancelled', 'checked_out', 'no_show'].includes(reservation.status)) {
       throw new BadRequestException(`Cannot modify reservation in ${reservation.status} status`);
@@ -301,7 +285,12 @@ export class ConnectBookingService {
         await this.db
           .update(reservations)
           .set({ guestId: forked.id, updatedAt: new Date() })
-          .where(eq(reservations.id, reservation.id));
+          .where(
+            and(
+              eq(reservations.id, reservation.id),
+              eq(reservations.propertyId, booking.propertyId),
+            ),
+          );
         reservation.guestId = forked.id;
       } else {
         await this.db
@@ -381,7 +370,12 @@ export class ConnectBookingService {
     const [updated] = await this.db
       .update(reservations)
       .set(updateFields)
-      .where(eq(reservations.id, reservation.id))
+      .where(
+        and(
+          eq(reservations.id, reservation.id),
+          eq(reservations.propertyId, booking.propertyId),
+        ),
+      )
       .returning();
 
     // Emit webhook
@@ -409,23 +403,7 @@ export class ConnectBookingService {
    * Cancel booking — Agent 4.6 (Modification & Cancellation).
    */
   async cancel(confirmationNumber: string, reason?: string) {
-    const [booking] = await this.db
-      .select()
-      .from(bookings)
-      .where(eq(bookings.confirmationNumber, confirmationNumber));
-
-    if (!booking) {
-      throw new NotFoundException(`Booking ${confirmationNumber} not found`);
-    }
-
-    const [reservation] = await this.db
-      .select()
-      .from(reservations)
-      .where(eq(reservations.bookingId, booking.id));
-
-    if (!reservation) {
-      throw new NotFoundException('Reservation not found');
-    }
+    const { booking, reservation } = await this.loadBookingByConfirmation(confirmationNumber);
 
     if (['cancelled', 'checked_out', 'no_show'].includes(reservation.status)) {
       throw new BadRequestException(`Reservation already ${reservation.status}`);
@@ -435,7 +413,12 @@ export class ConnectBookingService {
     const [ratePlan] = await this.db
       .select()
       .from(ratePlans)
-      .where(eq(ratePlans.id, reservation.ratePlanId));
+      .where(
+        and(
+          eq(ratePlans.id, reservation.ratePlanId),
+          eq(ratePlans.propertyId, booking.propertyId),
+        ),
+      );
 
     const penaltyInfo = this.calculateCancellationPenalty(ratePlan, reservation);
 
@@ -448,7 +431,12 @@ export class ConnectBookingService {
         cancellationReason: reason ?? 'Cancelled by agent',
         updatedAt: new Date(),
       })
-      .where(eq(reservations.id, reservation.id));
+      .where(
+        and(
+          eq(reservations.id, reservation.id),
+          eq(reservations.propertyId, booking.propertyId),
+        ),
+      );
 
     // Generate cancellation number
     const cancellationNumber = `CXL-${Date.now().toString(36).toUpperCase()}`;
@@ -474,6 +462,33 @@ export class ConnectBookingService {
   }
 
   // --- Private Helpers ---
+
+  private async loadBookingByConfirmation(confirmationNumber: string) {
+    const [booking] = await this.db
+      .select()
+      .from(bookings)
+      .where(eq(bookings.confirmationNumber, confirmationNumber));
+
+    if (!booking) {
+      throw new NotFoundException(`Booking ${confirmationNumber} not found`);
+    }
+
+    const [reservation] = await this.db
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.bookingId, booking.id),
+          eq(reservations.propertyId, booking.propertyId),
+        ),
+      );
+
+    if (!reservation) {
+      throw new NotFoundException('Reservation not found for this booking');
+    }
+
+    return { booking, reservation };
+  }
 
   private async findOrCreateGuest(dto: AgentBookDto) {
     // Try to find by email — but ONLY reuse a guest that is already linked to

--- a/apps/api/src/modules/payment/payment.service.spec.ts
+++ b/apps/api/src/modules/payment/payment.service.spec.ts
@@ -392,10 +392,14 @@ describe('PaymentService', () => {
     describe('multi-refund partial scenario', () => {
       function buildRefundTxDb(
         original: any,
-        priorRefunds: any[],
+        prepareRefunds: any[],
+        postGatewayRefunds: any[],
         insertedRefund: any,
       ) {
+        let txRound = 0;
         const makeTx = () => {
+          txRound++;
+          const refundsForTx = txRound === 1 ? prepareRefunds : postGatewayRefunds;
           let selectCall = 0;
           return {
             select: vi.fn().mockImplementation(() => ({
@@ -408,7 +412,7 @@ describe('PaymentService', () => {
                     };
                   }
                   return {
-                    then: (resolve: any) => resolve(priorRefunds),
+                    then: (resolve: any) => resolve(refundsForTx),
                   };
                 }),
               }),
@@ -447,6 +451,7 @@ describe('PaymentService', () => {
         const db = buildRefundTxDb(
           capturedOriginal,
           [],
+          [],
           { id: 'refund-1', amount: '-50.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
@@ -456,9 +461,11 @@ describe('PaymentService', () => {
       });
 
       it('second partial refund on a legacy partially_refunded parent works', async () => {
+        const prior = [{ amount: '-50.00', originalPaymentId: 'pay-001' }];
         const db = buildRefundTxDb(
           partialOriginal,
-          [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
+          prior,
+          prior,
           { id: 'refund-2', amount: '-30.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
@@ -467,12 +474,14 @@ describe('PaymentService', () => {
       });
 
       it('final partial refund that closes the gap succeeds', async () => {
+        const prior = [
+          { amount: '-50.00', originalPaymentId: 'pay-001' },
+          { amount: '-30.00', originalPaymentId: 'pay-001' },
+        ];
         const db = buildRefundTxDb(
           partialOriginal,
-          [
-            { amount: '-50.00', originalPaymentId: 'pay-001' },
-            { amount: '-30.00', originalPaymentId: 'pay-001' },
-          ],
+          prior,
+          prior,
           { id: 'refund-3', amount: '-20.00', originalPaymentId: 'pay-001' },
         );
         const svc = await svcWith(db);
@@ -481,9 +490,11 @@ describe('PaymentService', () => {
       });
 
       it('rejects a refund that would exceed remaining refundable amount', async () => {
+        const prior = [{ amount: '-50.00', originalPaymentId: 'pay-001' }];
         const db = buildRefundTxDb(
           partialOriginal,
-          [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
+          prior,
+          prior,
           { id: 'unreachable' } as any,
         );
         const svc = await svcWith(db);
@@ -496,15 +507,18 @@ describe('PaymentService', () => {
         const db1 = buildRefundTxDb(
           capturedOriginal,
           [],
+          [],
           { id: 'refund-1', amount: '-50.00', originalPaymentId: 'pay-001' },
         );
         const svc1 = await svcWith(db1);
         await svc1.refundPayment('pay-001', 'prop-001', '50.00');
         const key1 = mockGateway.refund.mock.calls[mockGateway.refund.mock.calls.length - 1][2].idempotencyKey;
 
+        const prior = [{ amount: '-50.00', originalPaymentId: 'pay-001' }];
         const db2 = buildRefundTxDb(
           partialOriginal,
-          [{ amount: '-50.00', originalPaymentId: 'pay-001' }],
+          prior,
+          prior,
           { id: 'refund-2', amount: '-30.00', originalPaymentId: 'pay-001' },
         );
         const svc2 = await svcWith(db2);
@@ -512,6 +526,70 @@ describe('PaymentService', () => {
         const key2 = mockGateway.refund.mock.calls[mockGateway.refund.mock.calls.length - 1][2].idempotencyKey;
 
         expect(key1).not.toBe(key2);
+      });
+
+      it('does not re-emit webhook when ledger already reflects the refund', async () => {
+        const webhookChild = {
+          id: 'refund-webhook',
+          amount: '-50.00',
+          originalPaymentId: 'pay-001',
+          gatewayTransactionId: 'stripe_refund:ch_1:50.00',
+        };
+        const db = buildRefundTxDb(capturedOriginal, [], [webhookChild], webhookChild);
+        const svc = await svcWith(db);
+        const result = await svc.refundPayment('pay-001', 'prop-001', '50.00');
+        expect(result).toEqual(webhookChild);
+        expect(mockWebhookService.emit).not.toHaveBeenCalled();
+        expect(mockFolioService.recalculateBalance).not.toHaveBeenCalled();
+      });
+
+      it('records only the unrecorded portion when webhook recorded a partial refund', async () => {
+        const webhookChild = {
+          id: 'refund-webhook',
+          amount: '-30.00',
+          originalPaymentId: 'pay-001',
+          gatewayTransactionId: 'stripe_refund:ch_1:30.00',
+        };
+        const apiChild = {
+          id: 'refund-api',
+          amount: '-20.00',
+          originalPaymentId: 'pay-001',
+          gatewayTransactionId: 'mock-ref-123',
+        };
+        let insertValues: any;
+        let txRound = 0;
+        const makeTx = () => {
+          txRound++;
+          const refundsForTx = txRound === 1 ? [] : [webhookChild];
+          let selectCall = 0;
+          return {
+            select: vi.fn().mockImplementation(() => ({
+              from: vi.fn().mockReturnValue({
+                where: vi.fn().mockImplementation(() => {
+                  selectCall++;
+                  if (selectCall === 1) {
+                    return { for: vi.fn().mockResolvedValue([capturedOriginal]) };
+                  }
+                  return { then: (resolve: any) => resolve(refundsForTx) };
+                }),
+              }),
+            })),
+            insert: vi.fn().mockReturnValue({
+              values: vi.fn().mockImplementation((vals: any) => {
+                insertValues = vals;
+                return { returning: vi.fn().mockResolvedValue([apiChild]) };
+              }),
+            }),
+          };
+        };
+        const db = {
+          transaction: vi.fn(async (fn: any) => fn(makeTx())),
+          update: vi.fn(),
+          delete: vi.fn(),
+        };
+        const svc = await svcWith(db);
+        await svc.refundPayment('pay-001', 'prop-001', '50.00');
+        expect(insertValues.amount).toBe('-20.00');
       });
     });
   });

--- a/apps/api/src/modules/payment/payment.service.ts
+++ b/apps/api/src/modules/payment/payment.service.ts
@@ -341,7 +341,6 @@ export class PaymentService {
       throw new BadRequestException(`Refund failed: ${result.errorMessage}`);
     }
 
-    const refundRowAmount = refundDec.negated().toFixed(2);
     const refund = await this.db.transaction(async (tx: any) => {
       const [locked] = await tx
         .select()
@@ -351,21 +350,6 @@ export class PaymentService {
 
       if (!locked) {
         throw new NotFoundException(`Payment ${id} not found`);
-      }
-
-      if (result.transactionId) {
-        const [existingByGateway] = await tx
-          .select()
-          .from(payments)
-          .where(
-            and(
-              eq(payments.gatewayTransactionId, result.transactionId),
-              eq(payments.propertyId, propertyId),
-            ),
-          );
-        if (existingByGateway) {
-          return { row: existingByGateway, isNew: false };
-        }
       }
 
       const existingRefunds = await tx
@@ -378,16 +362,30 @@ export class PaymentService {
           ),
         );
       const alreadyRefundedDec = sumRefundChildren(existingRefunds ?? []);
-      const remainingDec = new Decimal(locked.amount).minus(alreadyRefundedDec);
 
-      if (refundDec.gt(remainingDec)) {
-        // Stripe webhook may have recorded this refund between prepare and insert.
-        if (alreadyRefundedDec.gte(totalAfterDec)) {
-          const latest = existingRefunds[existingRefunds.length - 1];
-          if (latest) {
-            return { row: latest, isNew: false };
-          }
+      if (result.transactionId) {
+        const existingByGateway = (existingRefunds ?? []).find(
+          (r: any) => r.gatewayTransactionId === result.transactionId,
+        );
+        if (existingByGateway) {
+          return { row: existingByGateway, isNew: false };
         }
+      }
+
+      // Webhook or a concurrent refund may have recorded part/all of this refund
+      // while the gateway call was in flight.
+      if (alreadyRefundedDec.gte(totalAfterDec)) {
+        const latest = existingRefunds[existingRefunds.length - 1];
+        if (latest) {
+          return { row: latest, isNew: false };
+        }
+      }
+
+      const ledgerRefundDec = Decimal.min(
+        refundDec,
+        totalAfterDec.minus(alreadyRefundedDec),
+      );
+      if (ledgerRefundDec.lte(0)) {
         throw new ConflictException(
           `Payment ${id} refundable amount changed during gateway refund`,
         );
@@ -399,7 +397,7 @@ export class PaymentService {
           folioId: locked.folioId,
           propertyId,
           method: locked.method,
-          amount: refundRowAmount,
+          amount: ledgerRefundDec.negated().toFixed(2),
           currencyCode: locked.currencyCode,
           status: 'captured',
           originalPaymentId: id,


### PR DESCRIPTION
## Summary
Targets `main` (#134 merged).

- **#12:** Post-gateway refund reconciliation — dedupe ledger rows/webhooks when a webhook or concurrent path already recorded the refund; insert only the unrecorded delta.
- **#7:** Connect `verify` / `modify` / `cancel` load reservations with `bookingId` **and** `propertyId` from the booking; related room type, room, folio, and rate-plan reads/updates are property-scoped.

Skipped: #8 (already on main), #5/#6 (already on main).

## Test plan
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/payment src/modules/connect/connect-booking.service.spec.ts`
- [ ] Concurrent partial refunds on the same payment cannot over-refund
- [ ] Connect modify/cancel cannot touch a reservation at another property via booking id alone