### PR TITLE
Core hooks for regional compliance integrations: invoice.* events, delivery-failure alerting, webhook docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/NestJS-framework-E0234E?logo=nestjs&logoColor=white" alt="NestJS" />
   <img src="https://img.shields.io/badge/PostgreSQL-database-4169E1?logo=postgresql&logoColor=white" alt="PostgreSQL" />
   <img src="https://img.shields.io/badge/License-Apache%202.0-blue" alt="Apache 2.0 License" />
-  <img src="https://img.shields.io/badge/Tests-1115%20passing-brightgreen" alt="1115 Tests Passing" />
+  <img src="https://img.shields.io/badge/Tests-1129%20passing-brightgreen" alt="1129 Tests Passing" />
   <img src="https://img.shields.io/badge/AI%20Agents-12%20built--in-blueviolet" alt="12 AI Agents" />
 </p>
 
@@ -427,7 +427,7 @@ executes; approval always runs the agent's own recommendation. Off by default
 | OTA Channels | Booking.com + Expedia (EQC) direct + SiteMinder (pmsXchange) | Direct + aggregated OTA connectivity (ARI + content) |
 | XML Processing | fast-xml-parser | Booking.com OTA XML protocol |
 | Package Manager | pnpm workspaces | Monorepo management |
-| Testing | Vitest (1115 tests across 134 test files) | Unit and integration tests |
+| Testing | Vitest (1129 tests across 136 test files) | Unit and integration tests |
 | Build | tsup (packages) + Vite (dashboard) + nest build (API) | Fast builds |
 | Containers | Docker + docker-compose | Local dev and production deployment |
 | CI/CD | GitHub Actions | Automated testing, builds, and releases |
