### PR TITLE
fix(front-desk): assign room before check-in for confirmed arrivals

### DIFF
--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -640,6 +640,20 @@ export class ReservationService {
     // Process each check-in individually
     for (const item of dto.reservations) {
       try {
+        // KB state machine (pending → confirmed → assigned → checked_in): a
+        // still-confirmed reservation must be assigned a room before it can
+        // check in. Assign first using the provided override or its
+        // pre-assigned room, then check in.
+        const reservation = await this.findByIdRaw(item.reservationId, propertyId);
+        if (reservation.status === 'confirmed') {
+          const roomToAssign = item.roomId ?? reservation.roomId ?? undefined;
+          if (!roomToAssign) {
+            throw new BadRequestException(
+              `Reservation ${item.reservationId} has no room assigned — provide a roomId`,
+            );
+          }
+          await this.assignRoom(item.reservationId, propertyId, { roomId: roomToAssign });
+        }
         const result = await this.checkIn(item.reservationId, propertyId, {
           roomId: item.roomId,
           skipDepositAuth: item.skipDepositAuth,

--- a/apps/dashboard/src/pages/FrontDesk.tsx
+++ b/apps/dashboard/src/pages/FrontDesk.tsx
@@ -75,12 +75,30 @@ export default function FrontDesk() {
   };
 
   const checkInMutation = useMutation({
-    mutationFn: (data: { id: string; roomId?: string; idType?: string; idNumber?: string }) =>
-      api.patch(`/v1/reservations/${data.id}/check-in`, {
+    mutationFn: async (data: {
+      id: string;
+      status: string;
+      preAssignedRoomId?: string;
+      roomId?: string;
+      idType?: string;
+      idNumber?: string;
+    }) => {
+      // KB state machine: pending → confirmed → assigned → checked_in.
+      // A still-confirmed arrival must be assigned a room before it can check
+      // in, otherwise the API rejects the confirmed → checked_in transition.
+      if (data.status === 'confirmed') {
+        const roomToAssign = data.roomId || data.preAssignedRoomId;
+        if (!roomToAssign) {
+          throw new Error('Assign a room before checking in this guest.');
+        }
+        await api.patch(`/v1/reservations/${data.id}/assign-room`, { roomId: roomToAssign });
+      }
+      return api.patch(`/v1/reservations/${data.id}/check-in`, {
         roomId: data.roomId || undefined,
         idType: data.idType,
         idNumber: data.idNumber,
-      }),
+      });
+    },
     onSuccess: () => {
       invalidateAll();
       setCheckInModal(null);
@@ -382,6 +400,8 @@ export default function FrontDesk() {
               <button
                 onClick={() => checkInMutation.mutate({
                   id: checkInModal.id,
+                  status: checkInModal.status,
+                  preAssignedRoomId: checkInModal.roomId,
                   roomId: selectedRoom || undefined,
                   idType,
                   idNumber: idNumber || undefined,


### PR DESCRIPTION
Confirmed arrivals were being sent straight to check-in, which the KB state machine rejects (confirmed cannot go directly to checked_in), returning 400. Both single check-in (dashboard) and group check-in (API) now assign a room first, then check in.

Made with [Cursor](https://cursor.com)