### PR TITLE
fix(api): checkout balance, folio self-transfer, night audit index

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/NestJS-framework-E0234E?logo=nestjs&logoColor=white" alt="NestJS" />
   <img src="https://img.shields.io/badge/PostgreSQL-database-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL" />
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="Apache 2.0 License" />
-  <img src="https://img.shields.io/badge/Tests-1085%20passing-brightgreen" alt="1085 Tests Passing" />
+  <img src="https://img.shields.io/badge/Tests-1100%20passing-brightgreen" alt="1100 Tests Passing" />
   <img src="https://img.shields.io/badge/AI%20Agents-12%20built--in-blueviolet" alt="12 AI Agents" />
 </p>
 
@@ -425,7 +425,7 @@ executes; approval always runs the agent's own recommendation. Off by default
 | OTA Channels | Booking.com + Expedia (EQC) direct + SiteMinder (pmsXchange) | Direct + aggregated OTA connectivity (ARI + content) |
 | XML Processing | fast-xml-parser | Booking.com OTA XML protocol |
 | Package Manager | pnpm workspaces | Monorepo management |
-| Testing | Vitest (1085 tests across 128 test files) | Unit and integration tests |
+| Testing | Vitest (1100 tests across 129 test files) | Unit and integration tests |
 | Build | tsup (packages) + Vite (dashboard) + nest build (API) | Fast builds |
 | Containers | Docker + docker-compose | Local dev and production deployment |
 | CI/CD | GitHub Actions | Automated testing, builds, and releases |
@@ -547,7 +547,7 @@ Before going live, verify the items in [`docs/deployment.md`](./docs/deployment.
 ### Run tests
 
 ```bash
-# All tests (1085 tests across 128 test files)
+# All tests (1100 tests across 129 test files)
 pnpm test
 
 # API tests only
@@ -1063,7 +1063,7 @@ HAIP is built in public and contributions are welcome.
 pnpm install          # Install dependencies
 pnpm build            # Build all workspace packages
 pnpm dev              # Start API in dev mode (hot reload)
-pnpm test             # Run all tests (1085 tests, 128 files)
+pnpm test             # Run all tests (1100 tests, 129 files)
 pnpm typecheck        # TypeScript strict check
 pnpm lint             # ESLint
 ```

--- a/apps/api/src/modules/accounting/accounting.controller.ts
+++ b/apps/api/src/modules/accounting/accounting.controller.ts
@@ -34,6 +34,13 @@ export class AccountingController {
     private readonly accountingCodeService: AccountingCodeService,
   ) {}
 
+  @Get('accounting')
+  @ApiOperation({ summary: 'Accounting API namespace' })
+  @ApiResponse({ status: 200, description: 'Available accounting endpoints' })
+  accountingIndex() {
+    return { endpoints: ['deposits', 'ar/ledgers', 'accounting/codes'] };
+  }
+
   // --- Deposit Ledger (KB 10) ---
 
   @Post('deposits')

--- a/apps/api/src/modules/auth/unauthenticated-routes.spec.ts
+++ b/apps/api/src/modules/auth/unauthenticated-routes.spec.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { json, raw } from 'express';
+import request from 'supertest';
+import { AppModule } from '../../app.module';
+import { AllExceptionsFilter } from '../../common/filters/all-exceptions.filter';
+import { securityHeaders } from '../../common/http/security-headers';
+
+/**
+ * Module root paths must be registered so JwtAuthGuard runs before Nest returns
+ * 404 for unknown routes. Financial modules use dashboard nav keys (/cashier,
+ * /accounting, /reports) that must reject unauthenticated callers with 401.
+ */
+describe('Unauthenticated access to financial module routes', () => {
+  let app: INestApplication;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    for (const key of [
+      'NODE_ENV',
+      'AUTH_ENABLED',
+      'HAIP_ALLOW_INSECURE',
+      'SERVE_DASHBOARD',
+      'SERVE_BOOKING',
+    ]) {
+      savedEnv[key] = process.env[key];
+    }
+    process.env['NODE_ENV'] = 'test';
+    process.env['AUTH_ENABLED'] = 'true';
+    process.env['HAIP_ALLOW_INSECURE'] = 'true';
+    process.env['SERVE_DASHBOARD'] = 'false';
+    process.env['SERVE_BOOKING'] = 'false';
+
+    app = await NestFactory.create(AppModule, { logger: false });
+    app.use(securityHeaders());
+    app.use('/api/v1/webhooks/stripe', raw({ type: 'application/json' }));
+    app.use(json());
+    app.setGlobalPrefix('api/v1');
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
+    app.useGlobalFilters(new AllExceptionsFilter());
+    await app.init();
+  }, 60_000);
+
+  afterAll(async () => {
+    if (app) await app.close();
+    for (const [key, prev] of Object.entries(savedEnv)) {
+      if (prev === undefined) delete process.env[key];
+      else process.env[key] = prev;
+    }
+  });
+
+  const protectedGets = [
+    '/api/v1/cashier',
+    '/api/v1/cashier/drawers/aaaaaaaa-0000-4000-a000-000000000001',
+    '/api/v1/accounting',
+    '/api/v1/accounting/codes',
+    '/api/v1/reports',
+    '/api/v1/reports/daily-revenue',
+    '/api/v1/deposits',
+  ];
+
+  for (const path of protectedGets) {
+    it(`GET ${path} without Authorization returns 401`, async () => {
+      const res = await request(app.getHttpServer()).get(path);
+      expect(res.status).toBe(401);
+    });
+  }
+});