@@ -549,7 +549,7 @@ Before going live, verify the items in [`docs/deployment.md`](./docs/deployment.
 ### Run tests
 
 ```bash
-# All tests (1115 tests across 134 test files)
+# All tests (1129 tests across 136 test files)
 pnpm test
 
 # API tests only
@@ -1065,7 +1065,7 @@ HAIP is built in public and contributions are welcome.
 pnpm install          # Install dependencies
 pnpm build            # Build all workspace packages
 pnpm dev              # Start API in dev mode (hot reload)
-pnpm test             # Run all tests (1115 tests, 134 files)
+pnpm test             # Run all tests (1129 tests, 136 files)
 pnpm typecheck        # TypeScript strict check
 pnpm lint             # ESLint
 ```

--- a/README.md
+++ b/README.md
@@ -376,9 +376,11 @@ executes; approval always runs the agent's own recommendation. Off by default
 
 ### Webhook Engine
 - Real-time webhook delivery on every entity state change
-- 64 event types including accounting events (`deposit.received`, `ar.transfer_created`, `cashdrawer.session_closed`), house-account & folio events (`houseaccount.opened`, `folio.transactions_moved`, `payment.corrected`), group events (`group.block_created`, `group.rooming_list_imported`), reservation-ops events (`reservation.note_added`, `reservation.message_sent`, `reservation.bulk_action_completed`), and AI agent events (`agent.decision_made`, `agent.cancellation_forecast_updated`, `guest.communication_drafted`, `guest.review_response_drafted`)
+- 73 event types including accounting events (`deposit.received`, `ar.transfer_created`, `cashdrawer.session_closed`), house-account & folio events (`houseaccount.opened`, `folio.transactions_moved`, `payment.corrected`), fiscal document events (`invoice.requested`, `invoice.issued`, `invoice.voided`), group events (`group.block_created`, `group.rooming_list_imported`), reservation-ops events (`reservation.note_added`, `reservation.message_sent`, `reservation.bulk_action_completed`), and AI agent events (`agent.decision_made`, `agent.cancellation_forecast_updated`, `guest.communication_drafted`, `guest.review_response_drafted`)
 - Event format: `entity.action` (e.g., `reservation.created`, `housekeeping.task_completed`)
 - Subscription management for external consumers
+- HMAC-signed deliveries with retries; permanent failures raise a critical staff notification
+- See **[`docs/webhooks.md`](./docs/webhooks.md)** for the integration guide (signature verification, payload conventions, fiscal documents, regional compliance examples)
 
 ### ChatGPT Gateway (Connect GPT)
 - A standalone, deployable **gateway that exposes HAIP hotel search & booking as a ChatGPT Custom GPT Action** (`tools/haip-connect-gpt`) — guests search availability and create/modify/cancel reservations by chatting

--- a/apps/api/src/modules/folio/dto/fiscal-document.dto.ts
+++ b/apps/api/src/modules/folio/dto/fiscal-document.dto.ts
@@ -1,0 +1,73 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  IsUUID,
+  IsUrl,
+  IsObject,
+  IsDateString,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RequestFiscalDocumentDto {
+  @ApiProperty({ description: 'Property ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  propertyId!: string;
+
+  @ApiProperty({
+    example: 'nfse',
+    description:
+      'Regional document type identifier (e.g. "nfse", "invoice"). Core does not interpret this value.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(50)
+  documentType!: string;
+
+  @ApiPropertyOptional({ description: 'Regional extras passed through to the issuing integration' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class IssueFiscalDocumentDto {
+  @ApiProperty({ description: 'Property ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  propertyId!: string;
+
+  @ApiProperty({ example: '2026-000123', description: 'Official document number assigned by the issuer' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  documentNumber!: string;
+
+  @ApiPropertyOptional({ description: 'Link to the official document (PDF/XML) at the issuer' })
+  @IsOptional()
+  @IsUrl({ require_protocol: true })
+  documentUrl?: string;
+
+  @ApiPropertyOptional({ description: 'Issuance timestamp (defaults to now)' })
+  @IsOptional()
+  @IsDateString()
+  issuedAt?: string;
+
+  @ApiPropertyOptional({ description: 'Regional extras (series, verification code, ...)' })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+}
+
+export class VoidFiscalDocumentDto {
+  @ApiProperty({ description: 'Property ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  propertyId!: string;
+
+  @ApiPropertyOptional({ description: 'Reason for voiding the document' })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/apps/api/src/modules/folio/fiscal-document.service.spec.ts
+++ b/apps/api/src/modules/folio/fiscal-document.service.spec.ts
@@ -1,0 +1,217 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+import { FiscalDocumentService } from './fiscal-document.service';
+import { WebhookService } from '../webhook/webhook.service';
+import { DRIZZLE } from '../../database/database.module';
+
+const mockFolio = {
+  id: 'folio-001',
+  propertyId: 'prop-001',
+  folioNumber: 'F-2026-0001',
+  status: 'settled',
+};
+
+const mockDoc = {
+  id: 'fdoc-001',
+  propertyId: 'prop-001',
+  folioId: 'folio-001',
+  documentType: 'nfse',
+  status: 'requested',
+  documentNumber: null,
+  metadata: { municipalCode: '3550308' },
+};
+
+/**
+ * Table-aware mock: dispatches select() results by pgTable name so folio
+ * lookups and fiscal-document lookups can return different rows.
+ */
+function createMockDb({
+  folioRows = [mockFolio],
+  docRows = [mockDoc],
+  written = [mockDoc],
+}: {
+  folioRows?: any[];
+  docRows?: any[];
+  written?: any[];
+} = {}) {
+  const tableName = (tbl: any) =>
+    String(tbl?.[Symbol.for('drizzle:Name')] ?? tbl?._?.name ?? '');
+
+  return {
+    select: vi.fn(() => ({
+      from: vi.fn((tbl: any) => {
+        const rows = tableName(tbl).includes('folios') ? folioRows : docRows;
+        const result: any = Promise.resolve(rows);
+        result.orderBy = vi.fn().mockResolvedValue(rows);
+        return { where: vi.fn(() => result) };
+      }),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn().mockResolvedValue(written),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn().mockResolvedValue(written),
+        })),
+      })),
+    })),
+  };
+}
+
+const mockWebhookService = { emit: vi.fn() };
+
+async function buildService(db: any) {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      FiscalDocumentService,
+      { provide: DRIZZLE, useValue: db },
+      { provide: WebhookService, useValue: mockWebhookService },
+    ],
+  }).compile();
+  return module.get<FiscalDocumentService>(FiscalDocumentService);
+}
+
+describe('FiscalDocumentService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('request', () => {
+    it('creates a requested document and emits invoice.requested', async () => {
+      const svc = await buildService(createMockDb());
+      const result = await svc.request('folio-001', {
+        propertyId: 'prop-001',
+        documentType: 'nfse',
+        metadata: { municipalCode: '3550308' },
+      });
+
+      expect(result.status).toBe('requested');
+      expect(mockWebhookService.emit).toHaveBeenCalledWith(
+        'invoice.requested',
+        'fiscal_document',
+        mockDoc.id,
+        {
+          folioId: 'folio-001',
+          folioNumber: 'F-2026-0001',
+          documentType: 'nfse',
+        },
+        'prop-001',
+      );
+    });
+
+    it('throws NotFound when the folio is not at the property (multi-tenancy)', async () => {
+      const svc = await buildService(createMockDb({ folioRows: [] }));
+      await expect(
+        svc.request('folio-001', { propertyId: 'other-prop', documentType: 'nfse' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockWebhookService.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('issue', () => {
+    it('marks a requested document issued and emits invoice.issued', async () => {
+      const issued = {
+        ...mockDoc,
+        status: 'issued',
+        documentNumber: '2026-000123',
+        issuedAt: new Date(),
+      };
+      const svc = await buildService(createMockDb({ written: [issued] }));
+
+      const result = await svc.issue('folio-001', 'fdoc-001', {
+        propertyId: 'prop-001',
+        documentNumber: '2026-000123',
+        documentUrl: 'https://issuer.example.gov/doc/123.pdf',
+      });
+
+      expect(result.status).toBe('issued');
+      expect(mockWebhookService.emit).toHaveBeenCalledWith(
+        'invoice.issued',
+        'fiscal_document',
+        issued.id,
+        {
+          folioId: 'folio-001',
+          documentType: 'nfse',
+          documentNumber: '2026-000123',
+        },
+        'prop-001',
+      );
+    });
+
+    it('rejects issuing a document that is not in requested state', async () => {
+      const alreadyIssued = { ...mockDoc, status: 'issued' };
+      const svc = await buildService(createMockDb({ docRows: [alreadyIssued] }));
+      await expect(
+        svc.issue('folio-001', 'fdoc-001', {
+          propertyId: 'prop-001',
+          documentNumber: '2026-000124',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(mockWebhookService.emit).not.toHaveBeenCalled();
+    });
+
+    it('throws NotFound when the document is not at the property (multi-tenancy)', async () => {
+      const svc = await buildService(createMockDb({ docRows: [] }));
+      await expect(
+        svc.issue('folio-001', 'fdoc-001', {
+          propertyId: 'other-prop',
+          documentNumber: '2026-000123',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('void', () => {
+    it('voids an issued document and emits invoice.voided', async () => {
+      const issued = { ...mockDoc, status: 'issued', documentNumber: '2026-000123' };
+      const voided = { ...issued, status: 'voided', voidReason: 'duplicate' };
+      const svc = await buildService(
+        createMockDb({ docRows: [issued], written: [voided] }),
+      );
+
+      const result = await svc.void('folio-001', 'fdoc-001', {
+        propertyId: 'prop-001',
+        reason: 'duplicate',
+      });
+
+      expect(result.status).toBe('voided');
+      expect(mockWebhookService.emit).toHaveBeenCalledWith(
+        'invoice.voided',
+        'fiscal_document',
+        voided.id,
+        {
+          folioId: 'folio-001',
+          documentType: 'nfse',
+          documentNumber: '2026-000123',
+        },
+        'prop-001',
+      );
+    });
+
+    it('rejects voiding an already-voided document', async () => {
+      const voided = { ...mockDoc, status: 'voided' };
+      const svc = await buildService(createMockDb({ docRows: [voided] }));
+      await expect(
+        svc.void('folio-001', 'fdoc-001', { propertyId: 'prop-001' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('list', () => {
+    it('throws NotFound when the folio is not at the property (multi-tenancy)', async () => {
+      const svc = await buildService(createMockDb({ folioRows: [] }));
+      await expect(svc.list('folio-001', 'other-prop')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('returns documents for the folio', async () => {
+      const svc = await buildService(createMockDb());
+      const rows = await svc.list('folio-001', 'prop-001');
+      expect(rows).toEqual([mockDoc]);
+    });
+  });
+});

--- a/apps/api/src/modules/folio/fiscal-document.service.ts
+++ b/apps/api/src/modules/folio/fiscal-document.service.ts
@@ -1,0 +1,194 @@
+import {
+  Injectable,
+  Inject,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import { eq, and, desc } from 'drizzle-orm';
+import { fiscalDocuments, folios } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import { WebhookService } from '../webhook/webhook.service';
+import type {
+  RequestFiscalDocumentDto,
+  IssueFiscalDocumentDto,
+  VoidFiscalDocumentDto,
+} from './dto/fiscal-document.dto';
+
+/**
+ * Fiscal documents — official tax document references on a folio.
+ *
+ * Core owns only the lifecycle (requested → issued → voided) and the emitted
+ * invoice.* events. The actual issuance against a government/tax authority is
+ * done by an EXTERNAL integration subscribed to `invoice.requested`, which
+ * reports the result back through `issue()` / `void()`. No regional tax logic
+ * lives here — regional fields go in `metadata`.
+ */
+@Injectable()
+export class FiscalDocumentService {
+  constructor(
+    @Inject(DRIZZLE) private readonly db: any,
+    private readonly webhookService: WebhookService,
+  ) {}
+
+  /**
+   * Request a fiscal document for a folio. Emits `invoice.requested` so a
+   * subscribed integration can perform the issuance.
+   */
+  async request(folioId: string, dto: RequestFiscalDocumentDto) {
+    const folio = await this.findFolio(folioId, dto.propertyId);
+
+    const [doc] = await this.db
+      .insert(fiscalDocuments)
+      .values({
+        propertyId: dto.propertyId,
+        folioId,
+        documentType: dto.documentType,
+        status: 'requested',
+        metadata: dto.metadata ?? null,
+      })
+      .returning();
+
+    await this.webhookService.emit(
+      'invoice.requested',
+      'fiscal_document',
+      doc.id,
+      {
+        folioId,
+        folioNumber: folio.folioNumber,
+        documentType: doc.documentType,
+      },
+      dto.propertyId,
+    );
+
+    return doc;
+  }
+
+  /**
+   * Record the issued document reference (called by the integration once the
+   * external issuer accepted the document). Emits `invoice.issued`.
+   */
+  async issue(folioId: string, documentId: string, dto: IssueFiscalDocumentDto) {
+    const doc = await this.findDocument(documentId, folioId, dto.propertyId);
+    if (doc.status !== 'requested') {
+      throw new BadRequestException(
+        `Fiscal document ${documentId} is ${doc.status}; only requested documents can be issued`,
+      );
+    }
+
+    const [updated] = await this.db
+      .update(fiscalDocuments)
+      .set({
+        status: 'issued',
+        documentNumber: dto.documentNumber,
+        documentUrl: dto.documentUrl ?? null,
+        issuedAt: dto.issuedAt ? new Date(dto.issuedAt) : new Date(),
+        // Merge so request-time metadata survives issuance.
+        metadata: { ...(doc.metadata ?? {}), ...(dto.metadata ?? {}) },
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(fiscalDocuments.id, documentId),
+          eq(fiscalDocuments.propertyId, dto.propertyId),
+        ),
+      )
+      .returning();
+
+    await this.webhookService.emit(
+      'invoice.issued',
+      'fiscal_document',
+      updated.id,
+      {
+        folioId,
+        documentType: updated.documentType,
+        documentNumber: updated.documentNumber,
+      },
+      dto.propertyId,
+    );
+
+    return updated;
+  }
+
+  /**
+   * Void a fiscal document — either cancelling a pending request or voiding
+   * an already-issued document. Emits `invoice.voided`.
+   */
+  async void(folioId: string, documentId: string, dto: VoidFiscalDocumentDto) {
+    const doc = await this.findDocument(documentId, folioId, dto.propertyId);
+    if (doc.status === 'voided') {
+      throw new BadRequestException(`Fiscal document ${documentId} is already voided`);
+    }
+
+    const [updated] = await this.db
+      .update(fiscalDocuments)
+      .set({
+        status: 'voided',
+        voidedAt: new Date(),
+        voidReason: dto.reason ?? null,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(fiscalDocuments.id, documentId),
+          eq(fiscalDocuments.propertyId, dto.propertyId),
+        ),
+      )
+      .returning();
+
+    await this.webhookService.emit(
+      'invoice.voided',
+      'fiscal_document',
+      updated.id,
+      {
+        folioId,
+        documentType: updated.documentType,
+        documentNumber: updated.documentNumber,
+      },
+      dto.propertyId,
+    );
+
+    return updated;
+  }
+
+  async list(folioId: string, propertyId: string) {
+    await this.findFolio(folioId, propertyId);
+    return this.db
+      .select()
+      .from(fiscalDocuments)
+      .where(
+        and(
+          eq(fiscalDocuments.folioId, folioId),
+          eq(fiscalDocuments.propertyId, propertyId),
+        ),
+      )
+      .orderBy(desc(fiscalDocuments.createdAt));
+  }
+
+  private async findFolio(folioId: string, propertyId: string) {
+    const [folio] = await this.db
+      .select()
+      .from(folios)
+      .where(and(eq(folios.id, folioId), eq(folios.propertyId, propertyId)));
+    if (!folio) {
+      throw new NotFoundException(`Folio ${folioId} not found`);
+    }
+    return folio;
+  }
+
+  private async findDocument(documentId: string, folioId: string, propertyId: string) {
+    const [doc] = await this.db
+      .select()
+      .from(fiscalDocuments)
+      .where(
+        and(
+          eq(fiscalDocuments.id, documentId),
+          eq(fiscalDocuments.folioId, folioId),
+          eq(fiscalDocuments.propertyId, propertyId),
+        ),
+      );
+    if (!doc) {
+      throw new NotFoundException(`Fiscal document ${documentId} not found`);
+    }
+    return doc;
+  }
+}

--- a/apps/api/src/modules/folio/folio.controller.ts
+++ b/apps/api/src/modules/folio/folio.controller.ts
@@ -21,6 +21,12 @@ import { CreateChargeDto } from './dto/create-charge.dto';
 import { ListChargesDto } from './dto/list-charges.dto';
 import { CreateRoutingRuleDto } from './dto/create-routing-rule.dto';
 import { MoveTransactionsDto } from './dto/move-transactions.dto';
+import {
+  RequestFiscalDocumentDto,
+  IssueFiscalDocumentDto,
+  VoidFiscalDocumentDto,
+} from './dto/fiscal-document.dto';
+import { FiscalDocumentService } from './fiscal-document.service';
 
 @ApiTags('folios')
 @Controller('folios')
@@ -28,6 +34,7 @@ export class FolioController {
   constructor(
     private readonly folioService: FolioService,
     private readonly folioRoutingService: FolioRoutingService,
+    private readonly fiscalDocumentService: FiscalDocumentService,
   ) {}
 
   // --- Split-folio routing rules (KB 14.2) ---
@@ -193,6 +200,60 @@ export class FolioController {
       chargeId: dto.chargeId,
       chargeType: dto.chargeType,
     });
+  }
+
+  // --- Fiscal documents (regional tax integrations, invoice.* events) ---
+
+  @Post(':id/fiscal-documents')
+  @Roles('admin', 'front_desk', 'night_auditor')
+  @ApiOperation({
+    summary:
+      'Request a fiscal document (invoice/tax note) for a folio — emits invoice.requested for external issuing integrations',
+  })
+  @ApiResponse({ status: 201, description: 'Fiscal document requested' })
+  requestFiscalDocument(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RequestFiscalDocumentDto,
+  ) {
+    return this.fiscalDocumentService.request(id, dto);
+  }
+
+  @Get(':id/fiscal-documents')
+  @ApiOperation({ summary: 'List fiscal documents for a folio' })
+  @ApiResponse({ status: 200, description: 'Fiscal documents' })
+  @ApiQuery({ name: 'propertyId', type: String })
+  listFiscalDocuments(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+  ) {
+    return this.fiscalDocumentService.list(id, propertyId);
+  }
+
+  @Post(':id/fiscal-documents/:documentId/issue')
+  @Roles('admin', 'front_desk', 'night_auditor')
+  @ApiOperation({
+    summary:
+      'Record the issued document reference (called by the issuing integration) — emits invoice.issued',
+  })
+  @ApiResponse({ status: 200, description: 'Fiscal document issued' })
+  issueFiscalDocument(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('documentId', ParseUUIDPipe) documentId: string,
+    @Body() dto: IssueFiscalDocumentDto,
+  ) {
+    return this.fiscalDocumentService.issue(id, documentId, dto);
+  }
+
+  @Post(':id/fiscal-documents/:documentId/void')
+  @Roles('admin', 'front_desk', 'night_auditor')
+  @ApiOperation({ summary: 'Void a fiscal document (or cancel a pending request) — emits invoice.voided' })
+  @ApiResponse({ status: 200, description: 'Fiscal document voided' })
+  voidFiscalDocument(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Param('documentId', ParseUUIDPipe) documentId: string,
+    @Body() dto: VoidFiscalDocumentDto,
+  ) {
+    return this.fiscalDocumentService.void(id, documentId, dto);
   }
 
   @Post(':id/transfer-to-city-ledger')

--- a/apps/api/src/modules/folio/folio.module.ts
+++ b/apps/api/src/modules/folio/folio.module.ts
@@ -4,11 +4,12 @@ import { TaxModule } from '../tax/tax.module';
 import { FolioController } from './folio.controller';
 import { FolioService } from './folio.service';
 import { FolioRoutingService } from './folio-routing.service';
+import { FiscalDocumentService } from './fiscal-document.service';
 
 @Module({
   imports: [WebhookModule, TaxModule],
   controllers: [FolioController],
-  providers: [FolioService, FolioRoutingService],
-  exports: [FolioService, FolioRoutingService],
+  providers: [FolioService, FolioRoutingService, FiscalDocumentService],
+  exports: [FolioService, FolioRoutingService, FiscalDocumentService],
 })
 export class FolioModule {}

--- a/apps/api/src/modules/staff-notifications/staff-notification.listener.spec.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notification.listener.spec.ts
@@ -1,0 +1,61 @@
+import { StaffNotificationListener } from './staff-notification.listener';
+import type { WebhookDeliveryFailedEvent } from '../webhook/webhook-delivery.service';
+
+describe('StaffNotificationListener — webhook.delivery_failed', () => {
+  const basePayload: WebhookDeliveryFailedEvent = {
+    propertyId: 'prop-1',
+    subscriptionId: 'sub-1',
+    subscriberName: 'BR Compliance Service',
+    deliveryId: 'del-1',
+    eventType: 'reservation.checked_in',
+    attempts: 5,
+    lastError: 'HTTP 500',
+  };
+
+  let staffNotifications: { create: ReturnType<typeof vi.fn> };
+  let listener: StaffNotificationListener;
+
+  beforeEach(() => {
+    staffNotifications = { create: vi.fn().mockResolvedValue({}) };
+    listener = new StaffNotificationListener(staffNotifications as any);
+  });
+
+  it('creates a critical notification when a delivery permanently fails', async () => {
+    await listener.onWebhookDeliveryFailed(basePayload);
+
+    expect(staffNotifications.create).toHaveBeenCalledTimes(1);
+    expect(staffNotifications.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        propertyId: 'prop-1',
+        type: 'webhook_delivery_failed',
+        severity: 'critical',
+        sourceEvent: 'webhook.delivery_failed',
+        sourceEntityType: 'webhook_delivery',
+        sourceEntityId: 'del-1',
+      }),
+    );
+    const arg = staffNotifications.create.mock.calls[0]![0];
+    expect(arg.title).toContain('reservation.checked_in');
+    expect(arg.message).toContain('BR Compliance Service');
+    expect(arg.message).toContain('5 attempts');
+  });
+
+  it('falls back to the subscription id when subscriberName is missing', async () => {
+    await listener.onWebhookDeliveryFailed({ ...basePayload, subscriberName: null });
+    const arg = staffNotifications.create.mock.calls[0]![0];
+    expect(arg.message).toContain('sub-1');
+  });
+
+  it('skips staff.notification_created failures (loop guard)', async () => {
+    await listener.onWebhookDeliveryFailed({
+      ...basePayload,
+      eventType: 'staff.notification_created',
+    });
+    expect(staffNotifications.create).not.toHaveBeenCalled();
+  });
+
+  it('ignores payloads without a propertyId', async () => {
+    await listener.onWebhookDeliveryFailed({ ...basePayload, propertyId: '' });
+    expect(staffNotifications.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/modules/staff-notifications/staff-notification.listener.ts
+++ b/apps/api/src/modules/staff-notifications/staff-notification.listener.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import type { WebhookPayload } from '../webhook/webhook.service';
+import {
+  WEBHOOK_DELIVERY_FAILED,
+  type WebhookDeliveryFailedEvent,
+} from '../webhook/webhook-delivery.service';
 import { StaffNotificationService } from './staff-notification.service';
 
 /**
@@ -42,6 +46,33 @@ export class StaffNotificationListener {
       sourceEvent: 'agent.decision_created',
       sourceEntityType: 'agent_decision',
       sourceEntityId: payload.entityId,
+    });
+  }
+
+  @OnEvent(WEBHOOK_DELIVERY_FAILED)
+  async onWebhookDeliveryFailed(payload: WebhookDeliveryFailedEvent) {
+    if (!payload?.propertyId) return;
+
+    // Loop guard: creating a notification emits staff.notification_created,
+    // which can itself be delivered to (and fail against) the same broken
+    // endpoint — alerting on THAT failure would notify forever. Skip it; the
+    // original failure already produced an alert.
+    if (payload.eventType === 'staff.notification_created') return;
+
+    const subscriber = payload.subscriberName ?? payload.subscriptionId;
+    await this.staffNotifications.create({
+      propertyId: payload.propertyId,
+      type: 'webhook_delivery_failed',
+      title: `Webhook delivery failed: ${payload.eventType}`,
+      message:
+        `Delivery to subscriber "${subscriber}" gave up after ${payload.attempts} attempts` +
+        `${payload.lastError ? ` (${payload.lastError})` : ''}. ` +
+        'The subscriber did NOT receive this event — if it powers a mandatory ' +
+        'integration (e.g. government reporting), re-deliver or reconcile manually.',
+      severity: 'critical',
+      sourceEvent: 'webhook.delivery_failed',
+      sourceEntityType: 'webhook_delivery',
+      sourceEntityId: payload.deliveryId,
     });
   }
 

--- a/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.spec.ts
@@ -186,6 +186,34 @@ describe('WebhookDeliveryService', () => {
     expect(stored.attempts).toBe(5);
   });
 
+  it('emits webhook.delivery_failed internally on permanent failure', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const db = createStatefulMockDb({ ...subscription, subscriberName: 'BR Compliance' });
+    const emitter = { emit: vi.fn() };
+    const service = new WebhookDeliveryService(db as any, emitter as any);
+
+    const delivery = await service.enqueue(payload, subscription.id);
+    await new Promise((r) => setImmediate(r));
+
+    // Not yet permanent — no alert.
+    expect(emitter.emit).not.toHaveBeenCalled();
+
+    for (let i = 0; i < 4; i++) {
+      await service.attemptDelivery(delivery.id);
+    }
+
+    expect(emitter.emit).toHaveBeenCalledTimes(1);
+    expect(emitter.emit).toHaveBeenCalledWith('webhook.delivery_failed', {
+      propertyId: 'prop-1',
+      subscriptionId: 'sub-1',
+      subscriberName: 'BR Compliance',
+      deliveryId: delivery.id,
+      eventType: 'reservation.created',
+      attempts: 5,
+      lastError: 'HTTP 500',
+    });
+  });
+
   it('signs "unsigned" when subscription has no secret', async () => {
     fetchMock.mockResolvedValue({ ok: true, status: 200 });
     const sub = { ...subscription, secret: null };

--- a/apps/api/src/modules/webhook/webhook-delivery.service.ts
+++ b/apps/api/src/modules/webhook/webhook-delivery.service.ts
@@ -2,9 +2,11 @@ import {
   Injectable,
   Inject,
   Logger,
+  Optional,
   OnModuleInit,
   OnModuleDestroy,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { createHmac } from 'crypto';
 import { eq, and, lte, or, isNull } from 'drizzle-orm';
 import { webhookDeliveries, agentWebhookSubscriptions } from '@telivityhaip/database';
@@ -37,6 +39,25 @@ export interface DeliveryPayload {
 }
 
 /**
+ * Internal (in-process) event emitted when a delivery permanently fails after
+ * all retries. Deliberately NOT routed through WebhookService: it must not
+ * fan out to external subscribers (their endpoint is the thing that's
+ * failing). The field is `eventType`, not `event`, so the wildcard webhook
+ * fan-out in ConnectEventsService ignores it.
+ */
+export const WEBHOOK_DELIVERY_FAILED = 'webhook.delivery_failed';
+
+export interface WebhookDeliveryFailedEvent {
+  propertyId: string;
+  subscriptionId: string;
+  subscriberName: string | null;
+  deliveryId: string;
+  eventType: string;
+  attempts: number;
+  lastError: string | null;
+}
+
+/**
  * WebhookDeliveryService — delivers events to subscribers with HMAC signing and retry.
  *
  * Not using BullMQ because Redis isn't wired up. Pragmatic replacement:
@@ -50,7 +71,10 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WebhookDeliveryService.name);
   private scanTimer: NodeJS.Timeout | null = null;
 
-  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+  constructor(
+    @Inject(DRIZZLE) private readonly db: any,
+    @Optional() private readonly eventEmitter?: EventEmitter2,
+  ) {}
 
   onModuleInit() {
     // Skip the background scanner in tests to keep Vitest fast and deterministic.
@@ -216,6 +240,18 @@ export class WebhookDeliveryService implements OnModuleInit, OnModuleDestroy {
       this.logger.warn(
         `Webhook delivery ${deliveryId} FAILED after ${attemptNumber} attempts: ${errorMessage}`,
       );
+
+      // Alert staff — mandatory-delivery subscribers (e.g. government
+      // reporting integrations) must not fail silently.
+      this.eventEmitter?.emit(WEBHOOK_DELIVERY_FAILED, {
+        propertyId: delivery.propertyId,
+        subscriptionId: subscription.id,
+        subscriberName: subscription.subscriberName ?? null,
+        deliveryId,
+        eventType: delivery.eventType,
+        attempts: attemptNumber,
+        lastError: errorMessage,
+      } satisfies WebhookDeliveryFailedEvent);
       return;
     }
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,176 @@
+# Webhooks & Events
+
+HAIP emits an event for every significant state change, following the
+`entity.action` naming convention (`reservation.checked_in`, `folio.settled`,
+`invoice.issued`, ...). External services — channel partners, OTAIP agents, and
+**regional compliance integrations** (government guest registration, tax
+invoicing, ...) — consume these events by subscribing to webhooks or by
+polling.
+
+The authoritative event catalog is `WEBHOOK_EVENTS` in
+[`packages/shared/src/index.ts`](../packages/shared/src/index.ts).
+
+## Subscribing
+
+```
+POST   /api/v1/connect/subscriptions               # Subscribe to events
+GET    /api/v1/connect/subscriptions?propertyId=…  # List subscriptions
+DELETE /api/v1/connect/subscriptions/:id           # Unsubscribe
+POST   /api/v1/connect/subscriptions/:id/test      # Send a test event
+GET    /api/v1/connect/subscriptions/:id/deliveries # Inspect delivery attempts
+GET    /api/v1/connect/events                      # Poll for events (fallback)
+```
+
+Create a subscription with the events you want (wildcards supported):
+
+```json
+POST /api/v1/connect/subscriptions
+{
+  "propertyId": "0d0af5aa-…",
+  "subscriberId": "br-compliance-service",
+  "subscriberName": "Brazil Compliance Service",
+  "callbackUrl": "https://compliance.example.com/haip-events",
+  "events": ["reservation.checked_in", "reservation.checked_out", "invoice.*"],
+  "secret": "a-long-random-hmac-secret-you-keep"
+}
+```
+
+Notes:
+
+- `callbackUrl` must be HTTPS and publicly resolvable (private/internal
+  addresses are rejected — SSRF protection).
+- The `secret` is write-only: it is never returned by the API, so keep your
+  own copy. It is used to sign every delivery (see below).
+- Event patterns support `entity.*` (all actions of one entity) and `*` / `**`
+  (everything).
+
+## Delivery format
+
+Each matching event is POSTed to your `callbackUrl`:
+
+```
+POST <callbackUrl>
+Content-Type: application/json
+X-HAIP-Signature: sha256=<hex HMAC-SHA256 of the raw body, keyed by your secret>
+X-HAIP-Event-Id: <delivery uuid>
+X-HAIP-Event-Type: reservation.checked_in
+```
+
+```json
+{
+  "eventType": "reservation.checked_in",
+  "propertyId": "0d0af5aa-…",
+  "entityType": "reservation",
+  "entityId": "9a1b2c3d-…",
+  "data": { "roomId": "…", "folioId": "…", "isEarlyCheckin": false },
+  "timestamp": "2026-07-17T14:03:22.118Z"
+}
+```
+
+Verify the signature before trusting a delivery:
+
+```ts
+import { createHmac, timingSafeEqual } from 'crypto';
+
+function verify(rawBody: string, header: string, secret: string): boolean {
+  const expected = `sha256=${createHmac('sha256', secret).update(rawBody).digest('hex')}`;
+  return (
+    header.length === expected.length &&
+    timingSafeEqual(Buffer.from(header), Buffer.from(expected))
+  );
+}
+```
+
+Respond with any 2xx status within 5 seconds. Anything else (including a
+timeout) counts as a failed attempt.
+
+### Payloads are intentionally lean — fetch the entity by id
+
+Event payloads carry identifiers and a few action-specific fields, **not** the
+full entity. This keeps PII (guest identity documents, addresses) out of
+webhook bodies, delivery logs, and your queue. On receipt, fetch what you need
+from the REST API using `entityId`:
+
+- `reservation.checked_in` → `GET /api/v1/reservations/:entityId?propertyId=…`
+  → the reservation includes `guestId` → `GET /api/v1/guests/:guestId?propertyId=…`
+  for the guest profile (name, ID document, nationality, date of birth,
+  address — the fields typically needed for government guest registration).
+- `folio.settled` → `GET /api/v1/folios/:entityId?propertyId=…` and
+  `GET /api/v1/folios/:entityId/charges?propertyId=…` for line items.
+
+Your subscriber authenticates to the REST API with its own OAuth credentials;
+the webhook alone grants no data access.
+
+### Retries
+
+Failed deliveries are retried with exponential backoff: 30s, 2m, 10m, 1h, 6h
+(5 attempts total, ~7h). Deliveries can arrive **more than once** (at-least-
+once semantics) and out of order — deduplicate on `X-HAIP-Event-Id` and treat
+handlers as idempotent.
+
+After the final attempt the delivery is marked `failed` and a **critical staff
+notification** (`webhook_delivery_failed`) is created for the property, so
+operators notice when a mandatory integration (e.g. government reporting)
+stops receiving events. Failed deliveries remain inspectable via
+`GET /api/v1/connect/subscriptions/:id/deliveries`.
+
+### Reconciliation / polling fallback
+
+If your service was down past the retry window (or can't receive webhooks at
+all), poll:
+
+```
+GET /api/v1/connect/events?propertyId=…&since=2026-07-17T00:00:00Z&types=reservation.*
+```
+
+Running a periodic reconciliation sweep against this endpoint is the
+recommended safety net for compliance-critical integrations.
+
+## Fiscal documents (`invoice.*`)
+
+For jurisdictions that require official tax documents (e.g. NFS-e tax notes in
+Brazil), HAIP stores a **fiscal document reference** on the folio and emits
+`invoice.*` events. Core contains no regional tax logic — issuance is
+performed by an external integration:
+
+1. Staff (or an automation) requests a document:
+   `POST /api/v1/folios/:folioId/fiscal-documents`
+   `{ "propertyId": "…", "documentType": "nfse", "metadata": { … } }`
+   → HAIP emits **`invoice.requested`** (entity: `fiscal_document`).
+2. Your integration receives the event, fetches the folio and charges, and
+   issues the document against the government/tax-authority API.
+3. It reports the result back:
+   `POST /api/v1/folios/:folioId/fiscal-documents/:documentId/issue`
+   `{ "propertyId": "…", "documentNumber": "2026-000123", "documentUrl": "…" }`
+   → HAIP emits **`invoice.issued`** and the official document number is now
+   linked to the folio in the PMS.
+4. Voiding/cancelling (either a pending request or an issued document):
+   `POST /api/v1/folios/:folioId/fiscal-documents/:documentId/void`
+   → HAIP emits **`invoice.voided`**.
+
+`documentType` is a free-form regional identifier and `metadata` is a
+pass-through JSON object for regional fields (series, verification codes,
+municipal registrations, ...) — core never interprets either.
+
+List documents for a folio:
+`GET /api/v1/folios/:folioId/fiscal-documents?propertyId=…`
+
+## Example: government guest registration
+
+A minimal compliance integration for jurisdictions that require reporting
+guest data on arrival/departure:
+
+1. Subscribe to `reservation.checked_in` and `reservation.checked_out`.
+2. On each event, fetch the reservation, then the guest profile.
+3. Submit to the government API from your service.
+4. Deduplicate on `X-HAIP-Event-Id`; run a nightly reconciliation sweep via
+   `GET /api/v1/connect/events` to catch anything missed.
+5. Watch for `webhook_delivery_failed` staff notifications (or monitor
+   `/subscriptions/:id/deliveries`) so a broken endpoint is noticed quickly.
+
+## WebSocket mirror
+
+All webhook events are also broadcast over Socket.IO to dashboard clients
+subscribed to the property — see the README's *WebSocket — Real-time Events*
+section. WebSockets are for live UIs; use webhook subscriptions (with retries
+and signatures) for integrations.

--- a/packages/database/src/migrations/0007_fiscal_documents.sql
+++ b/packages/database/src/migrations/0007_fiscal_documents.sql
@@ -1,0 +1,24 @@
+-- Fiscal documents: references to official tax documents (invoices, tax notes)
+-- issued for a folio by external regional integrations (invoice.* events).
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'fiscal_document_status') THEN
+  CREATE TYPE fiscal_document_status AS ENUM ('requested','issued','voided');
+END IF; END $$;
+
+CREATE TABLE IF NOT EXISTS fiscal_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  folio_id uuid NOT NULL REFERENCES folios(id),
+  document_type varchar(50) NOT NULL,
+  status fiscal_document_status NOT NULL DEFAULT 'requested',
+  document_number varchar(100),
+  document_url text,
+  issued_at timestamptz,
+  voided_at timestamptz,
+  void_reason text,
+  metadata jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS fiscal_documents_property_folio_idx
+  ON fiscal_documents (property_id, folio_id);

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -883,6 +883,33 @@ async function main() {
       CREATE TYPE staff_notification_severity AS ENUM ('info','warning','critical');
     END IF; END $$`));
 
+  // Fiscal documents — external tax document references (invoice.* events)
+  await db.execute(sql.raw(`
+    DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'fiscal_document_status') THEN
+      CREATE TYPE fiscal_document_status AS ENUM ('requested','issued','voided');
+    END IF; END $$`));
+
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS fiscal_documents (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      folio_id uuid NOT NULL REFERENCES folios(id),
+      document_type varchar(50) NOT NULL,
+      status fiscal_document_status NOT NULL DEFAULT 'requested',
+      document_number varchar(100),
+      document_url text,
+      issued_at timestamptz,
+      voided_at timestamptz,
+      void_reason text,
+      metadata jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE INDEX IF NOT EXISTS fiscal_documents_property_folio_idx
+      ON fiscal_documents (property_id, folio_id)`));
+
   await db.execute(sql.raw(`
     CREATE TABLE IF NOT EXISTS staff_notifications (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/packages/database/src/schema/fiscal-document.ts
+++ b/packages/database/src/schema/fiscal-document.ts
@@ -1,0 +1,58 @@
+import { pgTable, uuid, varchar, text, timestamp, jsonb, pgEnum, index } from 'drizzle-orm/pg-core';
+import { properties } from './property.js';
+import { folios } from './folio.js';
+
+export const fiscalDocumentStatusEnum = pgEnum('fiscal_document_status', [
+  'requested', // Staff requested a fiscal document; awaiting external issuance
+  'issued',    // External integration reported the issued document reference
+  'voided',    // Document voided/cancelled (either before or after issuance)
+]);
+
+/**
+ * Fiscal documents — references to official tax documents (invoices, tax
+ * notes) issued for a folio by EXTERNAL regional integrations (e.g. NFS-e in
+ * Brazil, e-invoicing mandates elsewhere).
+ *
+ * Core stores only the reference and lifecycle, never regional tax logic:
+ * the actual issuance is performed by an external service subscribed to
+ * `invoice.requested` webhooks, which reports the result back via the API.
+ * Regional fields (series, verification codes, issuer ids, ...) belong in
+ * `metadata`.
+ */
+export const fiscalDocuments = pgTable(
+  'fiscal_documents',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    propertyId: uuid('property_id')
+      .notNull()
+      .references(() => properties.id),
+    folioId: uuid('folio_id')
+      .notNull()
+      .references(() => folios.id),
+
+    // Regional document type identifier (e.g. "nfse", "invoice"). Core does
+    // not interpret this value; it routes to the integration that does.
+    documentType: varchar('document_type', { length: 50 }).notNull(),
+    status: fiscalDocumentStatusEnum('status').notNull().default('requested'),
+
+    // Set when the external integration reports issuance.
+    documentNumber: varchar('document_number', { length: 100 }),
+    documentUrl: text('document_url'), // Link to the official PDF/XML at the issuer
+    issuedAt: timestamp('issued_at', { withTimezone: true }),
+
+    voidedAt: timestamp('voided_at', { withTimezone: true }),
+    voidReason: text('void_reason'),
+
+    // Regional extras (series, verification code, municipal registration, ...)
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    propertyFolioIdx: index('fiscal_documents_property_folio_idx').on(
+      table.propertyId,
+      table.folioId,
+    ),
+  }),
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -64,6 +64,12 @@ export {
   payments,
 } from './folio.js';
 
+// Fiscal documents — external tax document references (invoice.* events)
+export {
+  fiscalDocumentStatusEnum,
+  fiscalDocuments,
+} from './fiscal-document.js';
+
 // Housekeeping
 export {
   housekeepingTaskStatusEnum,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -26,6 +26,13 @@ export const WEBHOOK_EVENTS = {
   'payment.refunded': 'payment.refunded',
   'payment.failed': 'payment.failed',
 
+  // Fiscal document / invoice events (regional tax integrations).
+  // Core stores only a document reference on the folio; issuance is performed
+  // by external integrations subscribed to invoice.requested.
+  'invoice.requested': 'invoice.requested',
+  'invoice.issued': 'invoice.issued',
+  'invoice.voided': 'invoice.voided',
+
   // Room events
   'room.status_changed': 'room.status_changed',
 


### PR DESCRIPTION

## Summary

Supports #159 (Brazilian government guest registration + tax invoice integrations). The existing webhook subscription system already covers the event-driven side; this PR adds the three core pieces that make external regional integrations clean to build, without putting any regional tax logic in core.

> Supersedes #161 (same changes + README test-count sync that CI rejected on the previous branch).

### 1. Fiscal document references + `invoice.*` events

Jurisdictions like Brazil require official tax documents (NFS-e tax notes) per folio. Core now stores a **reference** to such documents and emits lifecycle events, while issuance stays in an external integration:

- New `fiscal_documents` table (property-scoped, folio-linked, `metadata` jsonb for regional fields — series, verification codes, etc. Core never interprets them).
- New events: `invoice.requested`, `invoice.issued`, `invoice.voided`.
- New endpoints on folios:
  - `POST /folios/:id/fiscal-documents` — request a document → emits `invoice.requested`
  - `POST /folios/:id/fiscal-documents/:documentId/issue` — integration reports the issued document number → emits `invoice.issued`
  - `POST /folios/:id/fiscal-documents/:documentId/void` — void/cancel → emits `invoice.voided`
  - `GET /folios/:id/fiscal-documents` — list
- All queries scoped by `propertyId` per the multi-tenancy rules; migration added to both `push-schema.ts` and `src/migrations/0007_fiscal_documents.sql`.

### 2. Staff alerting on permanent webhook delivery failure

A delivery that exhausted all 5 retries (~7h) previously went silent — unacceptable when the subscriber is a mandatory government-reporting integration. `WebhookDeliveryService` now emits an in-process `webhook.delivery_failed` event on permanent failure, and `StaffNotificationListener` creates a **critical** staff notification. The internal event is deliberately not fanned out to external subscribers (their endpoint is the thing failing), and failures of `staff.notification_created` deliveries are skipped to prevent an alert-on-alert loop.

### 3. Webhook integration guide (`docs/webhooks.md`)

Documents subscribing via the Connect API, HMAC signature verification (with code sample), the lean-payload / fetch-by-`entityId` convention (keeps guest PII out of webhook bodies), retry + at-least-once semantics, the polling reconciliation fallback, the fiscal document flow, and a worked government guest-registration example. Linked from the README. README test counts synced to 1129 / 136.

## Testing

- 18 new tests (fiscal document lifecycle + multi-tenancy scoping, delivery-failure event emission, listener behavior incl. loop guard).
- Full suite: **1129 tests across 136 files**. Typecheck clean, lint 0 errors.

## Notes for reviewers

- The fiscal document concept is not in the KB; it is deliberately modeled as pure integration plumbing (a reference + lifecycle + events), not hotel/tax domain logic. `documentType` and `metadata` are opaque to core.
- `EventEmitter2` is injected `@Optional()` into `WebhookDeliveryService` so existing direct-construction tests remain valid.


