### PR TITLE
fix: Added SPA route catch-all

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -91,7 +91,10 @@ if (process.env['NODE_ENV'] === 'production' || process.env['SERVE_DASHBOARD'] =
   imports.push(
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', '..', 'dashboard', 'dist'),
-      exclude: ['/api/(.*)', '/booking/(.*)'],
+      // @nestjs/serve-static v5 defaults to `{*any}`, which Express 4 treats
+      // as a literal route rather than an SPA catch-all.
+      renderPath: '*',
+      exclude: ['/api{/*path}', '/booking{/*path}'],
     }),
   );
 }
@@ -101,7 +104,8 @@ if (process.env['NODE_ENV'] === 'production' || process.env['SERVE_BOOKING'] ===
     ServeStaticModule.forRoot({
       rootPath: join(__dirname, '..', '..', 'booking', 'dist'),
       serveRoot: '/booking',
-      exclude: ['/api/(.*)'],
+      renderPath: '*',
+      exclude: ['/api{/*path}'],
     }),
   );
 }


### PR DESCRIPTION
# Fix SPA deep-link routing for dashboard and booking engine

The Nest static-serving module defaulted to {*any}, which is interpreted as a literal route by the project’s Express 4 runtime. As a result, dashboard and booking-engine deep links were not reliably served with their SPA entry point.

# Changes
- Added an explicit renderPath: '*' for the dashboard static bundle.
- Added an explicit renderPath: '*' for the booking-engine static bundle.
- Replaced legacy /(.*) exclusions with path-to-regexp v8-compatible patterns:
  - /api{/*path}
  - /booking{/*path}
- Preserved API and booking routes so they are not intercepted by the dashboard SPA fallback.

# Checklist

[x] Scope is limited to api.
[x] Typecheck passed.
[x] Automated tests passed successfully.