--- a/apps/api/src/modules/cashier/cashier.controller.ts
+++ b/apps/api/src/modules/cashier/cashier.controller.ts
@@ -16,9 +16,16 @@ import { RecordMovementDto } from './dto/record-movement.dto';
 import { CloseSessionDto } from './dto/close-session.dto';
 
 @ApiTags('cashier')
-@Controller('cash')
+@Controller(['cash', 'cashier'])
 export class CashierController {
   constructor(private readonly cashierService: CashierService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Cashier API namespace' })
+  @ApiResponse({ status: 200, description: 'Available cashier endpoints' })
+  cashierIndex() {
+    return { endpoints: ['drawers', 'sessions'] };
+  }
 
   @Post('drawers')
   @Roles('admin', 'front_desk', 'night_auditor')

--- a/apps/api/src/modules/folio/folio.service.spec.ts
+++ b/apps/api/src/modules/folio/folio.service.spec.ts
@@ -230,6 +230,25 @@ describe('FolioService', () => {
   });
 
   describe('transferCharge', () => {
+    it('should reject self-transfer', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: { transaction: vi.fn() } },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      await expect(
+        svc.transferCharge('folio-001', 'prop-001', {
+          chargeId: 'charge-001',
+          targetFolioId: 'folio-001',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
     it('should transfer charge between folios', async () => {
       let selectCallCount = 0;
       const targetFolio = { ...mockFolio, id: 'folio-002' };
@@ -398,6 +417,219 @@ describe('FolioService', () => {
       const result = await svc.reverseCharge('folio-001', 'charge-001', 'prop-001');
       expect(result.isReversal).toBe(true);
       expect(parseFloat(result.amount)).toBeLessThan(0);
+    });
+  });
+
+  describe('close', () => {
+    it('should close a settled folio', async () => {
+      const settledFolio = { ...mockFolio, status: 'settled' };
+      const closedFolio = { ...settledFolio, status: 'closed', closedAt: new Date() };
+      let callCount = 0;
+      const db = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => {
+                callCount++;
+                resolve(callCount === 1 ? [settledFolio] : []);
+              },
+            }),
+          }),
+        })),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([closedFolio]),
+            }),
+          }),
+        }),
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      const result = await svc.close('folio-001', 'prop-001');
+      expect(result.status).toBe('closed');
+    });
+
+    it('should throw when folio is not settled', async () => {
+      const db = createMockDb([mockFolio]);
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      await expect(svc.close('folio-001', 'prop-001')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('getCharges', () => {
+    it('should return paginated charges with filters', async () => {
+      let selectCall = 0;
+      const db = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({
+                offset: vi.fn().mockReturnValue({
+                  orderBy: vi.fn().mockResolvedValue([mockCharge]),
+                }),
+              }),
+              then: (resolve: any) => {
+                selectCall++;
+                resolve([{ count: 1 }]);
+              },
+            }),
+          }),
+        })),
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      const result = await svc.getCharges('folio-001', {
+        propertyId: 'prop-001',
+        type: 'room',
+        page: 1,
+        limit: 10,
+      });
+      expect(result.data).toEqual([mockCharge]);
+      expect(result.total).toBe(1);
+      expect(result.page).toBe(1);
+    });
+  });
+
+  describe('lockCharges', () => {
+    it('should lock charges up to audit date', async () => {
+      const locked = [{ ...mockCharge, isLocked: true }];
+      const db = {
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue(locked),
+            }),
+          }),
+        }),
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      const result = await svc.lockCharges('folio-001', 'prop-001', new Date('2026-04-05'));
+      expect(result.lockedCount).toBe(1);
+    });
+  });
+
+  describe('postRoomTariff', () => {
+    it('should post a room tariff charge', async () => {
+      let selectCallCount = 0;
+      const db = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => {
+                selectCallCount++;
+                if (selectCallCount === 1) resolve([mockFolio]);
+                else resolve([{ total: '150.00' }]);
+              },
+            }),
+          }),
+        })),
+        insert: vi.fn().mockReturnValue({
+          values: vi.fn().mockReturnValue({
+            returning: vi.fn().mockResolvedValue([mockCharge]),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        }),
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      const result = await svc.postRoomTariff(
+        'folio-001',
+        'prop-001',
+        '150.00',
+        'USD',
+        new Date('2026-04-05'),
+      );
+      expect(result.type).toBe('room');
+    });
+  });
+
+  describe('createAutoFolio', () => {
+    it('should create a guest folio for a reservation', async () => {
+      const result = await service.createAutoFolio({
+        id: 'res-001',
+        propertyId: 'prop-001',
+        guestId: 'guest-001',
+        currencyCode: 'USD',
+      });
+      expect(result).toEqual(mockFolio);
+      expect(mockWebhookService.emit).toHaveBeenCalled();
+    });
+  });
+
+  describe('settle — pending payments guard', () => {
+    it('should throw when pending authorized payments exist', async () => {
+      let callCount = 0;
+      const db = {
+        select: vi.fn().mockImplementation(() => ({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => {
+                callCount++;
+                if (callCount === 1) resolve([mockFolio]);
+                else resolve([{ count: 2 }]);
+              },
+            }),
+          }),
+        })),
+      };
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          FolioService,
+          { provide: DRIZZLE, useValue: db },
+          { provide: WebhookService, useValue: mockWebhookService },
+          { provide: TaxService, useValue: mockTaxService },
+        ],
+      }).compile();
+      const svc = module.get<FolioService>(FolioService);
+
+      await expect(svc.settle('folio-001', 'prop-001')).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/apps/api/src/modules/folio/folio.service.ts
+++ b/apps/api/src/modules/folio/folio.service.ts
@@ -185,6 +185,10 @@ export class FolioService {
   }
 
   async transferCharge(folioId: string, propertyId: string, dto: TransferChargeDto) {
+    if (folioId === dto.targetFolioId) {
+      throw new BadRequestException('Source and target folio must differ');
+    }
+
     // Bug 2: wrap charge move + both balance recalculations in a transaction,
     // and SELECT ... FOR UPDATE both folio rows up-front so concurrent
     // transfers/recalculations on the same folios are serialized.

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -17,6 +17,20 @@ import { RequirePermissions } from '../auth/permissions.decorator';
 export class ReportsController {
   constructor(private readonly reportsService: ReportsService) {}
 
+  @Get()
+  @ApiOperation({ summary: 'Available reports' })
+  async listReports() {
+    return {
+      reports: [
+        'daily-revenue',
+        'occupancy',
+        'financial-summary',
+        'trial-balance',
+        'occupancy-trend',
+      ],
+    };
+  }
+
   @Get('/daily-revenue')
   @ApiOperation({ summary: 'Daily revenue report' })
   @ApiQuery({ name: 'propertyId', required: true })

--- a/apps/api/src/modules/reservation/check-out.spec.ts
+++ b/apps/api/src/modules/reservation/check-out.spec.ts
@@ -248,18 +248,14 @@ describe('ReservationService — checkOut', () => {
     expect(mockPaymentService.voidPayment).toHaveBeenCalledWith('pay-auth-001', 'prop-001');
   });
 
-  it('should return folio summary with balances on non-express checkout', async () => {
+  it('should throw on non-express checkout with outstanding balance', async () => {
     mockFolioService.list.mockResolvedValue({
       data: [{ ...mockFolio, balance: '150.00' }],
     });
+    mockFolioService.findById.mockResolvedValue({ ...mockFolio, balance: '150.00' });
     const db = createCheckOutDb();
     const svc = await createService(db);
-    const result = await svc.checkOut('res-001', 'prop-001');
-    expect(result.folioSummary).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ folioId: 'folio-001', balance: '150.00' }),
-      ]),
-    );
+    await expect(svc.checkOut('res-001', 'prop-001')).rejects.toThrow(BadRequestException);
   });
 
   it('should work from stayover state', async () => {

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -486,16 +486,15 @@ export class ReservationService {
       }
     }
 
-    // Express checkout: validate balances before claiming the transition.
-    if (dto.expressCheckout) {
-      for (const folio of folios) {
-        if (folio.status !== 'open') continue;
-        const refreshed = await this.folioService.findById(folio.id, reservation.propertyId);
-        if (new Decimal(refreshed.balance).abs().gt('0.01')) {
-          throw new BadRequestException(
-            `Cannot express checkout: folio ${folio.folioNumber} has outstanding balance of ${refreshed.balance}`,
-          );
-        }
+    // KB §5.4: balance must be zero at checkout (express and standard paths).
+    for (const folio of folios) {
+      if (folio.status !== 'open') continue;
+      const refreshed = await this.folioService.findById(folio.id, reservation.propertyId);
+      if (new Decimal(refreshed.balance).abs().gt('0.01')) {
+        const prefix = dto.expressCheckout ? 'Cannot express checkout' : 'Cannot checkout';
+        throw new BadRequestException(
+          `${prefix}: folio ${refreshed.folioNumber} has outstanding balance of ${refreshed.balance}`,
+        );
       }
     }
 

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -377,6 +377,7 @@ async function main() {
       completed_at timestamptz,
       created_at timestamptz NOT NULL DEFAULT now()
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS night_audit_runs_property_date_unique ON audit_runs (property_id, business_date)`,
     // audit_logs
     `CREATE TABLE IF NOT EXISTS audit_logs (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary
- Block non-express checkout when an open folio has outstanding balance (KB §5.4).
- Reject folio charge self-transfer when source and target folio IDs match.
- Add `night_audit_runs_property_date_unique` index to `push-schema` migrate path.
- Register cashier/accounting/reports module root routes so unauthenticated GETs return 401 instead of 404.

## Test plan
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/reservation/check-out.spec.ts`
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/folio/folio.service.spec.ts`
- [x] `pnpm --filter @telivityhaip/api exec vitest run src/modules/auth/unauthenticated-routes.spec.ts`


Made with [Cursor](https://cursor.com)