### PR TITLE
feat(deploy): production compose path, GHCR publish, release smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,55 @@ jobs:
           DATABASE_URL: postgresql://haip:haip@localhost:5432/haip_test
           REDIS_URL: redis://localhost:6379
 
+  release-smoke:
+    name: Release smoke (PMS contract)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: haip
+          POSTGRES_PASSWORD: haip
+          POSTGRES_DB: haip_smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Run release smoke test
+        run: pnpm --filter @telivityhaip/api run test:release-smoke
+        env:
+          DATABASE_URL: postgresql://haip:haip@localhost:5432/haip_smoke
+          REDIS_URL: redis://localhost:6379
+          RELEASE_SMOKE: '1'
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   ci:
@@ -71,6 +72,9 @@ jobs:
     name: Auto Release
     needs: ci
     runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.version.outputs.skip }}
+      next: ${{ steps.version.outputs.next }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -158,3 +162,38 @@ jobs:
           body_path: changelog.md
           generate_release_notes: false
           draft: false
+
+  publish-image:
+    name: Publish API image to GHCR
+    needs: release
+    if: needs.release.outputs.skip == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          push: true
+          build-args: |
+            VITE_AUTH_ENABLED=true
+            VITE_KEYCLOAK_URL=http://localhost:8080
+            VITE_KEYCLOAK_REALM=haip
+            VITE_KEYCLOAK_CLIENT_ID=haip-dashboard
+          tags: |
+            ghcr.io/telivityai/haip-api:${{ needs.release.outputs.next }}
+            ghcr.io/telivityai/haip-api:latest

--- a/README.md
+++ b/README.md
@@ -450,15 +450,22 @@ hotel with the AI agents already running**, and serves everything at one URL:
 The first run builds the image and can take a few minutes; subsequent starts are
 fast. A one-shot `init` container pushes the schema and seeds the demo before the
 API starts (idempotent — safe to re-run). Auth is **off by default** so you land
-straight in the app; to explore the Keycloak login/RBAC flow instead, run
-`docker compose --profile auth up` and set `AUTH_ENABLED=true`.
+straight in the app; to explore the Keycloak login/RBAC flow instead, run:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.auth.yml --profile auth up -d --build
+```
+
+See [`docs/deployment.md`](./docs/deployment.md) for production self-host.
 
 > One-click cloud demo: see [Deploy to the cloud](#deploy-to-the-cloud) to spin up
 > a hosted instance with zero local setup.
 
 ### Production self-host
 
-Credentials-only setup: the repo wires services; you supply secrets in `.env.production`.
+See **[`docs/deployment.md`](./docs/deployment.md)** for the full production guide (compose files, env vars, TLS, backups, upgrades, GHCR images).
+
+Quick start:
 
 ```bash
 cp .env.production.example .env.production
@@ -467,11 +474,7 @@ cp .env.production.example .env.production
 docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build
 ```
 
-- **Dashboard:** `http://localhost:3000` (or your host)
-- **Keycloak:** `http://localhost:8080` (change default admin password after first login)
-- **Auth is on** (`AUTH_ENABLED=true`); do not set `HAIP_ALLOW_INSECURE`
-
-Install scheduled jobs (night audit, group block cutoffs) from [`scripts/cron/`](./scripts/cron/) — see [`docs/operations/cron.md`](./docs/operations/cron.md) for endpoint details and required roles.
+Auth is on (`AUTH_ENABLED=true`); do not set `HAIP_ALLOW_INSECURE`.
 
 ### Local development
 
@@ -515,15 +518,7 @@ builds a single image serving the API, dashboard (`/`), and booking engine (`/bo
 
 ### Production checklist
 
-Before going live, verify:
-
-- `AUTH_ENABLED=true` with Keycloak configured (`KEYCLOAK_URL`, realm, client)
-- `STRIPE_MODE=live` (or `test`) with real keys — not `mock`
-- Do **not** set `HAIP_ALLOW_INSECURE` in production
-- `SERVE_DASHBOARD=true` and/or `SERVE_BOOKING=true` if serving UIs from the API container
-- External cron for night audit and agent training — see [`docs/operations/cron.md`](./docs/operations/cron.md)
-- `CORS_ORIGINS` set to your dashboard/booking hostnames
-- `STORAGE_DRIVER=s3` if using photo uploads (MinIO or AWS)
+Before going live, verify the items in [`docs/deployment.md`](./docs/deployment.md#required-environment-variables) and [`docs/operations/cron.md`](./docs/operations/cron.md).
 
 ### Run tests
 

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -25,6 +25,16 @@ COPY apps/booking/ ./apps/booking/
 RUN pnpm --filter @telivityhaip/shared run build
 RUN pnpm --filter @telivityhaip/database run build
 
+# Dashboard SPA — auth/Keycloak settings are baked at build time (Vite env).
+ARG VITE_AUTH_ENABLED=false
+ARG VITE_KEYCLOAK_URL=http://localhost:8080
+ARG VITE_KEYCLOAK_REALM=haip
+ARG VITE_KEYCLOAK_CLIENT_ID=haip-dashboard
+ENV VITE_AUTH_ENABLED=$VITE_AUTH_ENABLED \
+    VITE_KEYCLOAK_URL=$VITE_KEYCLOAK_URL \
+    VITE_KEYCLOAK_REALM=$VITE_KEYCLOAK_REALM \
+    VITE_KEYCLOAK_CLIENT_ID=$VITE_KEYCLOAK_CLIENT_ID
+
 # Build dashboard (Vite static output)
 RUN pnpm --filter dashboard run build
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit -p tsconfig.build.json",
     "test": "vitest run",
+    "test:release-smoke": "RELEASE_SMOKE=1 vitest run src/release-smoke.integration.spec.ts",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "clean": "rm -rf dist"
@@ -57,7 +58,9 @@
     "@types/express": "^5.0.6",
     "@types/multer": "^1.4.12",
     "@types/passport-jwt": "^4.0.1",
+    "@types/supertest": "^6.0.2",
     "eslint": "^9.0.0",
+    "supertest": "^7.0.0",
     "typescript": "^5.7.0",
     "unplugin-swc": "^1.5.9",
     "vitest": "^2.1.0"

--- a/apps/api/src/release-smoke.integration.spec.ts
+++ b/apps/api/src/release-smoke.integration.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Release smoke test — exercises migrate → seed → core PMS HTTP contract.
+ *
+ * Runs only when RELEASE_SMOKE=1 (CI release-smoke job). Uses AUTH_ENABLED=false
+ * so the flow tests business endpoints without Keycloak setup.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Test } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+import request from 'supertest';
+import { AppModule } from './app.module';
+import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
+
+const runSmoke = process.env.RELEASE_SMOKE === '1';
+
+/** Seeded demo property and entities (packages/database/src/seed.ts). */
+const PROPERTY_ID = 'a0000001-0000-4000-a000-000000000001';
+const GUEST_ID = 'e0000001-0000-4000-a000-000000000001';
+const ROOM_TYPE_ID = 'b0000001-0000-4000-a000-000000000001';
+const RATE_PLAN_ID = 'd0000001-0000-4000-a000-000000000001';
+const ROOM_ID = 'c0000001-0000-4000-a000-000000000008'; // room 108 — vacant_clean
+
+function offsetDate(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+describe.runIf(runSmoke)('release smoke (migrate → reservation lifecycle)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) {
+      throw new Error('DATABASE_URL is required for release smoke');
+    }
+
+    process.env.AUTH_ENABLED = 'false';
+    process.env.NODE_ENV = 'test';
+    process.env.STRIPE_MODE = 'mock';
+    process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+
+    const root = join(__dirname, '..', '..', '..');
+    execSync('node packages/database/dist/push-schema.js', {
+      cwd: root,
+      env: { ...process.env, DATABASE_URL: dbUrl },
+      stdio: 'inherit',
+    });
+    execSync('node packages/database/dist/seed.js', {
+      cwd: root,
+      env: { ...process.env, DATABASE_URL: dbUrl },
+      stdio: 'inherit',
+    });
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleRef.createNestApplication();
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+    await app.init();
+  }, 120_000);
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('search availability → create reservation → check-in → folio charge → night audit', async () => {
+    const arrivalDate = offsetDate(30);
+    const departureDate = offsetDate(33);
+
+    const availRes = await request(app.getHttpServer())
+      .post('/api/v1/reservations/search-availability')
+      .send({
+        propertyId: PROPERTY_ID,
+        checkIn: arrivalDate,
+        checkOut: departureDate,
+        roomTypeId: ROOM_TYPE_ID,
+      })
+      .expect(201);
+
+    const availability = availRes.body;
+    expect(Array.isArray(availability)).toBe(true);
+    expect(availability.some((r: { roomTypeId: string }) => r.roomTypeId === ROOM_TYPE_ID)).toBe(
+      true,
+    );
+
+    const createRes = await request(app.getHttpServer())
+      .post('/api/v1/reservations')
+      .send({
+        propertyId: PROPERTY_ID,
+        guestId: GUEST_ID,
+        arrivalDate,
+        departureDate,
+        roomTypeId: ROOM_TYPE_ID,
+        ratePlanId: RATE_PLAN_ID,
+        totalAmount: '599.00',
+        currencyCode: 'USD',
+        source: 'direct',
+        adults: 2,
+      })
+      .expect(201);
+
+    const reservationId = createRes.body.id as string;
+    expect(reservationId).toBeTruthy();
+
+    await request(app.getHttpServer())
+      .patch(`/api/v1/reservations/${reservationId}/confirm`)
+      .query({ propertyId: PROPERTY_ID })
+      .expect(200);
+
+    await request(app.getHttpServer())
+      .patch(`/api/v1/reservations/${reservationId}/assign-room`)
+      .query({ propertyId: PROPERTY_ID })
+      .send({ roomId: ROOM_ID })
+      .expect(200);
+
+    const checkInRes = await request(app.getHttpServer())
+      .patch(`/api/v1/reservations/${reservationId}/check-in`)
+      .query({ propertyId: PROPERTY_ID })
+      .send({ roomId: ROOM_ID, idType: 'passport', idNumber: 'SMOKE123', idCountry: 'US' })
+      .expect(200);
+
+    const folioId = checkInRes.body.folio?.id as string;
+    expect(folioId).toBeTruthy();
+
+    await request(app.getHttpServer())
+      .post(`/api/v1/folios/${folioId}/charges`)
+      .send({
+        propertyId: PROPERTY_ID,
+        type: 'minibar',
+        description: 'Release smoke minibar charge',
+        amount: '12.50',
+        currencyCode: 'USD',
+        serviceDate: arrivalDate,
+      })
+      .expect(201);
+
+    const auditDate = offsetDate(-3);
+    const auditRes = await request(app.getHttpServer())
+      .post('/api/v1/night-audit/run')
+      .send({ propertyId: PROPERTY_ID, businessDate: auditDate })
+      .expect(200);
+
+    expect(auditRes.body.auditRun?.status === 'completed' || auditRes.body.alreadyRun === true).toBe(
+      true,
+    );
+  });
+});

--- a/docker-compose.auth.yml
+++ b/docker-compose.auth.yml
@@ -1,0 +1,43 @@
+# Auth exploration overlay for docker-compose.yml
+#
+# Turns API auth on when Keycloak is running (--profile auth). The dashboard SPA
+# is rebuilt with VITE_AUTH_ENABLED=true so the UI redirects to Keycloak login.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.auth.yml --profile auth up -d --build
+#
+# For production self-host (NODE_ENV=production, Stripe, CONNECT_API_KEY), use
+# docker-compose.prod.yml instead — see docs/deployment.md.
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      args:
+        VITE_AUTH_ENABLED: 'true'
+        VITE_KEYCLOAK_URL: http://localhost:8080
+        VITE_KEYCLOAK_REALM: haip
+        VITE_KEYCLOAK_CLIENT_ID: haip-dashboard
+    environment:
+      AUTH_ENABLED: 'true'
+      # Demo exploration only — not production. Prod overlay clears this flag.
+      HAIP_ALLOW_INSECURE: 'true'
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+      keycloak:
+        condition: service_healthy
+
+  init:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      args:
+        VITE_AUTH_ENABLED: 'true'
+        VITE_KEYCLOAK_URL: http://localhost:8080
+        VITE_KEYCLOAK_REALM: haip
+        VITE_KEYCLOAK_CLIENT_ID: haip-dashboard

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,14 @@
 
 services:
   api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      args:
+        VITE_AUTH_ENABLED: 'true'
+        VITE_KEYCLOAK_URL: http://localhost:8080
+        VITE_KEYCLOAK_REALM: haip
+        VITE_KEYCLOAK_CLIENT_ID: haip-dashboard
     env_file:
       - .env.production
     environment:
@@ -18,6 +26,7 @@ services:
       AUTH_ENABLED: 'true'
       SERVE_DASHBOARD: 'true'
       SERVE_BOOKING: 'true'
+      STRIPE_MODE: test
       # Override demo-only opt-out; must not be 'true' in production.
       HAIP_ALLOW_INSECURE: ''
       KEYCLOAK_URL: http://keycloak:8080
@@ -34,6 +43,14 @@ services:
         condition: service_healthy
 
   init:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+      args:
+        VITE_AUTH_ENABLED: 'true'
+        VITE_KEYCLOAK_URL: http://localhost:8080
+        VITE_KEYCLOAK_REALM: haip
+        VITE_KEYCLOAK_CLIENT_ID: haip-dashboard
     env_file:
       - .env.production
     environment:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,166 @@
+# HAIP Production Deployment
+
+This guide covers self-hosting HAIP with authentication enabled and secure defaults.
+For the zero-config local demo, see [Quick Start](../README.md#quick-start) in the README.
+
+## Compose files
+
+| File | Purpose |
+|------|---------|
+| [`docker-compose.yml`](../docker-compose.yml) | Default **demo** stack — auth off, `STRIPE_MODE=mock`, `HAIP_ALLOW_INSECURE=true` |
+| [`docker-compose.auth.yml`](../docker-compose.auth.yml) | Optional overlay — explore Keycloak login with `--profile auth` |
+| [`docker-compose.prod.yml`](../docker-compose.prod.yml) | **Production** overlay — `AUTH_ENABLED=true`, no insecure flag, `STRIPE_MODE=test` |
+
+### Demo (one command)
+
+```bash
+docker compose up -d --build
+```
+
+Serves dashboard, booking widget (`/booking/`), and API at `http://localhost:3000`. Auth is **off** by default.
+
+### Explore auth locally
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.auth.yml --profile auth up -d --build
+```
+
+- API enforces JWT (`AUTH_ENABLED=true`)
+- Dashboard SPA is built with `VITE_AUTH_ENABLED=true` and redirects to Keycloak
+- Keycloak admin: `http://localhost:8080` (default `admin` / `admin` — change immediately)
+
+Unauthenticated requests to protected API routes return **401**, e.g.:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  "http://localhost:3000/api/v1/reservations?propertyId=a0000001-0000-4000-a000-000000000001"
+# 401
+```
+
+### Production self-host
+
+```bash
+cp .env.production.example .env.production
+# Edit .env.production — fill Stripe keys, CONNECT_API_KEY, CORS, storage, etc.
+
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build
+```
+
+Services: **postgres**, **redis**, **keycloak** (`--profile auth`), **init** (migrate + seed), **api**.
+
+The API refuses to boot in `NODE_ENV=production` when `AUTH_ENABLED=false` or `STRIPE_MODE=mock`, unless `HAIP_ALLOW_INSECURE=true` (demo only — never set in production).
+
+Validate compose config before deploying:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml config
+```
+
+## Required environment variables
+
+Copy [`.env.production.example`](../.env.production.example) to `.env.production`. At minimum:
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `DATABASE_URL` | Yes | Postgres connection string |
+| `REDIS_URL` | Yes | Redis for cache, queues, pub/sub |
+| `AUTH_ENABLED` | Yes | Must be `true` in production |
+| `KEYCLOAK_URL` | Yes | Internal URL (`http://keycloak:8080` in compose) |
+| `KEYCLOAK_REALM` | Yes | Default `haip` |
+| `KEYCLOAK_CLIENT_ID` | Yes | API client, default `haip-api` |
+| `CONNECT_API_KEY` | Yes when auth on | Comma-separated keys for OTAIP Connect API |
+| `STRIPE_MODE` | Yes | `test` for staging, `live` for real charges |
+| `STRIPE_SECRET_KEY` | Yes | Stripe secret key matching mode |
+| `STRIPE_WEBHOOK_SECRET` | Yes | Webhook signing secret |
+| `SERVE_DASHBOARD` | Recommended | Serve bundled dashboard at `/` |
+| `SERVE_BOOKING` | Recommended | Serve booking widget at `/booking/` |
+| `CORS_ORIGINS` | If cross-origin | Comma-separated browser origins; omit for same-origin |
+| `STORAGE_DRIVER` | If uploads | `s3` with bucket credentials, or `local` |
+
+**Keycloak (production notes):** The base compose file runs Keycloak in `start-dev` mode for local exploration. For real deployments, run Keycloak in production mode with TLS, strong admin credentials, and a managed Postgres database — do not expose port 8080 publicly without a reverse proxy.
+
+**Stripe:** Production overlay sets `STRIPE_MODE=test` by default. Switch to `live` and live keys only when ready to accept real payments.
+
+## TLS termination
+
+Terminate TLS at a reverse proxy in front of the API container (port 3000). Example **Caddy** site block:
+
+```caddyfile
+pms.example.com {
+    reverse_proxy haip-api:3000
+}
+```
+
+Example **nginx**:
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name pms.example.com;
+    ssl_certificate     /etc/ssl/certs/pms.crt;
+    ssl_certificate_key /etc/ssl/private/pms.key;
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+Set `CORS_ORIGINS=https://pms.example.com` when the browser calls the API from a different hostname.
+
+## Scheduled jobs (cron)
+
+Night audit, group block cutoffs, and agent training run via **external cron** hitting authenticated API endpoints. See [`docs/operations/cron.md`](./operations/cron.md) and [`scripts/cron/`](../scripts/cron/).
+
+## Database backup and restore
+
+Backup (run from a host with `pg_dump` access):
+
+```bash
+pg_dump "$DATABASE_URL" -Fc -f haip-$(date +%Y%m%d).dump
+```
+
+Test restore on staging before relying on backups:
+
+```bash
+pg_restore -d "$STAGING_DATABASE_URL" --clean --if-exists haip-YYYYMMDD.dump
+```
+
+## Upgrades
+
+1. **Backup** the database (`pg_dump` above).
+2. Pull the new image (or rebuild).
+3. Run schema migration **before** switching traffic:
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml run --rm init \
+     sh -c "node packages/database/dist/push-schema.js"
+   ```
+4. Restart the API: `docker compose ... up -d api`.
+
+The `init` service is idempotent — safe to re-run on every deploy.
+
+## Container images (GHCR)
+
+On each release, GitHub Actions publishes:
+
+```
+ghcr.io/telivityai/haip-api:<tag>
+ghcr.io/telivityai/haip-api:latest
+```
+
+Pull and run (supply your own `.env.production` and Postgres/Redis/Keycloak):
+
+```bash
+docker pull ghcr.io/telivityai/haip-api:latest
+docker run --env-file .env.production -p 3000:3000 ghcr.io/telivityai/haip-api:latest
+```
+
+For the full stack (Postgres, Redis, Keycloak, migrate/seed), use the compose files above rather than a bare `docker run`.
+
+## Booking widget with auth on
+
+When `AUTH_ENABLED=true`, the public booking engine requires a per-property **booking key** (`x-booking-key` header or `?key=` query param). Generate or rotate keys in the dashboard under **Settings → Booking Engine**.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,9 +135,15 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.1
         version: 4.0.1
+      '@types/supertest':
+        specifier: ^6.0.2
+        version: 6.0.3
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@1.21.7)
+      supertest:
+        specifier: ^7.0.0
+        version: 7.2.2
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -1702,6 +1708,10 @@ packages:
       '@nestjs/platform-socket.io':
         optional: true
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
@@ -1721,6 +1731,9 @@ packages:
     resolution: {integrity: sha512-um0xL3fO7Mf4fDxcqx9KryrB7zgRM5JSlvGN5AGkP6JLM5XEKyjeAiPbNxdXVXQ16isuAhYpvP88NgL2BGd6aA==}
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
+
+  '@paralleldrive/cuid2@2.3.1':
+    resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
 
   '@petamoriken/float16@3.9.3':
     resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
@@ -2102,6 +2115,9 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookiejar@2.1.5':
+    resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
@@ -2159,6 +2175,9 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
@@ -2202,6 +2221,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/superagent@8.1.10':
+    resolution: {integrity: sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -2499,6 +2524,9 @@ packages:
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -2781,6 +2809,9 @@ packages:
     resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
     engines: {node: '>= 6'}
 
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2812,9 +2843,16 @@ packages:
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2979,6 +3017,9 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -3447,6 +3488,10 @@ packages:
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3947,6 +3992,11 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -4071,6 +4121,9 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -4696,6 +4749,14 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  superagent@10.3.0:
+    resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.2.2:
+    resolution: {integrity: sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==}
+    engines: {node: '>=14.18.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5160,6 +5221,9 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -6363,6 +6427,8 @@ snapshots:
     optionalDependencies:
       '@nestjs/platform-socket.io': 10.4.22(@nestjs/common@10.4.22(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/websockets@10.4.22)(rxjs@7.8.2)
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -6384,6 +6450,10 @@ snapshots:
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
+
+  '@paralleldrive/cuid2@2.3.1':
+    dependencies:
+      '@noble/hashes': 1.8.0
 
   '@petamoriken/float16@3.9.3': {}
 
@@ -6713,6 +6783,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.17
 
+  '@types/cookiejar@2.1.5': {}
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 22.19.17
@@ -6777,6 +6849,8 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 22.19.17
 
+  '@types/methods@1.1.4': {}
+
   '@types/ms@2.1.0': {}
 
   '@types/multer@1.4.13':
@@ -6829,6 +6903,18 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.17
+
+  '@types/superagent@8.1.10':
+    dependencies:
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 22.19.17
+      form-data: 4.0.5
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.10
 
   '@types/validator@13.15.10': {}
 
@@ -7262,6 +7348,8 @@ snapshots:
 
   array-timsort@1.0.3: {}
 
+  asap@2.0.6: {}
+
   assertion-error@2.0.1: {}
 
   asynckit@0.4.0: {}
@@ -7540,6 +7628,8 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
+  component-emitter@1.3.1: {}
+
   concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
@@ -7565,7 +7655,11 @@ snapshots:
 
   cookie-signature@1.0.7: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.2: {}
+
+  cookiejar@2.1.4: {}
 
   core-util-is@1.0.3: {}
 
@@ -7692,6 +7786,11 @@ snapshots:
   dequal@2.0.3: {}
 
   destroy@1.2.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   didyoumean@1.2.2: {}
 
@@ -8279,6 +8378,12 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formidable@3.5.4:
+    dependencies:
+      '@paralleldrive/cuid2': 2.3.1
+      dezalgo: 1.0.4
+      once: 1.4.0
+
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
@@ -8780,6 +8885,8 @@ snapshots:
 
   mime@1.6.0: {}
 
+  mime@2.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   mimic-response@3.1.0: {}
@@ -8878,6 +8985,10 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -9539,6 +9650,28 @@ snapshots:
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
 
+  superagent@10.3.0:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.4.3
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.5
+      formidable: 3.5.4
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.14.2
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.2.2:
+    dependencies:
+      cookie-signature: 1.2.2
+      methods: 1.1.2
+      superagent: 10.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10091,6 +10224,8 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 5.1.2
       strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Minimum production deploy path (Part B): auth-on compose, deployment docs, GHCR image publish, and release smoke test.

## Changes

### B1/B2 — Prod + auth compose
- [`apps/api/Dockerfile`](apps/api/Dockerfile): `ARG`/`ENV` for `VITE_AUTH_ENABLED` and Keycloak URLs (dashboard auth baked at build time)
- [`docker-compose.auth.yml`](docker-compose.auth.yml) (new): fixes auth-profile lie — `AUTH_ENABLED=true` + auth-enabled dashboard build
- [`docker-compose.prod.yml`](docker-compose.prod.yml): build args for auth dashboard, explicit `STRIPE_MODE=test`

### B3 — Deployment documentation
- [`docs/deployment.md`](docs/deployment.md) (new): demo vs prod compose, env vars, TLS sketch, cron link, pg_dump/restore, upgrade steps, GHCR pull
- [`README.md`](README.md): slimmed production sections → link to deployment doc; fixed auth exploration command

### B4 — GHCR publish
- [`.github/workflows/release.yml`](.github/workflows/release.yml): `publish-image` job pushes `ghcr.io/telivityai/haip-api:<tag>` and `:latest` on release

### B5 — Release smoke test
- [`apps/api/src/release-smoke.integration.spec.ts`](apps/api/src/release-smoke.integration.spec.ts): migrate + seed → search availability → create reservation → check-in → folio charge → night audit
- [`.github/workflows/ci.yml`](.github/workflows/ci.yml): `release-smoke` job (Postgres + Redis services)
- Added `supertest` dev dependency

## Verification (commands run)

```bash
pnpm install && pnpm build                    # OK
pnpm test                                     # OK — 1030 tests (1029 passed + 1 skipped smoke in default run)
pnpm --filter @telivityhaip/api run test:release-smoke  # OK (with RELEASE_SMOKE=1, haip_smoke DB)

# assertSecureConfig
# OK prod blocks AUTH_ENABLED=false
# OK prod allows AUTH_ENABLED=true + STRIPE_MODE=test

cp .env.production.example .env.production
docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth config  # OK
rm .env.production
```

**Docker daemon:** unavailable in agent environment (no socket). `docker compose config` validated with example env file; full `docker compose up` not run here. CI `demo-smoke` job still covers default demo path on merge.

## Related

Part A (README) is in separate PR #140 .


