### PR TITLE
feat(deploy): multi-arch GHCR + VPS/cloud guides (close #95, #96)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -183,12 +189,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push API image
+      - name: Build and push API image (amd64 + arm64)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/api/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           build-args: |
             VITE_AUTH_ENABLED=true
             VITE_KEYCLOAK_URL=http://localhost:8080

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to HAIP are documented here. This project adheres to
 > Version numbers and release tags are assigned automatically by the release
 > workflow on merge — this section is intentionally left as _Unreleased_.
 
+### Added — Multi-arch GHCR images + VPS/cloud deploy guides
+
+- **Multi-platform GHCR publish** — release workflow builds `linux/amd64` and
+  `linux/arm64` for `ghcr.io/telivityai/haip-api` via Buildx/QEMU.
+- **Deployment docs** — VPS self-host steps plus Render / Railway / AWS / GCP
+  sketches in `docs/deployment.md` (closes remaining BRIEF-020 deploy gaps).
+
 ### Added — Staff branding, contextual help, report favorites & KPI thresholds
 
 - **Staff dashboard white-label** — property fields for display name, logo, primary/accent

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,7 +145,7 @@ The `init` service is idempotent — safe to re-run on every deploy.
 
 ## Container images (GHCR)
 
-On each release, GitHub Actions publishes:
+On each release, GitHub Actions publishes a **multi-platform** image (`linux/amd64` and `linux/arm64`):
 
 ```
 ghcr.io/telivityai/haip-api:<tag>
@@ -160,6 +160,70 @@ docker run --env-file .env.production -p 3000:3000 ghcr.io/telivityai/haip-api:l
 ```
 
 For the full stack (Postgres, Redis, Keycloak, migrate/seed), use the compose files above rather than a bare `docker run`.
+
+## VPS self-host (Ubuntu)
+
+Minimal path for a single VM (Hetzner, DigitalOcean, Linode, AWS EC2, etc.).
+
+1. **Provision** an Ubuntu 22.04/24.04 host with at least 2 vCPU / 4 GB RAM (8 GB recommended if Keycloak runs on the same box).
+2. **Install Docker** (official docs): Engine + Compose plugin. Confirm with `docker compose version`.
+3. **Clone and configure:**
+   ```bash
+   git clone https://github.com/TelivityAI/haip.git
+   cd haip
+   cp .env.production.example .env.production
+   # Fill DATABASE_URL / REDIS_URL if overriding compose defaults,
+   # Stripe keys, CONNECT_API_KEY, CORS_ORIGINS, strong Keycloak admin password.
+   ```
+4. **Firewall:** allow `22`, `80`, `443` only. Do **not** expose Postgres (`5432`), Redis (`6379`), or Keycloak (`8080`) publicly — terminate TLS on the host and proxy to the API on `127.0.0.1:3000` (or a private Docker network).
+5. **Start production stack:**
+   ```bash
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml --profile auth up -d --build
+   ```
+6. **TLS:** point DNS at the VPS and put Caddy or nginx in front (see [TLS termination](#tls-termination)). Set `CORS_ORIGINS=https://pms.example.com` if the browser origin differs from the API host.
+7. **Cron:** schedule night audit / group cutoffs from the host using [`scripts/cron/`](../scripts/cron/) and [`docs/operations/cron.md`](./operations/cron.md).
+8. **Backups:** nightly `pg_dump` of `DATABASE_URL` off-box (see [Database backup and restore](#database-backup-and-restore)).
+
+Alternatively, skip building on the VPS and pull the GHCR image, then run compose with an override that sets `image: ghcr.io/telivityai/haip-api:latest` for the `api` service (still need Postgres, Redis, Keycloak, and the `init` migrate step).
+
+## Cloud deployment options
+
+These are sketches for running the **published GHCR image** (or the production compose overlay) on common platforms. HAIP expects Postgres, Redis, and (for auth-on) Keycloak — use managed addons where the platform provides them.
+
+### Render
+
+| Mode | What to use |
+|------|-------------|
+| **Demo** (auth off) | One-click [`render.yaml`](../render.yaml) blueprint from the README — intentionally insecure for try-out only (`HAIP_ALLOW_INSECURE=true`). |
+| **Production** | Do **not** use the demo blueprint as-is. Create a **Web Service** from `ghcr.io/telivityai/haip-api:<tag>` (or Dockerfile), attach **managed Postgres** + **Redis**, set `AUTH_ENABLED=true`, `NODE_ENV=production`, real Stripe keys, `CONNECT_API_KEY`, and `CORS_ORIGINS`. Run Keycloak as a separate private service (or external IdP) and never set `HAIP_ALLOW_INSECURE`. Run migrate via a one-off job (`node packages/database/dist/push-schema.js`) before switching traffic. |
+
+### Railway
+
+1. Create a project with **Postgres** and **Redis** plugins; copy their connection URLs into service variables.
+2. Deploy the API from the GitHub repo (Railway builds [`apps/api/Dockerfile`](../apps/api/Dockerfile)) **or** deploy from `ghcr.io/telivityai/haip-api:<tag>`.
+3. Set production env vars from [`.env.production.example`](../.env.production.example): `AUTH_ENABLED=true`, `NODE_ENV=production`, Stripe, `CONNECT_API_KEY`, Keycloak URL/realm/client, `SERVE_DASHBOARD=true`, `SERVE_BOOKING=true`.
+4. Add Keycloak as another Railway service (or point at an external realm). Restrict public networking to the API only.
+5. Run schema migration once (Railway one-off / release command) before serving traffic.
+
+### AWS
+
+Typical pattern: **ECS Fargate** (or EC2 + Docker) for `ghcr.io/telivityai/haip-api`, **RDS Postgres**, **ElastiCache Redis**, and Keycloak on ECS or a managed OIDC provider.
+
+1. Push/pull the multi-arch GHCR image into the account (or mirror to ECR).
+2. Task definition: port `3000`, secrets from SSM/Secrets Manager for `DATABASE_URL`, `REDIS_URL`, Stripe, Connect keys.
+3. ALB + ACM certificate for TLS; security groups so only the ALB reaches the task.
+4. Run migrate as a one-off ECS task (`node packages/database/dist/push-schema.js`) on each upgrade before rolling the service.
+5. Schedule night-audit / cutoff cron via EventBridge → authenticated HTTPS calls (see [`docs/operations/cron.md`](./operations/cron.md)).
+
+### GCP
+
+Typical pattern: **Cloud Run** for the API image, **Cloud SQL (Postgres)**, **Memorystore (Redis)**, Keycloak on Cloud Run/GKE or external OIDC.
+
+1. Deploy `ghcr.io/telivityai/haip-api:<tag>` to Cloud Run (allow unauthenticated only if a proxy/IAP sits in front; otherwise keep the service private and expose via HTTPS load balancer).
+2. Wire `DATABASE_URL` / `REDIS_URL` via Secret Manager; set `AUTH_ENABLED=true` and the rest of the production env table above.
+3. Cloud Run min instances ≥ 1 if you need warm WebSocket / cron targets.
+4. Run migrate from Cloud Run Jobs (same `push-schema` entrypoint) on deploy.
+5. Use Cloud Scheduler for night audit / group cutoff HTTPS jobs.
 
 ## Booking widget with auth on
 


### PR DESCRIPTION

## Summary

Finishes the open deploy issues from BRIEF-020:

- **Closes #95** — already shipped on `main` via #138 / #141 (`docker-compose.prod.yml`, multi-stage API Dockerfile with dashboard/booking baked in via `SERVE_DASHBOARD` / `SERVE_BOOKING`, `.env.production.example`, `docs/deployment.md`). Separate Dashboard/Nginx Dockerfile was intentionally superseded by the single-image design.
- **Closes #96** — completes the remaining gaps:
  1. Multi-platform GHCR publish (`linux/amd64` + `linux/arm64`) via Buildx/QEMU in `.github/workflows/release.yml`
  2. VPS self-host guide in `docs/deployment.md`
  3. Cloud sketches for Render (demo vs prod), Railway, AWS, GCP

## Out of scope (left open)

- #92–#94 DerbySoft
- #97–#101 Orchestration
- #104 German fiscalization

## Test plan

- [x] Workflow YAML includes `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `platforms: linux/amd64,linux/arm64`
- [x] `docs/deployment.md` has VPS + cloud sections
- [ ] After merge, next release publishes a multi-arch manifest to `ghcr.io/telivityai/haip-api`


