### PR TITLE
feat: HIA gap features — portfolio rollup, universal search, staff alerts, export automation

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -37,6 +37,8 @@ import { NotificationsModule } from './modules/notifications/notifications.modul
 import { PosModule } from './modules/pos/pos.module';
 import { DoorLockModule } from './modules/door-lock/door-lock.module';
 import { LlmModule } from './modules/llm/llm.module';
+import { SearchModule } from './modules/search/search.module';
+import { StaffNotificationsModule } from './modules/staff-notifications/staff-notifications.module';
 
 const imports: any[] = [
   ConfigModule.forRoot({
@@ -76,6 +78,8 @@ const imports: any[] = [
   PosModule,
   DoorLockModule,
   LlmModule,
+  SearchModule,
+  StaffNotificationsModule,
 ];
 
 // Serve the bundled dashboard as static files. Enabled in production, or

--- a/apps/api/src/modules/accounting-export/accounting-export.listener.spec.ts
+++ b/apps/api/src/modules/accounting-export/accounting-export.listener.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AccountingExportListener } from './accounting-export.listener';
+
+describe('AccountingExportListener', () => {
+  let listener: AccountingExportListener;
+  let exportService: any;
+  let webhookService: any;
+
+  beforeEach(() => {
+    exportService = {
+      revenueJournalCsv: vi.fn().mockResolvedValue('date,category,account,amount\n'),
+      trialBalanceCsv: vi.fn().mockResolvedValue('date,ledger,opening\n'),
+    };
+    webhookService = { emit: vi.fn().mockResolvedValue(undefined) };
+    listener = new AccountingExportListener(exportService, webhookService);
+  });
+
+  it('emits accounting.export.ready on audit.completed', async () => {
+    await listener.onAuditCompleted({
+      event: 'audit.completed',
+      entityType: 'audit_run',
+      entityId: 'audit-1',
+      propertyId: 'prop-1',
+      data: { businessDate: '2026-07-08' },
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(exportService.revenueJournalCsv).toHaveBeenCalledWith('prop-1', '2026-07-08');
+    expect(exportService.trialBalanceCsv).toHaveBeenCalledWith('prop-1', '2026-07-08');
+    expect(webhookService.emit).toHaveBeenCalledWith(
+      'accounting.export.ready',
+      'accounting_export',
+      'audit-1',
+      expect.objectContaining({
+        businessDate: '2026-07-08',
+        downloadPaths: expect.objectContaining({
+          revenueJournal: expect.stringContaining('revenue-journal.csv'),
+        }),
+      }),
+      'prop-1',
+    );
+  });
+
+  it('skips when propertyId or businessDate missing', async () => {
+    await listener.onAuditCompleted({
+      event: 'audit.completed',
+      entityType: 'audit_run',
+      entityId: 'audit-1',
+      data: {},
+      timestamp: new Date().toISOString(),
+    });
+    expect(webhookService.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/accounting-export/accounting-export.listener.ts
+++ b/apps/api/src/modules/accounting-export/accounting-export.listener.ts
@@ -1,0 +1,56 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import type { WebhookPayload } from '../webhook/webhook.service';
+import { WebhookService } from '../webhook/webhook.service';
+import { AccountingExportService } from './accounting-export.service';
+
+/**
+ * On night-audit day close, pre-generate accounting CSV exports and notify
+ * subscribers via webhook — no manual download required.
+ */
+@Injectable()
+export class AccountingExportListener {
+  private readonly logger = new Logger(AccountingExportListener.name);
+
+  constructor(
+    private readonly exportService: AccountingExportService,
+    private readonly webhookService: WebhookService,
+  ) {}
+
+  @OnEvent('audit.completed')
+  async onAuditCompleted(payload: WebhookPayload) {
+    if (!payload.propertyId) return;
+
+    const businessDate = String(payload.data?.['businessDate'] ?? '');
+    if (!businessDate) return;
+
+    try {
+      const [revenueJournal, trialBalance] = await Promise.all([
+        this.exportService.revenueJournalCsv(payload.propertyId, businessDate),
+        this.exportService.trialBalanceCsv(payload.propertyId, businessDate),
+      ]);
+
+      await this.webhookService.emit(
+        'accounting.export.ready',
+        'accounting_export',
+        payload.entityId,
+        {
+          businessDate,
+          revenueJournalLineCount: revenueJournal.split('\n').length - 1,
+          trialBalanceLineCount: trialBalance.split('\n').length - 1,
+          revenueJournalPreview: revenueJournal.slice(0, 500),
+          trialBalancePreview: trialBalance.slice(0, 500),
+          downloadPaths: {
+            revenueJournal: `/api/v1/accounting-export/revenue-journal.csv?propertyId=${payload.propertyId}&date=${businessDate}`,
+            trialBalance: `/api/v1/accounting-export/trial-balance.csv?propertyId=${payload.propertyId}&date=${businessDate}`,
+          },
+        },
+        payload.propertyId,
+      );
+    } catch (err: any) {
+      this.logger.warn(
+        `Accounting export on audit.completed failed for ${payload.propertyId}: ${err?.message ?? err}`,
+      );
+    }
+  }
+}

--- a/apps/api/src/modules/accounting-export/accounting-export.module.ts
+++ b/apps/api/src/modules/accounting-export/accounting-export.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { AccountingExportController } from './accounting-export.controller';
 import { AccountingExportService } from './accounting-export.service';
+import { AccountingExportListener } from './accounting-export.listener';
 import { ReportsModule } from '../reports/reports.module';
 import { AuthModule } from '../auth/auth.module';
+import { WebhookModule } from '../webhook/webhook.module';
 
 @Module({
-  imports: [ReportsModule, AuthModule],
+  imports: [ReportsModule, AuthModule, WebhookModule],
   controllers: [AccountingExportController],
-  providers: [AccountingExportService],
+  providers: [AccountingExportService, AccountingExportListener],
 })
 export class AccountingExportModule {}

--- a/apps/api/src/modules/agent/agent.service.ts
+++ b/apps/api/src/modules/agent/agent.service.ts
@@ -164,6 +164,19 @@ export class AgentService {
       }
 
       decisions.push(decision);
+
+      await this.webhookService.emit(
+        'agent.decision_created',
+        'agent_decision',
+        decision.id,
+        {
+          agentType,
+          decisionType: rec.decisionType,
+          confidence: rec.confidence,
+          summary: rec.recommendation?.summary ?? rec.decisionType,
+        },
+        propertyId,
+      );
     }
 
     // Update last run timestamp

--- a/apps/api/src/modules/events/events.gateway.ts
+++ b/apps/api/src/modules/events/events.gateway.ts
@@ -127,6 +127,14 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     });
   }
 
+  broadcastStaffNotification(propertyId: string, notification: Record<string, unknown>) {
+    const room = `property:${propertyId}`;
+    this.server.to(room).emit('staffNotification', {
+      ...notification,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
   private extractToken(client: Socket): string | null {
     const authToken = (client.handshake.auth as any)?.token;
     if (typeof authToken === 'string' && authToken.length > 0) {

--- a/apps/api/src/modules/property/organization.controller.ts
+++ b/apps/api/src/modules/property/organization.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { OrganizationService } from './organization.service';
+
+@ApiTags('organizations')
+@Controller('organizations')
+export class OrganizationController {
+  constructor(private readonly organizationService: OrganizationService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List hotel groups / organizations' })
+  list() {
+    return this.organizationService.findAll();
+  }
+}

--- a/apps/api/src/modules/property/organization.service.ts
+++ b/apps/api/src/modules/property/organization.service.ts
@@ -1,0 +1,13 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import { organizations } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+
+@Injectable()
+export class OrganizationService {
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  async findAll() {
+    return this.db.select().from(organizations);
+  }
+}

--- a/apps/api/src/modules/property/property.module.ts
+++ b/apps/api/src/modules/property/property.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { PropertyController } from './property.controller';
+import { OrganizationController } from './organization.controller';
 import { PropertyService } from './property.service';
+import { OrganizationService } from './organization.service';
 import { WebhookModule } from '../webhook/webhook.module';
 
 @Module({
   imports: [WebhookModule],
-  controllers: [PropertyController],
-  providers: [PropertyService],
-  exports: [PropertyService],
+  controllers: [PropertyController, OrganizationController],
+  providers: [PropertyService, OrganizationService],
+  exports: [PropertyService, OrganizationService],
 })
 export class PropertyModule {}

--- a/apps/api/src/modules/reports/portfolio-property-resolver.ts
+++ b/apps/api/src/modules/reports/portfolio-property-resolver.ts
@@ -1,0 +1,63 @@
+import { Injectable, Inject, BadRequestException } from '@nestjs/common';
+import { eq, and, inArray } from 'drizzle-orm';
+import { properties } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import type { AuthUser } from '../auth/current-user.decorator';
+import { userCanAccessProperty } from '../auth/property-access';
+
+@Injectable()
+export class PortfolioPropertyResolver {
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  /**
+   * Resolve property IDs for portfolio-scoped operations. Filters to properties
+   * the caller may access. When organizationId is provided, further restricts
+   * to that org's properties.
+   */
+  async resolvePropertyIds(
+    user: AuthUser | undefined,
+    authEnabled: boolean,
+    organizationId?: string,
+    propertyIdsParam?: string[],
+  ): Promise<string[]> {
+    let rows = await this.db
+      .select({ id: properties.id, organizationId: properties.organizationId })
+      .from(properties)
+      .where(eq(properties.isActive, true));
+
+    if (organizationId) {
+      rows = rows.filter((r: { organizationId: string | null }) => r.organizationId === organizationId);
+    }
+
+    if (propertyIdsParam?.length) {
+      const allowed = new Set(propertyIdsParam);
+      rows = rows.filter((r: { id: string }) => allowed.has(r.id));
+    }
+
+    if (authEnabled && user) {
+      rows = rows.filter((r: { id: string }) => userCanAccessProperty(user, r.id));
+    }
+
+    const ids = rows.map((r: { id: string }) => r.id);
+    if (!ids.length) {
+      throw new BadRequestException('No accessible properties for portfolio scope');
+    }
+    return ids;
+  }
+
+  async findByOrganization(organizationId: string, user?: AuthUser, authEnabled = true) {
+    const conditions = [
+      eq(properties.isActive, true),
+      eq(properties.organizationId, organizationId),
+    ];
+    const rows = await this.db
+      .select()
+      .from(properties)
+      .where(and(...conditions));
+
+    if (authEnabled && user) {
+      return rows.filter((p: { id: string }) => userCanAccessProperty(user, p.id));
+    }
+    return rows;
+  }
+}

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -5,8 +5,11 @@ import {
   ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
 import { ReportsService } from './reports.service';
+import { PortfolioPropertyResolver } from './portfolio-property-resolver';
 import { RequirePermissions } from '../auth/permissions.decorator';
+import { CurrentUser, type AuthUser } from '../auth/current-user.decorator';
 
 @ApiTags('reports')
 @Controller('reports')
@@ -15,7 +18,20 @@ import { RequirePermissions } from '../auth/permissions.decorator';
 // property they belong to. PermissionsGuard enforces this for every route below.
 @RequirePermissions('reports.view')
 export class ReportsController {
-  constructor(private readonly reportsService: ReportsService) {}
+  constructor(
+    private readonly reportsService: ReportsService,
+    private readonly portfolioResolver: PortfolioPropertyResolver,
+    private readonly configService: ConfigService,
+  ) {}
+
+  private authOn(): boolean {
+    return this.configService.get<string>('AUTH_ENABLED', 'true') !== 'false';
+  }
+
+  private parsePropertyIds(raw?: string): string[] | undefined {
+    if (!raw) return undefined;
+    return raw.split(',').map((s) => s.trim()).filter(Boolean);
+  }
 
   @Get()
   @ApiOperation({ summary: 'Available reports' })
@@ -86,5 +102,45 @@ export class ReportsController {
     @Query('endDate') endDate: string,
   ) {
     return this.reportsService.getOccupancyTrend(propertyId, startDate, endDate);
+  }
+
+  @Get('/portfolio/financial-summary')
+  @ApiOperation({ summary: 'Portfolio financial summary across properties' })
+  @ApiQuery({ name: 'date', required: true })
+  @ApiQuery({ name: 'organizationId', required: false })
+  @ApiQuery({ name: 'propertyIds', required: false, description: 'Comma-separated property UUIDs' })
+  async getPortfolioFinancialSummary(
+    @Query('date') date: string,
+    @Query('organizationId') organizationId: string | undefined,
+    @Query('propertyIds') propertyIdsRaw: string | undefined,
+    @CurrentUser() user?: AuthUser,
+  ) {
+    const propertyIds = await this.portfolioResolver.resolvePropertyIds(
+      user,
+      this.authOn(),
+      organizationId,
+      this.parsePropertyIds(propertyIdsRaw),
+    );
+    return this.reportsService.getPortfolioFinancialSummary(propertyIds, date);
+  }
+
+  @Get('/portfolio/occupancy')
+  @ApiOperation({ summary: 'Portfolio occupancy across properties' })
+  @ApiQuery({ name: 'date', required: true })
+  @ApiQuery({ name: 'organizationId', required: false })
+  @ApiQuery({ name: 'propertyIds', required: false, description: 'Comma-separated property UUIDs' })
+  async getPortfolioOccupancy(
+    @Query('date') date: string,
+    @Query('organizationId') organizationId: string | undefined,
+    @Query('propertyIds') propertyIdsRaw: string | undefined,
+    @CurrentUser() user?: AuthUser,
+  ) {
+    const propertyIds = await this.portfolioResolver.resolvePropertyIds(
+      user,
+      this.authOn(),
+      organizationId,
+      this.parsePropertyIds(propertyIdsRaw),
+    );
+    return this.reportsService.getPortfolioOccupancy(propertyIds, date);
   }
 }

--- a/apps/api/src/modules/reports/reports.module.ts
+++ b/apps/api/src/modules/reports/reports.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ReportsController } from './reports.controller';
 import { ReportsService } from './reports.service';
+import { PortfolioPropertyResolver } from './portfolio-property-resolver';
 
 @Module({
   controllers: [ReportsController],
-  providers: [ReportsService],
-  exports: [ReportsService],
+  providers: [ReportsService, PortfolioPropertyResolver],
+  exports: [ReportsService, PortfolioPropertyResolver],
 })
 export class ReportsModule {}

--- a/apps/api/src/modules/reports/reports.service.portfolio.spec.ts
+++ b/apps/api/src/modules/reports/reports.service.portfolio.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ReportsService } from './reports.service';
+
+describe('ReportsService portfolio', () => {
+  const service = new ReportsService(null as any);
+
+  it('aggregates financial summary across properties', async () => {
+    vi.spyOn(service, 'getFinancialSummary').mockImplementation(async (id: string) => ({
+      date: '2026-07-08',
+      kpis: {
+        adr: 100,
+        revpar: 50,
+        occupancyRate: 0.5,
+        totalRevenue: id === 'p1' ? 1000 : 2000,
+        roomRevenue: id === 'p1' ? 800 : 1600,
+      },
+      revenueByType: {},
+      paymentsByMethod: {},
+      outstandingBalances: { totalFoliosOpen: 0, totalBalanceDue: 0 },
+      auditStatus: { lastAuditDate: null, lastAuditStatus: null, errorsInLastAudit: 0 },
+    }));
+
+    vi.spyOn(service, 'getOccupancy').mockImplementation(async (id: string) => ({
+      date: '2026-07-08',
+      totalRooms: 100,
+      availableRooms: 90,
+      occupiedRooms: id === 'p1' ? 45 : 45,
+      occupancyRate: 0.5,
+      occupancyPercent: '50.0%',
+      arrivals: 5,
+      departures: 3,
+      stayovers: 40,
+      noShows: 0,
+      cancellations: 0,
+      outOfOrder: 5,
+      outOfService: 5,
+    }));
+
+    const result = await service.getPortfolioFinancialSummary(['p1', 'p2'], '2026-07-08');
+
+    expect(result.propertyCount).toBe(2);
+    expect(result.kpis.totalRevenue).toBe(3000);
+    expect(result.kpis.totalRoomsSold).toBe(90);
+    expect(result.byProperty).toHaveLength(2);
+  });
+
+  it('aggregates occupancy across properties', async () => {
+    vi.spyOn(service, 'getOccupancy')
+      .mockResolvedValueOnce({
+        date: '2026-07-08',
+        totalRooms: 50,
+        availableRooms: 45,
+        occupiedRooms: 30,
+        occupancyRate: 0.67,
+        occupancyPercent: '67.0%',
+        arrivals: 10,
+        departures: 5,
+        stayovers: 20,
+        noShows: 0,
+        cancellations: 0,
+        outOfOrder: 3,
+        outOfService: 2,
+      })
+      .mockResolvedValueOnce({
+        date: '2026-07-08',
+        totalRooms: 80,
+        availableRooms: 70,
+        occupiedRooms: 35,
+        occupancyRate: 0.5,
+        occupancyPercent: '50.0%',
+        arrivals: 8,
+        departures: 6,
+        stayovers: 25,
+        noShows: 0,
+        cancellations: 0,
+        outOfOrder: 5,
+        outOfService: 5,
+      });
+
+    const result = await service.getPortfolioOccupancy(['p1', 'p2'], '2026-07-08');
+
+    expect(result.totalRooms).toBe(130);
+    expect(result.availableRooms).toBe(115);
+    expect(result.occupiedRooms).toBe(65);
+    expect(result.arrivals).toBe(18);
+    expect(result.departures).toBe(11);
+  });
+});

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { eq, and, sql, lte, gte } from 'drizzle-orm';
+import { eq, and, sql, lte, gte, inArray } from 'drizzle-orm';
 import Decimal from 'decimal.js';
 import {
   charges,
@@ -657,6 +657,118 @@ export class ReportsService {
         },
       },
       interLedgerTransfers: interLedgerTransfers.toFixed(2),
+    };
+  }
+
+  /**
+   * Portfolio financial summary — aggregates KPIs across multiple properties.
+   */
+  async getPortfolioFinancialSummary(propertyIds: string[], date: string) {
+    const summaries = await Promise.all(
+      propertyIds.map((id) => this.getFinancialSummary(id, date)),
+    );
+
+    let totalRevenue = new Decimal(0);
+    let roomRevenue = new Decimal(0);
+    let totalRoomsSold = 0;
+    let totalAvailableRooms = 0;
+    const byProperty: Array<{
+      propertyId: string;
+      totalRevenue: number;
+      occupancyRate: number;
+      adr: number;
+      revpar: number;
+    }> = [];
+
+    for (let i = 0; i < propertyIds.length; i++) {
+      const s = summaries[i];
+      const kpis = s.kpis ?? {};
+      totalRevenue = totalRevenue.plus(kpis.totalRevenue ?? 0);
+      roomRevenue = roomRevenue.plus(kpis.roomRevenue ?? 0);
+
+      const occ = await this.getOccupancy(propertyIds[i], date);
+      const roomsSold = occ.occupiedRooms ?? 0;
+      const available = occ.availableRooms ?? 0;
+      totalRoomsSold += roomsSold;
+      totalAvailableRooms += available;
+
+      byProperty.push({
+        propertyId: propertyIds[i],
+        totalRevenue: kpis.totalRevenue ?? 0,
+        occupancyRate: kpis.occupancyRate ?? 0,
+        adr: kpis.adr ?? 0,
+        revpar: kpis.revpar ?? 0,
+      });
+    }
+
+    const portfolioOccupancy = totalAvailableRooms > 0 ? totalRoomsSold / totalAvailableRooms : 0;
+    const portfolioAdr = totalRoomsSold > 0 ? roomRevenue.div(totalRoomsSold) : new Decimal(0);
+    const portfolioRevpar = portfolioAdr.times(portfolioOccupancy);
+
+    return {
+      date,
+      propertyCount: propertyIds.length,
+      propertyIds,
+      kpis: {
+        totalRevenue: totalRevenue.toNumber(),
+        roomRevenue: roomRevenue.toNumber(),
+        occupancyRate: Math.round(portfolioOccupancy * 10000) / 10000,
+        adr: Math.round(portfolioAdr.toNumber() * 100) / 100,
+        revpar: Math.round(portfolioRevpar.toNumber() * 100) / 100,
+        totalRoomsSold,
+        totalAvailableRooms,
+      },
+      byProperty,
+    };
+  }
+
+  /**
+   * Portfolio occupancy — sums room counts and activity across properties.
+   */
+  async getPortfolioOccupancy(propertyIds: string[], date: string) {
+    const rows = await Promise.all(
+      propertyIds.map((id) => this.getOccupancy(id, date)),
+    );
+
+    let totalRooms = 0;
+    let availableRooms = 0;
+    let occupiedRooms = 0;
+    let arrivals = 0;
+    let departures = 0;
+    let stayovers = 0;
+    const byProperty = propertyIds.map((id, i) => {
+      const r = rows[i];
+      totalRooms += r.totalRooms ?? 0;
+      availableRooms += r.availableRooms ?? 0;
+      occupiedRooms += r.occupiedRooms ?? 0;
+      arrivals += r.arrivals ?? 0;
+      departures += r.departures ?? 0;
+      stayovers += r.stayovers ?? 0;
+      return {
+        propertyId: id,
+        occupancyRate: r.occupancyRate ?? 0,
+        occupiedRooms: r.occupiedRooms ?? 0,
+        availableRooms: r.availableRooms ?? 0,
+        arrivals: r.arrivals ?? 0,
+        departures: r.departures ?? 0,
+      };
+    });
+
+    const occupancyRate = availableRooms > 0 ? occupiedRooms / availableRooms : 0;
+
+    return {
+      date,
+      propertyCount: propertyIds.length,
+      propertyIds,
+      totalRooms,
+      availableRooms,
+      occupiedRooms,
+      occupancyRate: Math.round(occupancyRate * 10000) / 10000,
+      occupancyPercent: `${(occupancyRate * 100).toFixed(1)}%`,
+      arrivals,
+      departures,
+      stayovers,
+      byProperty,
     };
   }
 }

--- a/apps/api/src/modules/search/dto/universal-search.dto.ts
+++ b/apps/api/src/modules/search/dto/universal-search.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsString, IsUUID, MinLength } from 'class-validator';
+
+export class UniversalSearchDto {
+  @IsString()
+  @MinLength(1)
+  q!: string;
+
+  @IsUUID()
+  propertyId!: string;
+
+  @IsOptional()
+  @IsString()
+  types?: string;
+}

--- a/apps/api/src/modules/search/search.controller.ts
+++ b/apps/api/src/modules/search/search.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, Query, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+import { SearchService } from './search.service';
+import { UniversalSearchDto } from './dto/universal-search.dto';
+import { PortfolioPropertyResolver } from '../reports/portfolio-property-resolver';
+import { CurrentUser, type AuthUser } from '../auth/current-user.decorator';
+
+@ApiTags('search')
+@Controller('search')
+export class SearchController {
+  constructor(
+    private readonly searchService: SearchService,
+    private readonly portfolioResolver: PortfolioPropertyResolver,
+    private readonly configService: ConfigService,
+  ) {}
+
+  private authOn(): boolean {
+    return this.configService.get<string>('AUTH_ENABLED', 'true') !== 'false';
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Universal search across guests, reservations, folios, rooms, groups' })
+  @ApiQuery({ name: 'q', required: true })
+  @ApiQuery({ name: 'propertyId', required: true })
+  @ApiQuery({ name: 'types', required: false, description: 'Comma-separated: guest,reservation,folio,room,group' })
+  search(@Query() dto: UniversalSearchDto) {
+    return this.searchService.search(dto.propertyId, dto.q, dto.types);
+  }
+
+  @Get('portfolio')
+  @ApiOperation({ summary: 'Universal search across all accessible properties' })
+  @ApiQuery({ name: 'q', required: true })
+  @ApiQuery({ name: 'organizationId', required: false })
+  @ApiQuery({ name: 'types', required: false })
+  async searchPortfolio(
+    @Query('q') q: string,
+    @Query('organizationId') organizationId: string | undefined,
+    @Query('types') types: string | undefined,
+    @CurrentUser() user?: AuthUser,
+  ) {
+    const propertyIds = await this.portfolioResolver.resolvePropertyIds(
+      user,
+      this.authOn(),
+      organizationId,
+    );
+    const results = await this.searchService.searchPortfolio(propertyIds, q, types);
+    const names = await this.searchService.propertyNameMap(propertyIds);
+    return results.map((r) => ({
+      ...r,
+      propertyName: names.get(r.propertyId),
+    }));
+  }
+}

--- a/apps/api/src/modules/search/search.module.ts
+++ b/apps/api/src/modules/search/search.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+import { ReportsModule } from '../reports/reports.module';
+
+@Module({
+  imports: [ReportsModule],
+  controllers: [SearchController],
+  providers: [SearchService],
+  exports: [SearchService],
+})
+export class SearchModule {}

--- a/apps/api/src/modules/search/search.service.spec.ts
+++ b/apps/api/src/modules/search/search.service.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SearchService } from './search.service';
+
+describe('SearchService', () => {
+  let service: SearchService;
+  let db: any;
+
+  beforeEach(() => {
+    db = {
+      select: vi.fn(),
+    };
+    service = new SearchService(db);
+  });
+
+  it('returns empty for blank query types default', async () => {
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([]),
+    };
+    db.select.mockReturnValue(chain);
+
+    const results = await service.search('prop-1', 'smith');
+    expect(results).toEqual([]);
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('fans out portfolio search across property ids', async () => {
+    const spy = vi.spyOn(service, 'search').mockResolvedValue([
+      {
+        type: 'guest',
+        id: 'g1',
+        propertyId: 'p1',
+        title: 'Jane Smith',
+        href: '/guests/g1',
+      },
+    ]);
+
+    const results = await service.searchPortfolio(['p1', 'p2'], 'smith');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(results).toHaveLength(2);
+  });
+});

--- a/apps/api/src/modules/search/search.service.ts
+++ b/apps/api/src/modules/search/search.service.ts
@@ -1,0 +1,257 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { eq, and, or, ilike, inArray } from 'drizzle-orm';
+import {
+  guests,
+  reservations,
+  bookings,
+  folios,
+  rooms,
+  groupProfiles,
+  properties,
+} from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+
+export type SearchResultType = 'guest' | 'reservation' | 'folio' | 'room' | 'group';
+
+export interface SearchResult {
+  type: SearchResultType;
+  id: string;
+  propertyId: string;
+  title: string;
+  subtitle?: string;
+  href: string;
+}
+
+const DEFAULT_TYPES: SearchResultType[] = ['guest', 'reservation', 'folio', 'room', 'group'];
+const LIMIT_PER_TYPE = 5;
+
+@Injectable()
+export class SearchService {
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  async search(propertyId: string, query: string, types?: string): Promise<SearchResult[]> {
+    const pattern = `%${query}%`;
+    const enabled = types
+      ? (types.split(',').map((t) => t.trim()) as SearchResultType[])
+      : DEFAULT_TYPES;
+
+    const results: SearchResult[] = [];
+
+    if (enabled.includes('guest')) {
+      results.push(...(await this.searchGuests(propertyId, pattern)));
+    }
+    if (enabled.includes('reservation')) {
+      results.push(...(await this.searchReservations(propertyId, pattern)));
+    }
+    if (enabled.includes('folio')) {
+      results.push(...(await this.searchFolios(propertyId, pattern)));
+    }
+    if (enabled.includes('room')) {
+      results.push(...(await this.searchRooms(propertyId, pattern)));
+    }
+    if (enabled.includes('group')) {
+      results.push(...(await this.searchGroups(propertyId, pattern)));
+    }
+
+    return results;
+  }
+
+  /**
+   * Portfolio search fans out across all accessible properties.
+   */
+  async searchPortfolio(propertyIds: string[], query: string, types?: string): Promise<SearchResult[]> {
+    const chunks = await Promise.all(
+      propertyIds.map((id) => this.search(id, query, types)),
+    );
+    return chunks.flat().slice(0, 25);
+  }
+
+  private async searchGuests(propertyId: string, pattern: string): Promise<SearchResult[]> {
+    const rows = await this.db
+      .select({
+        id: guests.id,
+        firstName: guests.firstName,
+        lastName: guests.lastName,
+        email: guests.email,
+      })
+      .from(guests)
+      .where(
+        and(
+          eq(guests.isDeleted, false),
+          inArray(
+            guests.id,
+            this.db
+              .select({ guestId: reservations.guestId })
+              .from(reservations)
+              .where(eq(reservations.propertyId, propertyId)),
+          ),
+          or(
+            ilike(guests.firstName, pattern),
+            ilike(guests.lastName, pattern),
+            ilike(guests.email, pattern),
+            ilike(guests.phone, pattern),
+          ),
+        ),
+      )
+      .limit(LIMIT_PER_TYPE);
+
+    return rows.map((g: { id: string; firstName: string; lastName: string; email: string | null }) => ({
+      type: 'guest' as const,
+      id: g.id,
+      propertyId,
+      title: `${g.firstName} ${g.lastName}`.trim(),
+      subtitle: g.email ?? undefined,
+      href: `/guests/${g.id}?propertyId=${propertyId}`,
+    }));
+  }
+
+  private async searchReservations(propertyId: string, pattern: string): Promise<SearchResult[]> {
+    const rows = await this.db
+      .select({
+        id: reservations.id,
+        status: reservations.status,
+        arrivalDate: reservations.arrivalDate,
+        departureDate: reservations.departureDate,
+        confirmationNumber: bookings.confirmationNumber,
+        guestFirst: guests.firstName,
+        guestLast: guests.lastName,
+      })
+      .from(reservations)
+      .innerJoin(bookings, eq(reservations.bookingId, bookings.id))
+      .innerJoin(guests, eq(reservations.guestId, guests.id))
+      .where(
+        and(
+          eq(reservations.propertyId, propertyId),
+          or(
+            ilike(bookings.confirmationNumber, pattern),
+            ilike(bookings.externalConfirmation, pattern),
+            ilike(guests.firstName, pattern),
+            ilike(guests.lastName, pattern),
+          ),
+        ),
+      )
+      .limit(LIMIT_PER_TYPE);
+
+    return rows.map((r: {
+      id: string;
+      status: string;
+      arrivalDate: string;
+      departureDate: string;
+      confirmationNumber: string;
+      guestFirst: string;
+      guestLast: string;
+    }) => ({
+      type: 'reservation' as const,
+      id: r.id,
+      propertyId,
+      title: r.confirmationNumber,
+      subtitle: `${r.guestFirst} ${r.guestLast} · ${r.arrivalDate} → ${r.departureDate}`,
+      href: `/reservations/calendar?propertyId=${propertyId}&highlight=${r.id}`,
+    }));
+  }
+
+  private async searchFolios(propertyId: string, pattern: string): Promise<SearchResult[]> {
+    const rows = await this.db
+      .select({
+        id: folios.id,
+        folioNumber: folios.folioNumber,
+        balance: folios.balance,
+        guestFirst: guests.firstName,
+        guestLast: guests.lastName,
+      })
+      .from(folios)
+      .innerJoin(guests, eq(folios.guestId, guests.id))
+      .where(
+        and(
+          eq(folios.propertyId, propertyId),
+          or(
+            ilike(folios.folioNumber, pattern),
+            ilike(guests.firstName, pattern),
+            ilike(guests.lastName, pattern),
+          ),
+        ),
+      )
+      .limit(LIMIT_PER_TYPE);
+
+    return rows.map((f: {
+      id: string;
+      folioNumber: string;
+      balance: string;
+      guestFirst: string;
+      guestLast: string;
+    }) => ({
+      type: 'folio' as const,
+      id: f.id,
+      propertyId,
+      title: f.folioNumber,
+      subtitle: `${f.guestFirst} ${f.guestLast} · Balance ${f.balance}`,
+      href: `/folios/${f.id}?propertyId=${propertyId}`,
+    }));
+  }
+
+  private async searchRooms(propertyId: string, pattern: string): Promise<SearchResult[]> {
+    const rows = await this.db
+      .select({
+        id: rooms.id,
+        number: rooms.number,
+        status: rooms.status,
+      })
+      .from(rooms)
+      .where(
+        and(
+          eq(rooms.propertyId, propertyId),
+          eq(rooms.isActive, true),
+          ilike(rooms.number, pattern),
+        ),
+      )
+      .limit(LIMIT_PER_TYPE);
+
+    return rows.map((r: { id: string; number: string; status: string }) => ({
+      type: 'room' as const,
+      id: r.id,
+      propertyId,
+      title: `Room ${r.number}`,
+      subtitle: r.status.replace(/_/g, ' '),
+      href: `/rooms?propertyId=${propertyId}&highlight=${r.id}`,
+    }));
+  }
+
+  private async searchGroups(propertyId: string, pattern: string): Promise<SearchResult[]> {
+    const rows = await this.db
+      .select({
+        id: groupProfiles.id,
+        name: groupProfiles.name,
+        groupType: groupProfiles.groupType,
+      })
+      .from(groupProfiles)
+      .where(
+        and(
+          eq(groupProfiles.propertyId, propertyId),
+          or(
+            ilike(groupProfiles.name, pattern),
+            ilike(groupProfiles.contactName, pattern),
+          ),
+        ),
+      )
+      .limit(LIMIT_PER_TYPE);
+
+    return rows.map((g: { id: string; name: string; groupType: string }) => ({
+      type: 'group' as const,
+      id: g.id,
+      propertyId,
+      title: g.name,
+      subtitle: g.groupType,
+      href: `/groups/${g.id}?propertyId=${propertyId}`,
+    }));
+  }
+
+  /** Resolve property name for portfolio search result subtitles. */
+  async propertyNameMap(propertyIds: string[]): Promise<Map<string, string>> {
+    if (!propertyIds.length) return new Map();
+    const rows = await this.db
+      .select({ id: properties.id, name: properties.name })
+      .from(properties)
+      .where(inArray(properties.id, propertyIds));
+    return new Map(rows.map((r: { id: string; name: string }) => [r.id, r.name]));
+  }
+}

--- a/apps/api/src/modules/staff-notifications/staff-notification.controller.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notification.controller.ts
@@ -1,0 +1,56 @@
+import { Controller, Get, Patch, Param, Query, ParseUUIDPipe } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { StaffNotificationService } from './staff-notification.service';
+import { CurrentUser, type AuthUser } from '../auth/current-user.decorator';
+
+@ApiTags('staff-notifications')
+@Controller('staff-notifications')
+export class StaffNotificationController {
+  constructor(private readonly service: StaffNotificationService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List staff notifications for current user at a property' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  list(
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const userId = user?.sub ?? 'anonymous';
+    return this.service.listForUser(propertyId, userId);
+  }
+
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Unread notification count' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  async unreadCount(
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const userId = user?.sub ?? 'anonymous';
+    const count = await this.service.unreadCount(propertyId, userId);
+    return { count };
+  }
+
+  @Patch('read-all')
+  @ApiOperation({ summary: 'Mark all notifications as read' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  markAllRead(
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const userId = user?.sub ?? 'anonymous';
+    return this.service.markAllRead(propertyId, userId);
+  }
+
+  @Patch(':id/read')
+  @ApiOperation({ summary: 'Mark a notification as read' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  markRead(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @CurrentUser() user: AuthUser,
+  ) {
+    const userId = user?.sub ?? 'anonymous';
+    return this.service.markRead(id, propertyId, userId);
+  }
+}

--- a/apps/api/src/modules/staff-notifications/staff-notification.listener.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notification.listener.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import type { WebhookPayload } from '../webhook/webhook.service';
+import { StaffNotificationService } from './staff-notification.service';
+
+/**
+ * Listens to domain events and creates staff-facing in-app notifications.
+ */
+@Injectable()
+export class StaffNotificationListener {
+  private readonly logger = new Logger(StaffNotificationListener.name);
+
+  constructor(private readonly staffNotifications: StaffNotificationService) {}
+
+  @OnEvent('agent.decision_created')
+  async onAgentDecision(payload: WebhookPayload) {
+    if (!payload.propertyId) return;
+
+    const data = payload.data ?? {};
+    const decisionType = String(data['decisionType'] ?? '');
+    const agentType = String(data['agentType'] ?? '');
+    const confidence = Number(data['confidence'] ?? 0);
+
+    const isAnomaly =
+      decisionType === 'night_audit_anomaly' ||
+      agentType === 'night_audit';
+
+    if (!isAnomaly && confidence < 0.7) return;
+
+    const severity = decisionType === 'night_audit_anomaly' ? 'critical' : 'warning';
+    const title =
+      decisionType === 'night_audit_anomaly'
+        ? 'Night audit anomaly detected'
+        : `${agentType.replace(/_/g, ' ')} alert`;
+
+    await this.staffNotifications.create({
+      propertyId: payload.propertyId,
+      type: isAnomaly ? 'anomaly' : 'agent_decision',
+      title,
+      message: String(data['summary'] ?? `Agent ${agentType} flagged ${decisionType} for review`),
+      severity,
+      sourceEvent: 'agent.decision_created',
+      sourceEntityType: 'agent_decision',
+      sourceEntityId: payload.entityId,
+    });
+  }
+
+  @OnEvent('audit.completed')
+  async onAuditCompleted(payload: WebhookPayload) {
+    if (!payload.propertyId) return;
+
+    const data = payload.data ?? {};
+    const summary = data['summary'] as Record<string, unknown> | undefined;
+    const businessDate = String(data['businessDate'] ?? '');
+
+    const errors = Array.isArray((data as any).errors) ? (data as any).errors : [];
+    if (errors.length > 0) {
+      await this.staffNotifications.create({
+        propertyId: payload.propertyId,
+        type: 'audit_error',
+        title: `Night audit completed with ${errors.length} error(s)`,
+        message: `Business date ${businessDate}: review audit run before day close.`,
+        severity: 'warning',
+        sourceEvent: 'audit.completed',
+        sourceEntityType: 'audit_run',
+        sourceEntityId: payload.entityId,
+      });
+      return;
+    }
+
+    const netRevenue = summary?.['netRevenue'];
+    if (netRevenue != null) {
+      await this.staffNotifications.create({
+        propertyId: payload.propertyId,
+        type: 'audit_completed',
+        title: 'Night audit completed',
+        message: `Business date ${businessDate} closed. Net revenue: ${netRevenue}.`,
+        severity: 'info',
+        sourceEvent: 'audit.completed',
+        sourceEntityType: 'audit_run',
+        sourceEntityId: payload.entityId,
+      });
+    }
+  }
+}

--- a/apps/api/src/modules/staff-notifications/staff-notification.service.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notification.service.ts
@@ -1,0 +1,179 @@
+import { Injectable, Inject, NotFoundException } from '@nestjs/common';
+import { eq, and, desc, sql, isNull, or } from 'drizzle-orm';
+import { staffNotifications, staffNotificationReads } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import { WebhookService } from '../webhook/webhook.service';
+import { EventsGateway } from '../events/events.gateway';
+
+export interface CreateStaffNotificationInput {
+  propertyId: string;
+  userId?: string | null;
+  type: string;
+  title: string;
+  message: string;
+  severity?: 'info' | 'warning' | 'critical';
+  sourceEvent?: string;
+  sourceEntityType?: string;
+  sourceEntityId?: string;
+}
+
+@Injectable()
+export class StaffNotificationService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: any,
+    private readonly webhookService: WebhookService,
+    private readonly eventsGateway: EventsGateway,
+  ) {}
+
+  async create(input: CreateStaffNotificationInput) {
+    const [row] = await this.db
+      .insert(staffNotifications)
+      .values({
+        propertyId: input.propertyId,
+        userId: input.userId ?? null,
+        type: input.type,
+        title: input.title,
+        message: input.message,
+        severity: input.severity ?? 'info',
+        sourceEvent: input.sourceEvent ?? null,
+        sourceEntityType: input.sourceEntityType ?? null,
+        sourceEntityId: input.sourceEntityId ?? null,
+      })
+      .returning();
+
+    await this.webhookService.emit(
+      'staff.notification_created',
+      'staff_notification',
+      row.id,
+      {
+        type: row.type,
+        title: row.title,
+        severity: row.severity,
+      },
+      input.propertyId,
+    );
+
+    this.eventsGateway.broadcastStaffNotification(input.propertyId, {
+      id: row.id,
+      type: row.type,
+      title: row.title,
+      message: row.message,
+      severity: row.severity,
+      createdAt: row.createdAt,
+    });
+
+    return row;
+  }
+
+  async listForUser(propertyId: string, userId: string, limit = 50) {
+    const rows = await this.db
+      .select({
+        id: staffNotifications.id,
+        propertyId: staffNotifications.propertyId,
+        type: staffNotifications.type,
+        title: staffNotifications.title,
+        message: staffNotifications.message,
+        severity: staffNotifications.severity,
+        sourceEvent: staffNotifications.sourceEvent,
+        sourceEntityType: staffNotifications.sourceEntityType,
+        sourceEntityId: staffNotifications.sourceEntityId,
+        createdAt: staffNotifications.createdAt,
+        readAt: staffNotificationReads.readAt,
+      })
+      .from(staffNotifications)
+      .leftJoin(
+        staffNotificationReads,
+        and(
+          eq(staffNotificationReads.notificationId, staffNotifications.id),
+          eq(staffNotificationReads.userId, userId),
+        ),
+      )
+      .where(
+        and(
+          eq(staffNotifications.propertyId, propertyId),
+          or(isNull(staffNotifications.userId), eq(staffNotifications.userId, userId)),
+        ),
+      )
+      .orderBy(desc(staffNotifications.createdAt))
+      .limit(limit);
+
+    return rows.map((r: { readAt: Date | null }) => ({
+      ...r,
+      isRead: r.readAt != null,
+    }));
+  }
+
+  async unreadCount(propertyId: string, userId: string): Promise<number> {
+    const [row] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(staffNotifications)
+      .leftJoin(
+        staffNotificationReads,
+        and(
+          eq(staffNotificationReads.notificationId, staffNotifications.id),
+          eq(staffNotificationReads.userId, userId),
+        ),
+      )
+      .where(
+        and(
+          eq(staffNotifications.propertyId, propertyId),
+          or(isNull(staffNotifications.userId), eq(staffNotifications.userId, userId)),
+          sql`${staffNotificationReads.id} is null`,
+        ),
+      );
+    return row?.count ?? 0;
+  }
+
+  async markRead(notificationId: string, propertyId: string, userId: string) {
+    const [notification] = await this.db
+      .select()
+      .from(staffNotifications)
+      .where(
+        and(
+          eq(staffNotifications.id, notificationId),
+          eq(staffNotifications.propertyId, propertyId),
+        ),
+      );
+    if (!notification) {
+      throw new NotFoundException(`Notification ${notificationId} not found`);
+    }
+
+    await this.db
+      .insert(staffNotificationReads)
+      .values({ notificationId, userId })
+      .onConflictDoNothing();
+
+    return { read: true };
+  }
+
+  async markAllRead(propertyId: string, userId: string) {
+    const unread = await this.db
+      .select({ id: staffNotifications.id })
+      .from(staffNotifications)
+      .leftJoin(
+        staffNotificationReads,
+        and(
+          eq(staffNotificationReads.notificationId, staffNotifications.id),
+          eq(staffNotificationReads.userId, userId),
+        ),
+      )
+      .where(
+        and(
+          eq(staffNotifications.propertyId, propertyId),
+          or(isNull(staffNotifications.userId), eq(staffNotifications.userId, userId)),
+          sql`${staffNotificationReads.id} is null`,
+        ),
+      );
+
+    if (unread.length) {
+      await this.db.insert(staffNotificationReads).values(
+        unread.map((r: { id: string }) => ({
+          notificationId: r.id,
+          userId,
+        })),
+      ).onConflictDoNothing();
+    }
+
+    return { marked: unread.length };
+  }
+}

--- a/apps/api/src/modules/staff-notifications/staff-notifications.module.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notifications.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { StaffNotificationController } from './staff-notification.controller';
+import { StaffNotificationService } from './staff-notification.service';
+import { StaffNotificationListener } from './staff-notification.listener';
+import { WebhookModule } from '../webhook/webhook.module';
+import { EventsModule } from '../events/events.module';
+
+@Module({
+  imports: [WebhookModule, EventsModule],
+  controllers: [StaffNotificationController],
+  providers: [StaffNotificationService, StaffNotificationListener],
+  exports: [StaffNotificationService],
+})
+export class StaffNotificationsModule {}

--- a/apps/dashboard/src/components/layout/Header.tsx
+++ b/apps/dashboard/src/components/layout/Header.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
-import { Bell, ChevronDown, Menu, LogOut, User, Languages } from 'lucide-react';
+import { ChevronDown, Menu, LogOut, User, Languages, Search } from 'lucide-react';
 import { format } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 import { useProperty } from '../../context/PropertyContext';
+import { PORTFOLIO_MODE_ID } from '../../lib/property-types';
 import { useAuth } from '../../context/AuthContext';
 import { useSocket } from '../../hooks/useSocket';
 import { SUPPORTED_LANGUAGES } from '../../i18n';
+import CommandPalette, { useCommandPaletteShortcut } from '../search/CommandPalette';
+import NotificationBell from '../notifications/NotificationBell';
 
 interface HeaderProps {
   onMenuClick: () => void;
@@ -13,127 +16,168 @@ interface HeaderProps {
 
 export default function Header({ onMenuClick }: HeaderProps) {
   const { t, i18n } = useTranslation();
-  const { propertyId, setPropertyId, properties } = useProperty();
+  const { propertyId, setPropertyId, properties, isPortfolioMode } = useProperty();
   const { user, roles, authEnabled, logout } = useAuth();
   const { connected } = useSocket();
   const [open, setOpen] = useState(false);
   const [langOpen, setLangOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
 
-  const activeProperty = properties.find((p) => p.id === propertyId);
+  useCommandPaletteShortcut(() => setSearchOpen(true));
+
+  const activeProperty = isPortfolioMode
+    ? null
+    : properties.find((p) => p.id === propertyId);
   const currentLang =
     SUPPORTED_LANGUAGES.find((l) => l.code === i18n.resolvedLanguage) ??
     SUPPORTED_LANGUAGES[0];
 
+  const propertyLabel = isPortfolioMode
+    ? t('header.allProperties', { defaultValue: 'All Properties' })
+    : (activeProperty?.name ?? t('header.selectProperty'));
+
   return (
-    <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-3 sm:px-6">
-      <div className="flex items-center gap-2 sm:gap-4">
-        <button
-          onClick={onMenuClick}
-          className="lg:hidden p-2 -ml-1 rounded-lg hover:bg-telivity-light-grey"
-          aria-label={t('header.openMenu')}
-        >
-          <Menu size={20} className="text-telivity-slate" />
-        </button>
-
-        <div className="relative">
+    <>
+      <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-3 sm:px-6">
+        <div className="flex items-center gap-2 sm:gap-4">
           <button
-            onClick={() => setOpen(!open)}
-            className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 hover:border-telivity-teal text-sm font-medium transition-colors"
-            aria-haspopup="listbox"
-            aria-expanded={open}
+            onClick={onMenuClick}
+            className="lg:hidden p-2 -ml-1 rounded-lg hover:bg-telivity-light-grey"
+            aria-label={t('header.openMenu')}
           >
-            <span className="truncate max-w-[140px] sm:max-w-none">{activeProperty?.name ?? t('header.selectProperty')}</span>
-            <ChevronDown size={14} />
+            <Menu size={20} className="text-telivity-slate" />
           </button>
-          {open && (
-            <div className="absolute top-full left-0 mt-1 w-64 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1" role="listbox">
-              {properties.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={() => { setPropertyId(p.id); setOpen(false); }}
-                  role="option"
-                  aria-selected={p.id === propertyId}
-                  className={`w-full text-left px-4 py-2 text-sm hover:bg-telivity-light-grey transition-colors ${
-                    p.id === propertyId ? 'text-telivity-teal font-semibold' : ''
-                  }`}
-                >
-                  {p.name}
-                  <span className="text-telivity-mid-grey ml-2">({p.code})</span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
 
-        <span className="text-sm text-telivity-mid-grey hidden sm:inline">
-          {format(new Date(), 'EEEE, MMM d, yyyy')}
-        </span>
-      </div>
-
-      <div className="flex items-center gap-3 sm:gap-4">
-        <div className="flex items-center gap-1.5">
-          <div className={`w-2 h-2 rounded-full ${connected ? 'bg-telivity-dark-teal' : 'bg-telivity-orange'}`} aria-hidden="true" />
-          <span className="text-xs text-telivity-mid-grey">{connected ? t('header.statusLive') : t('header.statusOffline')}</span>
-        </div>
-
-        {/* Language switcher */}
-        <div className="relative">
-          <button
-            onClick={() => setLangOpen(!langOpen)}
-            className="flex items-center gap-1 px-2 py-1.5 rounded-lg hover:bg-telivity-light-grey text-xs font-medium text-telivity-slate transition-colors"
-            aria-haspopup="listbox"
-            aria-expanded={langOpen}
-            aria-label={t('header.language')}
-            title={t('header.language')}
-          >
-            <Languages size={16} className="text-telivity-slate" />
-            <span className="uppercase">{currentLang.code}</span>
-            <ChevronDown size={12} />
-          </button>
-          {langOpen && (
-            <div className="absolute top-full right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1" role="listbox">
-              {SUPPORTED_LANGUAGES.map((lang) => (
-                <button
-                  key={lang.code}
-                  onClick={() => { i18n.changeLanguage(lang.code); setLangOpen(false); }}
-                  role="option"
-                  aria-selected={lang.code === currentLang.code}
-                  className={`w-full text-left px-4 py-2 text-sm hover:bg-telivity-light-grey transition-colors ${
-                    lang.code === currentLang.code ? 'text-telivity-teal font-semibold' : ''
-                  }`}
-                >
-                  {lang.label}
-                  <span className="text-telivity-mid-grey ml-2 uppercase">({lang.code})</span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-
-        <button className="relative p-2 rounded-lg hover:bg-telivity-light-grey transition-colors" aria-label={t('header.notifications')}>
-          <Bell size={18} className="text-telivity-slate" />
-        </button>
-
-        {authEnabled && user && (
-          <div className="flex items-center gap-2 ml-2 pl-3 border-l border-gray-200">
-            <div className="hidden sm:block text-right">
-              <p className="text-xs font-medium text-telivity-slate">{user.name || user.email}</p>
-              <p className="text-[10px] text-telivity-mid-grey capitalize">
-                {roles.filter(r => !r.startsWith('default-')).join(', ') || t('header.user')}
-              </p>
-            </div>
-            <User size={16} className="sm:hidden text-telivity-slate" />
+          <div className="relative">
             <button
-              onClick={logout}
-              className="p-1.5 rounded-lg hover:bg-red-50 transition-colors"
-              aria-label={t('header.logout')}
-              title={t('header.logout')}
+              onClick={() => setOpen(!open)}
+              className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 hover:border-telivity-teal text-sm font-medium transition-colors"
+              aria-haspopup="listbox"
+              aria-expanded={open}
             >
-              <LogOut size={16} className="text-telivity-mid-grey hover:text-red-600" />
+              <span className="truncate max-w-[140px] sm:max-w-none">{propertyLabel}</span>
+              <ChevronDown size={14} />
             </button>
+            {open && (
+              <div className="absolute top-full left-0 mt-1 w-64 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1" role="listbox">
+                {properties.length > 1 && (
+                  <button
+                    onClick={() => { setPropertyId(PORTFOLIO_MODE_ID); setOpen(false); }}
+                    role="option"
+                    aria-selected={isPortfolioMode}
+                    className={`w-full text-left px-4 py-2 text-sm hover:bg-telivity-light-grey transition-colors border-b border-gray-100 ${
+                      isPortfolioMode ? 'text-telivity-teal font-semibold' : 'font-medium text-telivity-navy'
+                    }`}
+                  >
+                    {t('header.allProperties', { defaultValue: 'All Properties' })}
+                    <span className="text-telivity-mid-grey ml-2 text-xs">({properties.length})</span>
+                  </button>
+                )}
+                {properties.map((p) => (
+                  <button
+                    key={p.id}
+                    onClick={() => { setPropertyId(p.id); setOpen(false); }}
+                    role="option"
+                    aria-selected={p.id === propertyId}
+                    className={`w-full text-left px-4 py-2 text-sm hover:bg-telivity-light-grey transition-colors ${
+                      p.id === propertyId ? 'text-telivity-teal font-semibold' : ''
+                    }`}
+                  >
+                    {p.name}
+                    <span className="text-telivity-mid-grey ml-2">({p.code})</span>
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-        )}
-      </div>
-    </header>
+
+          <button
+            onClick={() => setSearchOpen(true)}
+            className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 hover:border-telivity-teal text-sm text-telivity-mid-grey transition-colors min-w-[180px]"
+          >
+            <Search size={14} />
+            <span className="flex-1 text-left">{t('header.search', { defaultValue: 'Search…' })}</span>
+            <kbd className="text-[10px] bg-telivity-light-grey px-1.5 py-0.5 rounded">⌘K</kbd>
+          </button>
+
+          <span className="text-sm text-telivity-mid-grey hidden md:inline">
+            {format(new Date(), 'EEEE, MMM d, yyyy')}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-3 sm:gap-4">
+          <div className="flex items-center gap-1.5">
+            <div className={`w-2 h-2 rounded-full ${connected ? 'bg-telivity-dark-teal' : 'bg-telivity-orange'}`} aria-hidden="true" />
+            <span className="text-xs text-telivity-mid-grey hidden sm:inline">{connected ? t('header.statusLive') : t('header.statusOffline')}</span>
+          </div>
+
+          <button
+            onClick={() => setSearchOpen(true)}
+            className="sm:hidden p-2 rounded-lg hover:bg-telivity-light-grey"
+            aria-label={t('header.search', { defaultValue: 'Search' })}
+          >
+            <Search size={18} className="text-telivity-slate" />
+          </button>
+
+          {/* Language switcher */}
+          <div className="relative">
+            <button
+              onClick={() => setLangOpen(!langOpen)}
+              className="flex items-center gap-1 px-2 py-1.5 rounded-lg hover:bg-telivity-light-grey text-xs font-medium text-telivity-slate transition-colors"
+              aria-haspopup="listbox"
+              aria-expanded={langOpen}
+              aria-label={t('header.language')}
+              title={t('header.language')}
+            >
+              <Languages size={16} className="text-telivity-slate" />
+              <span className="uppercase hidden sm:inline">{currentLang.code}</span>
+              <ChevronDown size={12} />
+            </button>
+            {langOpen && (
+              <div className="absolute top-full right-0 mt-1 w-36 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1" role="listbox">
+                {SUPPORTED_LANGUAGES.map((lang) => (
+                  <button
+                    key={lang.code}
+                    onClick={() => { i18n.changeLanguage(lang.code); setLangOpen(false); }}
+                    role="option"
+                    aria-selected={lang.code === currentLang.code}
+                    className={`w-full text-left px-4 py-2 text-sm hover:bg-telivity-light-grey transition-colors ${
+                      lang.code === currentLang.code ? 'text-telivity-teal font-semibold' : ''
+                    }`}
+                  >
+                    {lang.label}
+                    <span className="text-telivity-mid-grey ml-2 uppercase">({lang.code})</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <NotificationBell />
+
+          {authEnabled && user && (
+            <div className="flex items-center gap-2 ml-2 pl-3 border-l border-gray-200">
+              <div className="hidden sm:block text-right">
+                <p className="text-xs font-medium text-telivity-slate">{user.name || user.email}</p>
+                <p className="text-[10px] text-telivity-mid-grey capitalize">
+                  {roles.filter(r => !r.startsWith('default-')).join(', ') || t('header.user')}
+                </p>
+              </div>
+              <User size={16} className="sm:hidden text-telivity-slate" />
+              <button
+                onClick={logout}
+                className="p-1.5 rounded-lg hover:bg-red-50 transition-colors"
+                aria-label={t('header.logout')}
+                title={t('header.logout')}
+              >
+                <LogOut size={16} className="text-telivity-mid-grey hover:text-red-600" />
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <CommandPalette open={searchOpen} onClose={() => setSearchOpen(false)} />
+    </>
   );
 }

--- a/apps/dashboard/src/components/notifications/NotificationBell.tsx
+++ b/apps/dashboard/src/components/notifications/NotificationBell.tsx
@@ -1,0 +1,167 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Bell, X, CheckCheck } from 'lucide-react';
+import { format } from 'date-fns';
+import { api } from '../../lib/api';
+import { useProperty } from '../../context/PropertyContext';
+import { getSocket } from '../../lib/socket';
+
+interface StaffNotification {
+  id: string;
+  type: string;
+  title: string;
+  message: string;
+  severity: 'info' | 'warning' | 'critical';
+  createdAt: string;
+  isRead: boolean;
+}
+
+interface NotificationBellProps {
+  className?: string;
+}
+
+export default function NotificationBell({ className }: NotificationBellProps) {
+  const { propertyId, isPortfolioMode } = useProperty();
+  const [open, setOpen] = useState(false);
+  const queryClient = useQueryClient();
+
+  const { data: notifications = [] } = useQuery({
+    queryKey: ['staff-notifications', propertyId],
+    queryFn: () =>
+      api
+        .get('/v1/staff-notifications', { params: { propertyId } })
+        .then((r) => (r.data?.data ?? r.data ?? []) as StaffNotification[]),
+    enabled: !!propertyId && !isPortfolioMode,
+    refetchInterval: 60_000,
+  });
+
+  const { data: unreadData } = useQuery({
+    queryKey: ['staff-notifications-unread', propertyId],
+    queryFn: () =>
+      api
+        .get('/v1/staff-notifications/unread-count', { params: { propertyId } })
+        .then((r) => r.data?.count ?? r.data ?? 0),
+    enabled: !!propertyId && !isPortfolioMode,
+  });
+
+  const unreadCount = typeof unreadData === 'number' ? unreadData : 0;
+
+  const markRead = useMutation({
+    mutationFn: (id: string) =>
+      api.patch(`/v1/staff-notifications/${id}/read`, null, { params: { propertyId } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['staff-notifications', propertyId] });
+      queryClient.invalidateQueries({ queryKey: ['staff-notifications-unread', propertyId] });
+    },
+  });
+
+  const markAllRead = useMutation({
+    mutationFn: () =>
+      api.patch('/v1/staff-notifications/read-all', null, { params: { propertyId } }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['staff-notifications', propertyId] });
+      queryClient.invalidateQueries({ queryKey: ['staff-notifications-unread', propertyId] });
+    },
+  });
+
+  const handleSocketNotification = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ['staff-notifications', propertyId] });
+    queryClient.invalidateQueries({ queryKey: ['staff-notifications-unread', propertyId] });
+  }, [queryClient, propertyId]);
+
+  useEffect(() => {
+    if (!propertyId || isPortfolioMode) return;
+    const socket = getSocket();
+    socket.on('staffNotification', handleSocketNotification);
+    return () => {
+      socket.off('staffNotification', handleSocketNotification);
+    };
+  }, [propertyId, isPortfolioMode, handleSocketNotification]);
+
+  if (!propertyId || isPortfolioMode) {
+    return (
+      <button
+        className={`relative p-2 rounded-lg opacity-40 cursor-not-allowed ${className ?? ''}`}
+        aria-label="Notifications (select a property)"
+        disabled
+      >
+        <Bell size={18} className="text-telivity-slate" />
+      </button>
+    );
+  }
+
+  const severityColor = (s: string) => {
+    if (s === 'critical') return 'border-l-red-500';
+    if (s === 'warning') return 'border-l-telivity-orange';
+    return 'border-l-telivity-teal';
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className={`relative p-2 rounded-lg hover:bg-telivity-light-grey transition-colors ${className ?? ''}`}
+        aria-label="Notifications"
+        aria-expanded={open}
+      >
+        <Bell size={18} className="text-telivity-slate" />
+        {unreadCount > 0 && (
+          <span className="absolute top-1 right-1 min-w-[16px] h-4 px-1 rounded-full bg-telivity-orange text-white text-[10px] font-bold flex items-center justify-center">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} aria-hidden="true" />
+          <div className="absolute right-0 top-full mt-2 w-80 sm:w-96 bg-white rounded-xl shadow-lg border border-gray-200 z-50 overflow-hidden">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100">
+              <h3 className="text-sm font-semibold text-telivity-navy">Notifications</h3>
+              <div className="flex items-center gap-1">
+                {unreadCount > 0 && (
+                  <button
+                    onClick={() => markAllRead.mutate()}
+                    className="p-1.5 rounded hover:bg-telivity-light-grey text-telivity-teal"
+                    title="Mark all read"
+                  >
+                    <CheckCheck size={14} />
+                  </button>
+                )}
+                <button onClick={() => setOpen(false)} className="p-1.5 rounded hover:bg-telivity-light-grey">
+                  <X size={14} className="text-telivity-mid-grey" />
+                </button>
+              </div>
+            </div>
+            <div className="max-h-96 overflow-y-auto">
+              {notifications.length === 0 ? (
+                <p className="px-4 py-8 text-sm text-telivity-mid-grey text-center">No notifications</p>
+              ) : (
+                <ul>
+                  {notifications.map((n) => (
+                    <li key={n.id}>
+                      <button
+                        className={`w-full text-left px-4 py-3 border-b border-gray-50 hover:bg-telivity-light-grey border-l-4 ${severityColor(n.severity)} ${
+                          !n.isRead ? 'bg-telivity-teal/5' : ''
+                        }`}
+                        onClick={() => {
+                          if (!n.isRead) markRead.mutate(n.id);
+                        }}
+                      >
+                        <p className="text-sm font-medium text-telivity-navy">{n.title}</p>
+                        <p className="text-xs text-telivity-mid-grey mt-0.5 line-clamp-2">{n.message}</p>
+                        <p className="text-[10px] text-telivity-mid-grey mt-1">
+                          {format(new Date(n.createdAt), 'MMM d, HH:mm')}
+                        </p>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/components/search/CommandPalette.tsx
+++ b/apps/dashboard/src/components/search/CommandPalette.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Search, X } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../../lib/api';
+import { useProperty } from '../../context/PropertyContext';
+
+interface SearchResult {
+  type: string;
+  id: string;
+  propertyId: string;
+  propertyName?: string;
+  title: string;
+  subtitle?: string;
+  href: string;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function CommandPalette({ open, onClose }: CommandPaletteProps) {
+  const navigate = useNavigate();
+  const { propertyId, isPortfolioMode } = useProperty();
+  const [query, setQuery] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(query.trim()), 200);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setDebounced('');
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [open]);
+
+  const { data: results = [], isFetching } = useQuery({
+    queryKey: ['search', debounced, propertyId, isPortfolioMode],
+    queryFn: async () => {
+      if (!debounced) return [];
+      const endpoint = isPortfolioMode ? '/v1/search/portfolio' : '/v1/search';
+      const params: Record<string, string> = { q: debounced };
+      if (!isPortfolioMode && propertyId) params.propertyId = propertyId;
+      const res = await api.get(endpoint, { params });
+      return (res.data?.data ?? res.data ?? []) as SearchResult[];
+    },
+    enabled: open && debounced.length >= 2 && (!!propertyId || isPortfolioMode),
+  });
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (open) onClose();
+      }
+      if (e.key === 'Escape' && open) onClose();
+    },
+    [open, onClose],
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-start justify-center pt-[15vh] px-4">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden="true" />
+      <div
+        className="relative w-full max-w-xl bg-white rounded-xl shadow-2xl border border-gray-200 overflow-hidden"
+        role="dialog"
+        aria-label="Search"
+      >
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-100">
+          <Search size={18} className="text-telivity-mid-grey flex-shrink-0" />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={isPortfolioMode ? 'Search all properties…' : 'Search guests, reservations, folios…'}
+            className="flex-1 text-sm outline-none text-telivity-navy placeholder:text-telivity-mid-grey"
+          />
+          <button onClick={onClose} className="p-1 rounded hover:bg-telivity-light-grey" aria-label="Close search">
+            <X size={16} className="text-telivity-mid-grey" />
+          </button>
+        </div>
+        <div className="max-h-80 overflow-y-auto">
+          {debounced.length < 2 ? (
+            <p className="px-4 py-6 text-sm text-telivity-mid-grey text-center">
+              Type at least 2 characters to search
+              <span className="block text-xs mt-1">⌘K / Ctrl+K</span>
+            </p>
+          ) : isFetching ? (
+            <p className="px-4 py-6 text-sm text-telivity-mid-grey text-center">Searching…</p>
+          ) : results.length === 0 ? (
+            <p className="px-4 py-6 text-sm text-telivity-mid-grey text-center">No results</p>
+          ) : (
+            <ul>
+              {results.map((r) => (
+                <li key={`${r.type}-${r.id}-${r.propertyId}`}>
+                  <button
+                    className="w-full text-left px-4 py-2.5 hover:bg-telivity-light-grey transition-colors border-b border-gray-50 last:border-0"
+                    onClick={() => {
+                      navigate(r.href);
+                      onClose();
+                    }}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-[10px] uppercase font-semibold text-telivity-teal bg-telivity-teal/10 px-1.5 py-0.5 rounded">
+                        {r.type}
+                      </span>
+                      <span className="text-sm font-medium text-telivity-navy truncate">{r.title}</span>
+                    </div>
+                    {(r.subtitle || r.propertyName) && (
+                      <p className="text-xs text-telivity-mid-grey mt-0.5 truncate">
+                        {r.propertyName ? `${r.propertyName} · ` : ''}
+                        {r.subtitle}
+                      </p>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Global keyboard shortcut hook — opens command palette on ⌘K / Ctrl+K */
+export function useCommandPaletteShortcut(onOpen: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpen();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onOpen]);
+}

--- a/apps/dashboard/src/context/PropertyContext.tsx
+++ b/apps/dashboard/src/context/PropertyContext.tsx
@@ -2,17 +2,18 @@ import { createContext, useContext, useState, useEffect, type ReactNode } from '
 import { useSearchParams } from 'react-router-dom';
 import { api, setPropertyId as setApiPropertyId } from '../lib/api';
 import { joinPropertyRoom, leavePropertyRoom } from '../lib/socket';
-
-export interface PropertySummary {
-  id: string;
-  name: string;
-  code: string;
-}
+import {
+  PORTFOLIO_MODE_ID,
+  type PropertySummary,
+  type OrganizationSummary,
+} from '../lib/property-types';
 
 interface PropertyContextValue {
   propertyId: string | null;
   setPropertyId: (id: string) => void;
+  isPortfolioMode: boolean;
   properties: PropertySummary[];
+  organizations: OrganizationSummary[];
   propertiesLoading: boolean;
   propertiesError: string | null;
 }
@@ -20,7 +21,9 @@ interface PropertyContextValue {
 const PropertyContext = createContext<PropertyContextValue>({
   propertyId: null,
   setPropertyId: () => {},
+  isPortfolioMode: false,
   properties: [],
+  organizations: [],
   propertiesLoading: false,
   propertiesError: null,
 });
@@ -31,8 +34,11 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
     searchParams.get('propertyId'),
   );
   const [properties, setProperties] = useState<PropertySummary[]>([]);
+  const [organizations, setOrganizations] = useState<OrganizationSummary[]>([]);
   const [propertiesLoading, setPropertiesLoading] = useState(true);
   const [propertiesError, setPropertiesError] = useState<string | null>(null);
+
+  const isPortfolioMode = propertyId === PORTFOLIO_MODE_ID;
 
   function setPropertyId(id: string) {
     setPropertyIdState(id);
@@ -45,13 +51,18 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     setPropertiesLoading(true);
     setPropertiesError(null);
-    api
-      .get('/v1/properties')
-      .then((res) => {
-        const list: PropertySummary[] = res.data?.data ?? res.data ?? [];
+    Promise.all([
+      api.get('/v1/properties'),
+      api.get('/v1/organizations').catch(() => ({ data: [] })),
+    ])
+      .then(([propRes, orgRes]) => {
+        const list: PropertySummary[] = propRes.data?.data ?? propRes.data ?? [];
+        const orgList: OrganizationSummary[] = orgRes.data?.data ?? orgRes.data ?? [];
         setProperties(list);
+        setOrganizations(orgList);
         if (!propertyId && list.length > 0) {
-          setPropertyId(list[0].id);
+          // Default to portfolio when user has multiple properties
+          setPropertyId(list.length > 1 ? PORTFOLIO_MODE_ID : list[0].id);
         }
       })
       .catch((err) => {
@@ -62,16 +73,28 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (isPortfolioMode) {
+      setApiPropertyId(null);
+      return;
+    }
     setApiPropertyId(propertyId);
     if (propertyId) {
       joinPropertyRoom(propertyId);
       return () => leavePropertyRoom(propertyId);
     }
-  }, [propertyId]);
+  }, [propertyId, isPortfolioMode]);
 
   return (
     <PropertyContext.Provider
-      value={{ propertyId, setPropertyId, properties, propertiesLoading, propertiesError }}
+      value={{
+        propertyId,
+        setPropertyId,
+        isPortfolioMode,
+        properties,
+        organizations,
+        propertiesLoading,
+        propertiesError,
+      }}
     >
       {children}
     </PropertyContext.Provider>
@@ -81,3 +104,5 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
 export function useProperty() {
   return useContext(PropertyContext);
 }
+
+export { PORTFOLIO_MODE_ID };

--- a/apps/dashboard/src/lib/property-types.ts
+++ b/apps/dashboard/src/lib/property-types.ts
@@ -1,0 +1,15 @@
+/** Sentinel value for portfolio (all properties) mode in the property switcher. */
+export const PORTFOLIO_MODE_ID = 'portfolio';
+
+export interface PropertySummary {
+  id: string;
+  name: string;
+  code: string;
+  organizationId?: string | null;
+}
+
+export interface OrganizationSummary {
+  id: string;
+  name: string;
+  code: string;
+}

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -12,8 +12,9 @@ import {
   Users,
   DoorOpen,
   Brain,
+  Building2,
 } from 'lucide-react';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend, BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
 import { format } from 'date-fns';
 import { api } from '../lib/api';
 import { formatOccupancyPercent } from '../lib/api-helpers';
@@ -44,53 +45,64 @@ interface ActivityEvent {
 }
 
 export default function Dashboard() {
-  const { propertyId } = useProperty();
+  const { propertyId, setPropertyId, isPortfolioMode, properties } = useProperty();
   const navigate = useNavigate();
   const today = format(new Date(), 'yyyy-MM-dd');
+
+  const { data: portfolioFinancial } = useQuery({
+    queryKey: ['reports', 'portfolio', 'financial-summary', today],
+    queryFn: () => api.get('/v1/reports/portfolio/financial-summary', { params: { date: today } }).then((r) => r.data),
+    enabled: isPortfolioMode,
+  });
+
+  const { data: portfolioOccupancy } = useQuery({
+    queryKey: ['reports', 'portfolio', 'occupancy', today],
+    queryFn: () => api.get('/v1/reports/portfolio/occupancy', { params: { date: today } }).then((r) => r.data),
+    enabled: isPortfolioMode,
+  });
 
   const { data: financial } = useQuery({
     queryKey: ['reports', 'financial-summary', propertyId, today],
     queryFn: () => api.get('/v1/reports/financial-summary', { params: { propertyId, date: today } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: occupancy } = useQuery({
     queryKey: ['reports', 'occupancy', propertyId, today],
     queryFn: () => api.get('/v1/reports/occupancy', { params: { propertyId, date: today } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: roomSummary } = useQuery({
     queryKey: ['rooms', 'status-summary', propertyId],
     queryFn: () => api.get('/v1/rooms/status-summary', { params: { propertyId } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: arrivals } = useQuery({
     queryKey: ['reservations', 'arrivals', propertyId, today],
     queryFn: () => api.get('/v1/reservations', { params: { propertyId, status: 'confirmed', arrivalDateFrom: today, arrivalDateTo: today } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: departures } = useQuery({
     queryKey: ['reservations', 'departures', propertyId, today],
     queryFn: () => api.get('/v1/reservations', { params: { propertyId, status: 'checked_in', departureDateFrom: today, departureDateTo: today } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: inHouse } = useQuery({
     queryKey: ['reservations', 'in-house', propertyId],
     queryFn: () => api.get('/v1/reservations', { params: { propertyId, status: 'checked_in' } }).then((r) => r.data),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
   const { data: agentStatuses } = useQuery({
     queryKey: ['agents', propertyId],
     queryFn: () => api.get(`/v1/agents/${propertyId}`).then((r) => r.data?.data ?? r.data ?? []),
-    enabled: !!propertyId,
+    enabled: !!propertyId && !isPortfolioMode,
   });
 
-  // Real-time activity feed
   const [activities, setActivities] = useState<ActivityEvent[]>([]);
 
   const handleEvent = useCallback((payload: ActivityEvent) => {
@@ -98,10 +110,122 @@ export default function Dashboard() {
   }, []);
 
   useEffect(() => {
+    if (isPortfolioMode) return;
     const socket = getSocket();
     socket.on('pmsEvent', handleEvent);
     return () => { socket.off('pmsEvent', handleEvent); };
-  }, [handleEvent]);
+  }, [handleEvent, isPortfolioMode]);
+
+  if (!propertyId) {
+    return (
+      <div className="flex items-center justify-center h-64 text-telivity-mid-grey">
+        Select a property to view the dashboard
+      </div>
+    );
+  }
+
+  // Portfolio mode dashboard
+  if (isPortfolioMode) {
+    const fin = portfolioFinancial?.data ?? portfolioFinancial ?? {};
+    const occ = portfolioOccupancy?.data ?? portfolioOccupancy ?? {};
+    const kpis = fin.kpis ?? {};
+    const byProperty = fin.byProperty ?? [];
+    const propertyNameMap = new Map(properties.map((p) => [p.id, p.name]));
+
+    const chartData = byProperty.map((row: { propertyId: string; totalRevenue: number }) => ({
+      name: propertyNameMap.get(row.propertyId) ?? row.propertyId.slice(0, 8),
+      revenue: row.totalRevenue,
+    }));
+
+    return (
+      <div>
+        <div className="flex items-center gap-3 mb-6">
+          <Building2 size={24} className="text-telivity-teal" />
+          <h1 className="text-2xl font-semibold text-telivity-navy">Portfolio Dashboard</h1>
+          <span className="text-sm text-telivity-mid-grey ml-auto">
+            {fin.propertyCount ?? properties.length} properties · {format(new Date(), 'EEEE, MMMM d, yyyy')}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+          <KpiCard
+            title="Portfolio Occupancy"
+            value={formatOccupancyPercent(kpis.occupancyRate)}
+            subtitle={`${occ.occupiedRooms ?? 0} of ${occ.availableRooms ?? 0} rooms`}
+            icon={Percent}
+          />
+          <KpiCard
+            title="Portfolio ADR"
+            value={kpis.adr != null ? `$${Number(kpis.adr).toFixed(2)}` : '—'}
+            subtitle="Weighted average"
+            icon={DollarSign}
+          />
+          <KpiCard
+            title="Portfolio RevPAR"
+            value={kpis.revpar != null ? `$${Number(kpis.revpar).toFixed(2)}` : '—'}
+            subtitle="Across all properties"
+            icon={TrendingUp}
+          />
+          <KpiCard
+            title="Total Revenue Today"
+            value={kpis.totalRevenue != null ? `$${Number(kpis.totalRevenue).toFixed(2)}` : '—'}
+            subtitle={`${occ.arrivals ?? 0} arrivals · ${occ.departures ?? 0} departures`}
+            icon={BedDouble}
+          />
+        </div>
+
+        {chartData.length > 0 && (
+          <div className="bg-white rounded-xl shadow-sm p-5 mb-6">
+            <h2 className="text-sm font-semibold text-telivity-navy mb-4">Revenue by Property</h2>
+            <ResponsiveContainer width="100%" height={240}>
+              <BarChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+                <XAxis dataKey="name" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip formatter={(v: number) => [`$${v.toFixed(2)}`, 'Revenue']} />
+                <Bar dataKey="revenue" fill="#06bdb4" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        <div className="bg-white rounded-xl shadow-sm p-5">
+          <h2 className="text-sm font-semibold text-telivity-navy mb-4">Property Breakdown</h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-telivity-mid-grey border-b border-gray-100">
+                  <th className="pb-2 font-medium">Property</th>
+                  <th className="pb-2 font-medium">Occupancy</th>
+                  <th className="pb-2 font-medium">ADR</th>
+                  <th className="pb-2 font-medium">RevPAR</th>
+                  <th className="pb-2 font-medium">Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {byProperty.map((row: { propertyId: string; occupancyRate: number; adr: number; revpar: number; totalRevenue: number }) => (
+                  <tr key={row.propertyId} className="border-b border-gray-50 last:border-0">
+                    <td className="py-2.5 font-medium text-telivity-navy">
+                      <button
+                        className="hover:text-telivity-teal"
+                        onClick={() => setPropertyId(row.propertyId)}
+                      >
+                        {propertyNameMap.get(row.propertyId) ?? row.propertyId}
+                      </button>
+                    </td>
+                    <td className="py-2.5">{formatOccupancyPercent(row.occupancyRate)}</td>
+                    <td className="py-2.5">${Number(row.adr).toFixed(2)}</td>
+                    <td className="py-2.5">${Number(row.revpar).toFixed(2)}</td>
+                    <td className="py-2.5">${Number(row.totalRevenue).toFixed(2)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   const occ = occupancy?.data ?? occupancy ?? {};
   const fin = financial?.data ?? financial ?? {};
@@ -122,14 +246,6 @@ export default function Dashboard() {
   const totalRooms = chartData.reduce((sum: number, d: { value: number }) => sum + d.value, 0);
   const occupiedCount = chartData.find((d: { name: string }) => d.name === 'Occupied')?.value ?? 0;
 
-  if (!propertyId) {
-    return (
-      <div className="flex items-center justify-center h-64 text-telivity-mid-grey">
-        Select a property to view the dashboard
-      </div>
-    );
-  }
-
   return (
     <div>
       <div className="flex items-center gap-3 mb-6">
@@ -138,7 +254,6 @@ export default function Dashboard() {
         <span className="text-sm text-telivity-mid-grey ml-auto">{format(new Date(), 'EEEE, MMMM d, yyyy')}</span>
       </div>
 
-      {/* KPI Cards */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <KpiCard
           title="Occupancy"
@@ -166,9 +281,7 @@ export default function Dashboard() {
         />
       </div>
 
-      {/* Today's Activity + Room Chart */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-        {/* Today's Activity */}
         <div className="bg-white rounded-xl shadow-sm p-5">
           <h2 className="text-sm font-semibold text-telivity-navy mb-4">Today's Activity</h2>
           <div className="space-y-3">
@@ -211,7 +324,6 @@ export default function Dashboard() {
           </div>
         </div>
 
-        {/* Room Status Donut */}
         <div className="bg-white rounded-xl shadow-sm p-5 lg:col-span-2">
           <h2 className="text-sm font-semibold text-telivity-navy mb-4">Room Status</h2>
           {chartData.length > 0 ? (
@@ -243,7 +355,6 @@ export default function Dashboard() {
         </div>
       </div>
 
-      {/* Revenue Intelligence Card */}
       {Array.isArray(agentStatuses) && agentStatuses.length > 0 && (
         <div
           className="bg-white rounded-xl shadow-sm p-5 mb-6 cursor-pointer hover:ring-2 hover:ring-telivity-teal/30 transition-all"
@@ -256,9 +367,9 @@ export default function Dashboard() {
             <div className="flex-1">
               <h2 className="text-sm font-semibold text-telivity-navy">Revenue Intelligence</h2>
               <p className="text-xs text-telivity-mid-grey mt-0.5">
-                {agentStatuses.filter((a: any) => a.isEnabled).length} agents active
+                {agentStatuses.filter((a: { isEnabled: boolean }) => a.isEnabled).length} agents active
                 {' | '}
-                {agentStatuses.reduce((s: number, a: any) => s + (a.pendingDecisions ?? 0), 0)} pending decisions
+                {agentStatuses.reduce((s: number, a: { pendingDecisions?: number }) => s + (a.pendingDecisions ?? 0), 0)} pending decisions
               </p>
             </div>
             <span className="text-xs text-telivity-teal font-medium">View Revenue Management &rarr;</span>
@@ -266,7 +377,6 @@ export default function Dashboard() {
         </div>
       )}
 
-      {/* Recent Activity Feed */}
       <div className="bg-white rounded-xl shadow-sm p-5">
         <h2 className="text-sm font-semibold text-telivity-navy mb-4">Recent Activity (Live)</h2>
         {activities.length > 0 ? (

--- a/packages/database/src/migrations/0005_hia_gap_features.sql
+++ b/packages/database/src/migrations/0005_hia_gap_features.sql
@@ -1,0 +1,41 @@
+-- HIA gap features: organizations, portfolio support, staff notifications
+CREATE TABLE IF NOT EXISTS organizations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name varchar(255) NOT NULL,
+  code varchar(20) NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE properties ADD COLUMN IF NOT EXISTS organization_id uuid REFERENCES organizations(id);
+
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'staff_notification_severity') THEN
+  CREATE TYPE staff_notification_severity AS ENUM ('info','warning','critical');
+END IF; END $$;
+
+CREATE TABLE IF NOT EXISTS staff_notifications (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  user_id varchar(255),
+  type varchar(50) NOT NULL,
+  title varchar(255) NOT NULL,
+  message text NOT NULL,
+  severity staff_notification_severity NOT NULL DEFAULT 'info',
+  source_event varchar(100),
+  source_entity_type varchar(50),
+  source_entity_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS staff_notifications_property_created_idx
+  ON staff_notifications (property_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS staff_notification_reads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  notification_id uuid NOT NULL REFERENCES staff_notifications(id),
+  user_id varchar(255) NOT NULL,
+  read_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS staff_notification_reads_unique
+  ON staff_notification_reads (notification_id, user_id);

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -868,8 +868,55 @@ async function main() {
     await db.execute(sql.raw(t));
   }
 
+  // Organizations (hotel groups) — portfolio reporting
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS organizations (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      name varchar(255) NOT NULL,
+      code varchar(20) NOT NULL UNIQUE,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'staff_notification_severity') THEN
+      CREATE TYPE staff_notification_severity AS ENUM ('info','warning','critical');
+    END IF; END $$`));
+
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS staff_notifications (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      user_id varchar(255),
+      type varchar(50) NOT NULL,
+      title varchar(255) NOT NULL,
+      message text NOT NULL,
+      severity staff_notification_severity NOT NULL DEFAULT 'info',
+      source_event varchar(100),
+      source_entity_type varchar(50),
+      source_entity_id uuid,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE INDEX IF NOT EXISTS staff_notifications_property_created_idx
+      ON staff_notifications (property_id, created_at DESC)`));
+
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS staff_notification_reads (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      notification_id uuid NOT NULL REFERENCES staff_notifications(id),
+      user_id varchar(255) NOT NULL,
+      read_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS staff_notification_reads_unique
+      ON staff_notification_reads (notification_id, user_id)`));
+
   // Idempotent column additions for pre-existing databases
   const alters = [
+    `ALTER TABLE properties ADD COLUMN IF NOT EXISTS organization_id uuid REFERENCES organizations(id)`,
     `ALTER TABLE tax_rules ADD COLUMN IF NOT EXISTS split_percentage numeric(5,2)`,
     // House accounts reuse charges/payments (KB 13): folio_id becomes nullable,
     // add house_account_id. A row belongs to EITHER a folio OR a house account.

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -5,8 +5,18 @@
  * DO NOT INVENT HOTEL DOMAIN LOGIC.
  */
 
+// Organization (hotel groups)
+export { organizations } from './organization.js';
+
 // Property
 export { properties } from './property.js';
+
+// Staff notifications
+export {
+  staffNotificationSeverityEnum,
+  staffNotifications,
+  staffNotificationReads,
+} from './staff-notification.js';
 
 // Media (images for property / room types / rooms)
 export { mediaOwnerTypeEnum, mediaCategoryEnum, media } from './media.js';

--- a/packages/database/src/schema/organization.ts
+++ b/packages/database/src/schema/organization.ts
@@ -1,0 +1,13 @@
+import { pgTable, uuid, varchar, timestamp } from 'drizzle-orm/pg-core';
+
+/**
+ * Organization — hotel group / chain that owns one or more properties.
+ * Enables portfolio-level reporting across properties in the same org.
+ */
+export const organizations = pgTable('organizations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: varchar('name', { length: 255 }).notNull(),
+  code: varchar('code', { length: 20 }).notNull().unique(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+});

--- a/packages/database/src/schema/property.ts
+++ b/packages/database/src/schema/property.ts
@@ -1,4 +1,5 @@
 import { pgTable, uuid, varchar, text, boolean, timestamp, jsonb, integer } from 'drizzle-orm/pg-core';
+import { organizations } from './organization.js';
 
 /**
  * Property — top-level business unit (hotel, hostel, apartment complex).
@@ -6,6 +7,7 @@ import { pgTable, uuid, varchar, text, boolean, timestamp, jsonb, integer } from
  */
 export const properties = pgTable('properties', {
   id: uuid('id').primaryKey().defaultRandom(),
+  organizationId: uuid('organization_id').references(() => organizations.id),
   name: varchar('name', { length: 255 }).notNull(),
   code: varchar('code', { length: 20 }).notNull().unique(), // Short property code (e.g., "HTLNYC01")
   description: text('description'),

--- a/packages/database/src/schema/staff-notification.ts
+++ b/packages/database/src/schema/staff-notification.ts
@@ -1,0 +1,55 @@
+import { pgTable, uuid, varchar, text, timestamp, pgEnum, index } from 'drizzle-orm/pg-core';
+import { properties } from './property.js';
+
+export const staffNotificationSeverityEnum = pgEnum('staff_notification_severity', [
+  'info',
+  'warning',
+  'critical',
+]);
+
+/**
+ * Staff notifications — in-app alerts for property operators (anomalies, agent
+ * decisions, audit issues). Broadcast rows have userId = null (visible to all
+ * staff with access to the property). Per-user read state lives in
+ * staff_notification_reads.
+ */
+export const staffNotifications = pgTable(
+  'staff_notifications',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    propertyId: uuid('property_id')
+      .notNull()
+      .references(() => properties.id),
+    // Nullable = broadcast to all staff at the property.
+    userId: varchar('user_id', { length: 255 }),
+    type: varchar('type', { length: 50 }).notNull(),
+    title: varchar('title', { length: 255 }).notNull(),
+    message: text('message').notNull(),
+    severity: staffNotificationSeverityEnum('severity').notNull().default('info'),
+    sourceEvent: varchar('source_event', { length: 100 }),
+    sourceEntityType: varchar('source_entity_type', { length: 50 }),
+    sourceEntityId: uuid('source_entity_id'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    propertyCreatedIdx: index('staff_notifications_property_created_idx').on(
+      t.propertyId,
+      t.createdAt,
+    ),
+  }),
+);
+
+export const staffNotificationReads = pgTable(
+  'staff_notification_reads',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    notificationId: uuid('notification_id')
+      .notNull()
+      .references(() => staffNotifications.id),
+    userId: varchar('user_id', { length: 255 }).notNull(),
+    readAt: timestamp('read_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniqueRead: index('staff_notification_reads_unique').on(t.notificationId, t.userId),
+  }),
+);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,12 @@ export const WEBHOOK_EVENTS = {
   'audit.started': 'audit.started',
   'audit.completed': 'audit.completed',
 
+  // Accounting export events
+  'accounting.export.ready': 'accounting.export.ready',
+
+  // Staff notification events
+  'staff.notification_created': 'staff.notification_created',
+
   // Channel manager events
   'channel.connected': 'channel.connected',
   'channel.disconnected': 'channel.disconnected',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the top four priorities from the HIA gap assessment to close demo-credibility gaps for hotel groups without building ERP modules.

### 1. Portfolio rollup
- Added `organizations` table and optional `organization_id` on `properties`
- New endpoints: `GET /v1/reports/portfolio/financial-summary` and `GET /v1/reports/portfolio/occupancy`
- Dashboard **All Properties** mode in the property switcher with aggregated KPIs, revenue-by-property chart, and property breakdown table

### 2. Universal search
- New `search` module: `GET /v1/search` (single property) and `GET /v1/search/portfolio` (all accessible properties)
- Searches guests, reservations, folios, rooms, and groups
- Dashboard command palette via **⌘K / Ctrl+K** and header search bar

### 3. Staff notifications
- `staff_notifications` + `staff_notification_reads` tables
- REST API: list, unread count, mark read / mark all read
- Listeners on `agent.decision_created` (now emitted from agent service) and `audit.completed`
- WebSocket `staffNotification` event; Header notification bell with live unread badge

### 4. Accounting export automation
- Listener on `audit.completed` pre-generates revenue journal and trial balance CSVs
- Emits new `accounting.export.ready` webhook with download paths and previews

## Schema

Migration: `packages/database/src/migrations/0005_hia_gap_features.sql` (also in `push-schema.ts`)

## Tests

- `reports.service.portfolio.spec.ts` — portfolio aggregation
- `search.service.spec.ts` — search fan-out
- `accounting-export.listener.spec.ts` — export webhook on day close

## Not in scope (per assessment)

AP, bank rec, budgeting GL, contextual help KB ingestion, saved report favorites — left for follow-up polish pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c4594e8-0c98-4537-adfa-e35cabfbc8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4594e8-0c98-4537-adfa-e35cabfbc8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

