### PR TITLE
chore: scrub oversharing comments from help module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,10 @@ All notable changes to HAIP are documented here. This project adheres to
 
 - **Staff dashboard white-label** — property fields for display name, logo, primary/accent
   colors (separate from guest booking-engine branding); applied in Sidebar / CSS vars.
-- **Contextual help** — public OSS route help panel (`GET /v1/help`) plus optional grounded
-  HAIP AI explain (`POST /v1/help/explain`). Help copy is code-owned and must not paste
-  private `kb/` doctrine.
-- **Report favorites** — `users.preferences.reportFavorites` via `GET/PATCH /v1/admin/me/preferences`.
-- **KPI warn thresholds** — `properties.settings.kpiThresholds` tint Dashboard KPI cards.
+- **Contextual help** — route help panel (`GET /v1/help`) plus optional grounded
+  HAIP AI explain (`POST /v1/help/explain`).
 
-### Added — HIA gap features (portfolio, search, staff alerts, export automation)
+### Added — Portfolio, search, staff alerts, export automation
 
 - **Portfolio rollup** — `organizations` table, optional `organization_id` on properties,
   `GET /v1/reports/portfolio/*` endpoints, dashboard **All Properties** mode with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to HAIP are documented here. This project adheres to
   colors (separate from guest booking-engine branding); applied in Sidebar / CSS vars.
 - **Contextual help** — route help panel (`GET /v1/help`) plus optional grounded
   HAIP AI explain (`POST /v1/help/explain`).
+- **Report favorites** — `users.preferences.reportFavorites` via `GET/PATCH /v1/admin/me/preferences`.
+- **KPI warn thresholds** — `properties.settings.kpiThresholds` tint Dashboard KPI cards.
 
 ### Added — Portfolio, search, staff alerts, export automation
 

--- a/apps/api/src/modules/help/help-content.ts
+++ b/apps/api/src/modules/help/help-content.ts
@@ -1,9 +1,6 @@
 /**
- * Public OSS help copy for the staff dashboard.
- *
- * DO NOT paste from private kb/ or proprietary research. Only generic UI / ops
- * guidance that is safe to publish in an open-source product. If unsure whether
- * a sentence came from private KB doctrine, delete it.
+ * Staff dashboard help copy — short UI guidance for each route.
+ * Keep entries generic and suitable for an open-source product.
  */
 
 export interface HelpEntry {

--- a/apps/api/src/modules/help/help.controller.ts
+++ b/apps/api/src/modules/help/help.controller.ts
@@ -10,7 +10,7 @@ export class HelpController {
 
   @Get()
   @ApiOperation({
-    summary: 'Public contextual help for a dashboard route (OSS-safe copy only)',
+    summary: 'Contextual help for a dashboard route',
   })
   @ApiQuery({ name: 'route', required: true, example: '/night-audit' })
   getHelp(@Query('route') route: string) {
@@ -25,7 +25,7 @@ export class HelpController {
 
   @Post('explain')
   @ApiOperation({
-    summary: 'Optional grounded AI explain for screen numeric facts (no KB text)',
+    summary: 'Optional grounded AI explain for screen numeric facts',
   })
   explain(@Body() dto: HelpExplainDto) {
     return this.helpService.explain(dto.route, dto.facts ?? {});

--- a/apps/api/src/modules/help/help.service.spec.ts
+++ b/apps/api/src/modules/help/help.service.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { HelpService } from './help.service';
 import { getHelpForRoute, normalizeHelpRoute } from './help-content';
 
-describe('help-content (public OSS copy)', () => {
+describe('help-content', () => {
   it('normalizes nested reservation routes', () => {
     expect(normalizeHelpRoute('/reservations/calendar')).toBe('/reservations');
     expect(normalizeHelpRoute('/folios/abc')).toBe('/folios');
@@ -19,10 +19,9 @@ describe('help-content (public OSS copy)', () => {
     expect(getHelpForRoute('/not-a-real-page')).toBeNull();
   });
 
-  it('does not embed private kb path strings in help text', () => {
+  it('returns stable public copy for night audit', () => {
     const night = getHelpForRoute('/night-audit');
-    const blob = JSON.stringify(night);
-    expect(blob).not.toMatch(/HAIP_KNOWLEDGE_BASE|kb\/research|kb\/HAIP/);
+    expect(night?.summary).toMatch(/business day/i);
   });
 });
 
@@ -47,7 +46,7 @@ describe('HelpService.explain', () => {
     await service.explain('/reports', {
       occupancyRate: 0.7,
       guestName: 'SHOULD_BE_STRIPPED',
-      note: 'private doctrine text',
+      note: 'freeform should not reach model',
     });
     expect(llm.explain).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -56,7 +55,7 @@ describe('HelpService.explain', () => {
     );
     const arg = llm.explain.mock.calls[0][0];
     expect(JSON.stringify(arg.numbers)).not.toContain('SHOULD_BE_STRIPPED');
-    expect(JSON.stringify(arg.numbers)).not.toContain('private doctrine');
+    expect(JSON.stringify(arg.numbers)).not.toContain('freeform');
   });
 
   it('returns null explanation when model is off', async () => {

--- a/apps/api/src/modules/help/help.service.ts
+++ b/apps/api/src/modules/help/help.service.ts
@@ -25,7 +25,7 @@ export class HelpService {
 
   /**
    * Grounded explain over allowlisted numeric screen facts only.
-   * Never injects KB text. Returns null when AI is off or ungrounded.
+   * Returns null when AI is off or ungrounded.
    */
   async explain(route: string, facts: Record<string, unknown> = {}) {
     const entry = getHelpForRoute(route);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scrubs oversharing wording from #149 in help module comments/tests/OpenAPI summaries and CHANGELOG. Behavior unchanged.

Prefer this over #150 (same scrub; this branch includes the follow-up changelog restore).

## Checklist
- [x] No private corpus path strings in help headers/tests
- [x] Competitor framing removed from CHANGELOG section title
- [x] Help tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c4594e8-0c98-4537-adfa-e35cabfbc8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c4594e8-0c98-4537-adfa-e35cabfbc8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

