### PR TITLE
Production self-host packaging

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,72 @@
+# HAIP Production Environment
+#
+# Fill in every value marked REQUIRED, then copy to .env.production:
+#   cp .env.production.example .env.production
+#
+# Do NOT commit .env.production — it contains secrets.
+# Used by: docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up
+
+# ── Database (REQUIRED) ───────────────────────────────────────────────────────
+# Default matches docker-compose postgres service (user/password/db: haip).
+DATABASE_URL=postgresql://haip:haip@postgres:5432/haip
+
+# ── Redis (REQUIRED) ──────────────────────────────────────────────────────────
+REDIS_URL=redis://redis:6379
+
+# ── API ───────────────────────────────────────────────────────────────────────
+PORT=3000
+NODE_ENV=production
+
+# Serve bundled dashboard (/) and booking engine (/booking/) from the API container.
+SERVE_DASHBOARD=true
+SERVE_BOOKING=true
+
+# Do NOT set HAIP_ALLOW_INSECURE in production — the API refuses insecure configs
+# when NODE_ENV=production unless that flag is explicitly true (demo only).
+
+# CORS: comma-separated browser origins allowed to call the API.
+# Omit or leave empty for same-origin only (dashboard/booking served from this host).
+# CORS_ORIGINS=https://pms.example.com
+
+# ── Authentication — Keycloak (REQUIRED) ────────────────────────────────────────
+AUTH_ENABLED=true
+# Internal URL when running inside docker-compose (api → keycloak):
+KEYCLOAK_URL=http://keycloak:8080
+KEYCLOAK_REALM=haip
+KEYCLOAK_CLIENT_ID=haip-api
+# KEYCLOAK_AUDIENCE=haip-api
+
+# Connect API (OTAIP agents) — comma-separated API keys (REQUIRED when AUTH_ENABLED=true).
+# CONNECT_API_KEY=your-connect-key-here
+
+# ── Stripe payments (REQUIRED) ────────────────────────────────────────────────
+# Use test for staging; live for real charges.
+STRIPE_MODE=test
+# STRIPE_MODE=live
+STRIPE_SECRET_KEY=sk_test_REPLACE_ME
+# STRIPE_PUBLISHABLE_KEY=pk_test_REPLACE_ME
+STRIPE_WEBHOOK_SECRET=whsec_REPLACE_ME
+
+# ── Email — guest communications agent (optional) ─────────────────────────────
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USER=
+# SMTP_PASS=
+# SMTP_FROM=noreply@example.com
+
+# ── Media storage (optional) ──────────────────────────────────────────────────
+# STORAGE_DRIVER=local
+# For uploads, use s3 and start MinIO with: docker compose --profile storage up
+# STORAGE_DRIVER=s3
+# S3_BUCKET=haip-media
+# S3_REGION=us-east-1
+# S3_ENDPOINT=
+# S3_ACCESS_KEY_ID=
+# S3_SECRET_ACCESS_KEY=
+# S3_FORCE_PATH_STYLE=false
+# S3_PUBLIC_BASE_URL=
+
+# ── Rate limiting (optional) ──────────────────────────────────────────────────
+# RATE_LIMIT_MAX=300
+# RATE_LIMIT_WINDOW_MS=60000
+# RATE_LIMIT_TRUST_PROXY=true

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist/
 # Environment
 .env
 .env.local
+.env.production
 .env.*.local
 
 # IDE

