### PR TITLE
fix: portfolio mode polish (reports, permissions, changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to HAIP are documented here. This project adheres to
 > Version numbers and release tags are assigned automatically by the release
 > workflow on merge — this section is intentionally left as _Unreleased_.
 
+### Added — HIA gap features (portfolio, search, staff alerts, export automation)
+
+- **Portfolio rollup** — `organizations` table, optional `organization_id` on properties,
+  `GET /v1/reports/portfolio/*` endpoints, dashboard **All Properties** mode with
+  aggregated KPIs and per-property breakdown.
+- **Universal search** — `GET /v1/search` and `GET /v1/search/portfolio`; dashboard
+  command palette (⌘K / Ctrl+K) across guests, reservations, folios, rooms, groups.
+- **Staff notifications** — in-app alerts with websocket push; populated from
+  `agent.decision_created` and `audit.completed`; notification bell in the header.
+- **Accounting export automation** — on `audit.completed`, pre-generates CSV exports
+  and emits `accounting.export.ready` webhook with download paths.
+
 ### Added — Revenue Manager (RManager) Agent
 
 - **Revenue Manager orchestrator agent** (`revenue_manager`) — a meta-agent that

--- a/apps/dashboard/src/components/layout/AppLayout.tsx
+++ b/apps/dashboard/src/components/layout/AppLayout.tsx
@@ -8,12 +8,14 @@ import { useMyPermissions } from '../../hooks/useAdmin';
 export default function AppLayout({ children }: { children: ReactNode }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { authEnabled, setPermissions } = useAuth();
-  const { propertyId } = useProperty();
+  const { propertyId, isPortfolioMode, properties } = useProperty();
 
-  // Under real auth, resolve the current user's effective permissions for the
-  // active property and feed them into AuthContext (drives nav/feature gating).
-  // When auth is disabled (demo), hasPermission already returns true.
-  const { data } = useMyPermissions(propertyId, authEnabled);
+  // Permissions are per-property. In portfolio mode, resolve against the first
+  // accessible property so nav gating still works without sending the sentinel id.
+  const permissionsPropertyId =
+    isPortfolioMode ? (properties[0]?.id ?? null) : propertyId;
+
+  const { data } = useMyPermissions(permissionsPropertyId, authEnabled);
   useEffect(() => {
     if (data?.permissions) setPermissions(data.permissions);
   }, [data, setPermissions]);

--- a/apps/dashboard/src/pages/Accounting.tsx
+++ b/apps/dashboard/src/pages/Accounting.tsx
@@ -206,7 +206,7 @@ function AccountingHome() {
             <Download size={14} /> Revenue Journal
           </a>
           <a href={exportUrl('trial-balance.csv')} className="inline-flex items-center gap-2 border border-gray-200 rounded-lg px-4 py-2 text-sm font-medium hover:bg-telivity-light-grey">
-            <Download size={14} /> Trial Balance
+            <Download size={14} /> Folio Ledger Trial Balance
           </a>
         </div>
       </div>

--- a/apps/dashboard/src/pages/Reports.tsx
+++ b/apps/dashboard/src/pages/Reports.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { BarChart3, Percent, DollarSign, TrendingUp } from 'lucide-react';
-import { LineChart, Line, BarChart, Bar, PieChart, Pie, Cell, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid, Legend } from 'recharts';
+import { BarChart3, Percent, DollarSign, TrendingUp, Building2 } from 'lucide-react';
+import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts';
 import { format, subDays } from 'date-fns';
 import { api } from '../lib/api';
 import { formatOccupancyPercent } from '../lib/api-helpers';
@@ -10,18 +10,26 @@ import KpiCard from '../components/ui/KpiCard';
 
 type ReportType = 'financial-summary' | 'occupancy' | 'daily-revenue' | 'occupancy-trend';
 
-const PIE_COLORS = ['#06bdb4', '#00a692', '#f2641b', '#eec517', '#bbbbc4', '#016491'];
-
 export default function Reports() {
-  const { propertyId } = useProperty();
+  const { propertyId, isPortfolioMode, properties } = useProperty();
   const [report, setReport] = useState<ReportType>('financial-summary');
   const [date, setDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [startDate, setStartDate] = useState(format(subDays(new Date(), 30), 'yyyy-MM-dd'));
   const [endDate, setEndDate] = useState(format(new Date(), 'yyyy-MM-dd'));
 
+  const portfolioReport =
+    isPortfolioMode && (report === 'financial-summary' || report === 'occupancy');
+
   const { data } = useQuery({
-    queryKey: ['reports', report, propertyId, report === 'occupancy-trend' ? startDate : date, report === 'occupancy-trend' ? endDate : null],
+    queryKey: ['reports', portfolioReport ? 'portfolio' : report, propertyId, report === 'occupancy-trend' ? startDate : date, report === 'occupancy-trend' ? endDate : null],
     queryFn: () => {
+      if (portfolioReport) {
+        const path =
+          report === 'financial-summary'
+            ? '/v1/reports/portfolio/financial-summary'
+            : '/v1/reports/portfolio/occupancy';
+        return api.get(path, { params: { date } }).then((r) => r.data);
+      }
       const params: Record<string, string> = { propertyId: propertyId! };
       if (report === 'occupancy-trend') {
         params.startDate = startDate;
@@ -31,23 +39,36 @@ export default function Reports() {
       }
       return api.get(`/v1/reports/${report}`, { params }).then((r) => r.data);
     },
-    enabled: !!propertyId,
+    enabled: !!propertyId && (!isPortfolioMode || portfolioReport),
   });
 
   const reportData = data?.data ?? data ?? {};
   const kpis = reportData.kpis ?? {};
   const revenue = reportData.revenue ?? {};
   const payments = reportData.payments ?? {};
+  const propertyNameMap = new Map(properties.map((p) => [p.id, p.name]));
 
   if (!propertyId) {
     return <div className="flex items-center justify-center h-64 text-telivity-mid-grey">Select a property</div>;
+  }
+
+  if (isPortfolioMode && !portfolioReport) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 text-telivity-mid-grey gap-2">
+        <Building2 size={32} className="text-telivity-teal/50" />
+        <p>Daily revenue and occupancy trend are per-property reports.</p>
+        <p className="text-sm">Select a single property to run this report.</p>
+      </div>
+    );
   }
 
   return (
     <div>
       <div className="flex items-center gap-3 mb-6">
         <BarChart3 size={24} className="text-telivity-teal" />
-        <h1 className="text-2xl font-semibold text-telivity-navy">Reports</h1>
+        <h1 className="text-2xl font-semibold text-telivity-navy">
+          {isPortfolioMode ? 'Portfolio Reports' : 'Reports'}
+        </h1>
       </div>
 
       {/* Report Selector + Date */}
@@ -88,7 +109,36 @@ export default function Reports() {
             <KpiCard title="RevPAR" value={kpis.revpar != null ? `$${Number(kpis.revpar).toFixed(2)}` : '—'} icon={TrendingUp} />
             <KpiCard title="Occupancy" value={formatOccupancyPercent(kpis.occupancyRate)} icon={Percent} />
           </div>
-          {reportData.revenueByType && (
+          {isPortfolioMode && Array.isArray(reportData.byProperty) && (
+            <div className="bg-white rounded-xl shadow-sm p-5">
+              <h3 className="text-sm font-semibold text-telivity-navy mb-3">By Property</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-telivity-mid-grey border-b border-gray-100">
+                      <th className="pb-2 font-medium">Property</th>
+                      <th className="pb-2 font-medium">Revenue</th>
+                      <th className="pb-2 font-medium">Occupancy</th>
+                      <th className="pb-2 font-medium">ADR</th>
+                      <th className="pb-2 font-medium">RevPAR</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(reportData.byProperty as Array<{ propertyId: string; totalRevenue: number; occupancyRate: number; adr: number; revpar: number }>).map((row) => (
+                      <tr key={row.propertyId} className="border-b border-gray-50">
+                        <td className="py-2">{propertyNameMap.get(row.propertyId) ?? row.propertyId}</td>
+                        <td className="py-2">${Number(row.totalRevenue).toFixed(2)}</td>
+                        <td className="py-2">{formatOccupancyPercent(row.occupancyRate)}</td>
+                        <td className="py-2">${Number(row.adr).toFixed(2)}</td>
+                        <td className="py-2">${Number(row.revpar).toFixed(2)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+          {!isPortfolioMode && reportData.revenueByType && (
             <div className="bg-white rounded-xl shadow-sm p-5">
               <h3 className="text-sm font-semibold text-telivity-navy mb-3">Revenue Breakdown</h3>
               <div className="space-y-2">
@@ -110,9 +160,43 @@ export default function Reports() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <KpiCard title="Occupied" value={reportData.occupiedRooms ?? 0} icon={Percent} />
             <KpiCard title="Available" value={reportData.availableRooms ?? 0} icon={Percent} />
-            <KpiCard title="OOO" value={reportData.outOfOrder ?? 0} icon={Percent} />
+            {!isPortfolioMode && (
+              <KpiCard title="OOO" value={reportData.outOfOrder ?? 0} icon={Percent} />
+            )}
+            {isPortfolioMode && (
+              <KpiCard title="Arrivals" value={reportData.arrivals ?? 0} icon={Percent} />
+            )}
             <KpiCard title="Occupancy %" value={formatOccupancyPercent(reportData.occupancyRate)} icon={Percent} />
           </div>
+          {isPortfolioMode && Array.isArray(reportData.byProperty) && (
+            <div className="bg-white rounded-xl shadow-sm p-5">
+              <h3 className="text-sm font-semibold text-telivity-navy mb-3">By Property</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-telivity-mid-grey border-b border-gray-100">
+                      <th className="pb-2 font-medium">Property</th>
+                      <th className="pb-2 font-medium">Occupied</th>
+                      <th className="pb-2 font-medium">Available</th>
+                      <th className="pb-2 font-medium">Occupancy</th>
+                      <th className="pb-2 font-medium">Arrivals</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(reportData.byProperty as Array<{ propertyId: string; occupiedRooms: number; availableRooms: number; occupancyRate: number; arrivals: number }>).map((row) => (
+                      <tr key={row.propertyId} className="border-b border-gray-50">
+                        <td className="py-2">{propertyNameMap.get(row.propertyId) ?? row.propertyId}</td>
+                        <td className="py-2">{row.occupiedRooms}</td>
+                        <td className="py-2">{row.availableRooms}</td>
+                        <td className="py-2">{formatOccupancyPercent(row.occupancyRate)}</td>
+                        <td className="py-2">{row.arrivals}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION

## Summary

Follow-up polish after #147 (HIA gap features, already merged). Closes remaining rough edges from the assessment plan.

- **AppLayout:** In portfolio mode, resolve RBAC permissions against the first accessible property (avoids sending `portfolio` as a UUID to `/admin/me/permissions`)
- **Reports:** Portfolio financial-summary and occupancy with per-property breakdown; clear message for per-property-only reports
- **Accounting:** Rename export label to "Folio Ledger Trial Balance" (per assessment — not a GL trial balance)
- **CHANGELOG:** Document shipped HIA gap features under Unreleased

All plan todos (portfolio, search, staff alerts, export automation) were delivered in #147; this PR is polish only.