--- a/README.md
+++ b/README.md
@@ -456,6 +456,23 @@ straight in the app; to explore the Keycloak login/RBAC flow instead, run
 > One-click cloud demo: see [Deploy to the cloud](#deploy-to-the-cloud) to spin up
 > a hosted instance with zero local setup.
 
+### Production self-host
+
+Credentials-only setup: the repo wires services; you supply secrets in `.env.production`.
+
+```bash
+cp .env.production.example .env.production
+# Edit .env.production — set DATABASE_URL, Stripe keys, Keycloak, CONNECT_API_KEY, etc.
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build
+```
+
+- **Dashboard:** `http://localhost:3000` (or your host)
+- **Keycloak:** `http://localhost:8080` (change default admin password after first login)
+- **Auth is on** (`AUTH_ENABLED=true`); do not set `HAIP_ALLOW_INSECURE`
+
+Install scheduled jobs (night audit, group block cutoffs) from [`scripts/cron/`](./scripts/cron/) — see [`docs/operations/cron.md`](./docs/operations/cron.md) for endpoint details and required roles.
+
 ### Local development
 
 For hot-reload development against the source (requires **Node ≥ 20** and **pnpm ≥ 9**):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,40 @@
+# Production self-host overrides for docker-compose.yml
+#
+# Prerequisites:
+#   cp .env.production.example .env.production   # fill credentials
+#
+# Start (Keycloak is on the `auth` profile in the base file):
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build
+#
+# Services: postgres, redis, keycloak (--profile auth), init, api.
+# Mock channel adapters and MinIO stay on optional profiles (channels, storage).
+
+services:
+  api:
+    env_file:
+      - .env.production
+    environment:
+      NODE_ENV: production
+      AUTH_ENABLED: 'true'
+      SERVE_DASHBOARD: 'true'
+      SERVE_BOOKING: 'true'
+      # Override demo-only opt-out; must not be 'true' in production.
+      HAIP_ALLOW_INSECURE: ''
+      KEYCLOAK_URL: http://keycloak:8080
+      DATABASE_URL: postgresql://haip:haip@postgres:5432/haip
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+
+  init:
+    env_file:
+      - .env.production
+    environment:
+      DATABASE_URL: postgresql://haip:haip@postgres:5432/haip

--- a/scripts/cron/README.md
+++ b/scripts/cron/README.md
@@ -1,0 +1,77 @@
+# HAIP scheduled jobs (cron)
+
+HAIP has no in-process scheduler. Run these scripts from **system cron**, Kubernetes CronJob, or similar.
+
+Full endpoint reference: [`docs/operations/cron.md`](../../docs/operations/cron.md).
+
+## Authentication
+
+All endpoints require a **Keycloak JWT** with the appropriate realm role (`night_auditor` or `admin` for night audit; `admin`, `night_auditor`, or `revenue_manager` for group cutoffs).
+
+Two supported options:
+
+### Option A — Client credentials (recommended)
+
+1. In Keycloak, create a **confidential** client (e.g. `haip-cron`) with **Service accounts** enabled.
+2. Assign realm roles to the service account user: at minimum `night_auditor` (or `admin`).
+3. Copy the client secret from the **Credentials** tab.
+4. Export:
+
+```bash
+export HAIP_URL=https://pms.example.com
+export HAIP_PROPERTY_ID=<property-uuid>
+export KEYCLOAK_URL=https://auth.example.com
+export KEYCLOAK_REALM=haip
+export KEYCLOAK_CLIENT_ID=haip-cron
+export KEYCLOAK_CLIENT_SECRET=<secret>
+```
+
+Scripts fetch a short-lived token automatically before each run.
+
+### Option B — Pre-issued token
+
+If you refresh tokens externally, set `HAIP_CRON_TOKEN` to a valid Bearer JWT and omit Keycloak client vars.
+
+## Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `HAIP_URL` | yes | Base URL of your deployment (no trailing slash) |
+| `HAIP_PROPERTY_ID` | yes | Property UUID to operate on |
+| `HAIP_BUSINESS_DATE` | no | Night audit date (`YYYY-MM-DD`); defaults to yesterday UTC |
+| `HAIP_CRON_TOKEN` | option B | Pre-fetched JWT |
+| `KEYCLOAK_URL` | option A | Keycloak base URL |
+| `KEYCLOAK_REALM` | option A | Realm name (default `haip`) |
+| `KEYCLOAK_CLIENT_ID` | option A | Cron service client id |
+| `KEYCLOAK_CLIENT_SECRET` | option A | Cron service client secret |
+
+## Install
+
+```bash
+chmod +x scripts/cron/*.sh
+```
+
+Copy [`crontab.example`](./crontab.example), edit paths and env, then:
+
+```bash
+crontab scripts/cron/crontab.example
+```
+
+Or source env from a file:
+
+```bash
+# /etc/haip/cron.env  (mode 600, root-owned)
+set -a
+source /etc/haip/cron.env
+set +a
+/path/to/haip/scripts/cron/night-audit.sh
+```
+
+## Scripts
+
+| Script | Schedule (typical) | API |
+|--------|-------------------|-----|
+| `night-audit.sh` | Daily ~00:30 property local time | `POST /api/v1/night-audit/run` |
+| `group-cutoffs.sh` | Daily after night audit | `POST /api/v1/groups/blocks/process-cutoffs` |
+
+Scripts exit non-zero on HTTP errors (non-2xx).

--- a/scripts/cron/_common.sh
+++ b/scripts/cron/_common.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared helpers for HAIP scheduled job scripts.
+set -euo pipefail
+
+: "${HAIP_URL:?Set HAIP_URL (e.g. https://pms.example.com)}"
+
+fetch_token() {
+  if [ -n "${HAIP_CRON_TOKEN:-}" ]; then
+    printf '%s' "$HAIP_CRON_TOKEN"
+    return 0
+  fi
+
+  : "${KEYCLOAK_URL:?Set KEYCLOAK_URL or HAIP_CRON_TOKEN}"
+  : "${KEYCLOAK_REALM:?Set KEYCLOAK_REALM (e.g. haip)}"
+  : "${KEYCLOAK_CLIENT_ID:?Set KEYCLOAK_CLIENT_ID (cron service client)}"
+  : "${KEYCLOAK_CLIENT_SECRET:?Set KEYCLOAK_CLIENT_SECRET}"
+
+  local response token
+  response=$(curl -sf \
+    -X POST "${KEYCLOAK_URL%/}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'grant_type=client_credentials' \
+    --data-urlencode "client_id=${KEYCLOAK_CLIENT_ID}" \
+    --data-urlencode "client_secret=${KEYCLOAK_CLIENT_SECRET}")
+
+  token=$(printf '%s' "$response" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+  if [ -z "$token" ]; then
+    echo "Failed to obtain access token from Keycloak" >&2
+    exit 1
+  fi
+  printf '%s' "$token"
+}
+
+# POST to /api/v1/<path>. Extra curl args (e.g. -d '...') after the path.
+api_post() {
+  local path="$1"
+  shift
+
+  local token url tmp http_code
+  token=$(fetch_token)
+  url="${HAIP_URL%/}/api/v1/${path#/}"
+  tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
+
+  http_code=$(curl -sS -o "$tmp" -w '%{http_code}' \
+    -X POST "$url" \
+    -H "Authorization: Bearer ${token}" \
+    -H 'Content-Type: application/json' \
+    "$@")
+
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    echo "POST ${url} failed with HTTP ${http_code}" >&2
+    cat "$tmp" >&2
+    exit 1
+  fi
+
+  cat "$tmp"
+}

--- a/scripts/cron/crontab.example
+++ b/scripts/cron/crontab.example
@@ -1,0 +1,21 @@
+# HAIP cron — example crontab
+#
+# Install: edit paths/env below, then: crontab scripts/cron/crontab.example
+#
+# Suggested schedule (adjust to property timezone):
+#   Night audit: 00:30 daily
+#   Group cutoffs: 01:00 daily (after night audit)
+
+SHELL=/bin/bash
+PATH=/usr/local/bin:/usr/bin:/bin
+
+# Load secrets from a root-owned file (chmod 600). Do not commit real values.
+# HAIP_URL=https://pms.example.com
+# HAIP_PROPERTY_ID=00000000-0000-4000-8000-000000000001
+# KEYCLOAK_URL=https://auth.example.com
+# KEYCLOAK_REALM=haip
+# KEYCLOAK_CLIENT_ID=haip-cron
+# KEYCLOAK_CLIENT_SECRET=replace-me
+
+30 0 * * * set -a && source /etc/haip/cron.env && set +a && /opt/haip/scripts/cron/night-audit.sh >> /var/log/haip/night-audit.log 2>&1
+0 1 * * * set -a && source /etc/haip/cron.env && set +a && /opt/haip/scripts/cron/group-cutoffs.sh >> /var/log/haip/group-cutoffs.log 2>&1

--- a/scripts/cron/group-cutoffs.sh
+++ b/scripts/cron/group-cutoffs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Release expired group allotment blocks (auto-release cutoff sweep).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+: "${HAIP_PROPERTY_ID:?Set HAIP_PROPERTY_ID (property UUID)}"
+
+api_post "groups/blocks/process-cutoffs?propertyId=${HAIP_PROPERTY_ID}"
+
+echo "Group cutoff sweep completed for ${HAIP_PROPERTY_ID}"

--- a/scripts/cron/night-audit.sh
+++ b/scripts/cron/night-audit.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Run night audit for one property. Requires JWT (see README.md).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=_common.sh
+source "${SCRIPT_DIR}/_common.sh"
+
+: "${HAIP_PROPERTY_ID:?Set HAIP_PROPERTY_ID (property UUID)}"
+
+if [ -z "${HAIP_BUSINESS_DATE:-}" ]; then
+  if date -u -d 'yesterday' +%Y-%m-%d >/dev/null 2>&1; then
+    HAIP_BUSINESS_DATE=$(date -u -d 'yesterday' +%Y-%m-%d)
+  else
+    HAIP_BUSINESS_DATE=$(date -u -v-1d +%Y-%m-%d)
+  fi
+fi
+
+api_post 'night-audit/run' \
+  -d "{\"propertyId\":\"${HAIP_PROPERTY_ID}\",\"businessDate\":\"${HAIP_BUSINESS_DATE}\"}"
+
+echo "Night audit completed for ${HAIP_PROPERTY_ID} (${HAIP_BUSINESS_DATE})"


### PR DESCRIPTION
## Summary
- Add `docker-compose.prod.yml` overlay for auth-on production deploys (dashboard + booking served from API)
- Add `.env.production.example` with required credentials and security defaults
- Add `scripts/cron/` helpers for night audit and group block cutoffs (Keycloak client-credentials or pre-issued JWT)
- Document production self-host flow in README; ignore `.env.production`

## Test plan
- [ ] `cp .env.production.example .env.production` and fill placeholders
- [ ] `docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build`
- [ ] Dashboard loads at `:3000`, Keycloak at `:8080`
- [ ] `chmod +x scripts/cron/*.sh` and dry-run `night-audit.sh` / `group-cutoffs.sh` with test credentials