### PR TITLE
fix(dashboard): register pt-BR locale for browser language detection

### DIFF
--- a/apps/dashboard/src/i18n.ts
+++ b/apps/dashboard/src/i18n.ts
@@ -23,8 +23,16 @@ import ptBR from './locales/pt-BR.json';
 export const SUPPORTED_LANGUAGES = [
   { code: 'en', label: 'English' },
   { code: 'de', label: 'Deutsch' },
-  { code: 'ptBR', label: 'Português (Brasil)' },
+  { code: 'pt-BR', label: 'Português (Brasil)' },
 ] as const;
+
+// Include `pt` so navigator `pt-BR` resolves via nonExplicitSupportedLngs (not shown in switcher).
+const SUPPORTED_LOCALES = [...SUPPORTED_LANGUAGES.map((l) => l.code), 'pt'] as const;
+
+// Migrate legacy locale code saved before pt-BR was registered correctly.
+if (typeof localStorage !== 'undefined' && localStorage.getItem('haip.lang') === 'ptBR') {
+  localStorage.setItem('haip.lang', 'pt-BR');
+}
 
 i18n
   .use(LanguageDetector)
@@ -33,10 +41,11 @@ i18n
     resources: {
       en: { translation: en },
       de: { translation: de },
-      ptBR: { translation: ptBR },
+      pt: { translation: ptBR },
+      'pt-BR': { translation: ptBR },
     },
     fallbackLng: 'en',
-    supportedLngs: SUPPORTED_LANGUAGES.map((l) => l.code),
+    supportedLngs: [...SUPPORTED_LOCALES],
     nonExplicitSupportedLngs: true, // treat de-DE, de-AT, etc. as `de`
     returnEmptyString: false, // empty "" values fall back to English, not blank
     interpolation: { escapeValue: false }, // React already escapes

--- a/apps/dashboard/src/lib/date-locale.ts
+++ b/apps/dashboard/src/lib/date-locale.ts
@@ -4,7 +4,7 @@ import { de, enUS, ptBR } from 'date-fns/locale';
 const DATE_LOCALES: Record<string, Locale> = {
   de,
   en: enUS,
-  ptBR: ptBR,
+  pt: ptBR,
 };
 
 export function getDateLocale(language?: string): Locale {


### PR DESCRIPTION

## Summary

Fixes Brazilian Portuguese auto-detection after #155 merged with the non-standard locale code `ptBR`.

## Problem

i18next could not match browser languages like `pt-BR` to the registered `ptBR` code, so Brazilian users fell back to English unless they manually selected the language from the header.

## Changes

- Register the canonical `pt-BR` locale code in `SUPPORTED_LANGUAGES` and `resources`
- Also register `pt` (hidden from the switcher) so `nonExplicitSupportedLngs` can resolve `pt-BR` navigator values
- Map date-fns formatting via the `pt` base language in `getDateLocale()`
- Migrate legacy `ptBR` values stored in `localStorage` (`haip.lang`) to `pt-BR`

## Verification

- `pnpm --filter @telivityhaip/dashboard typecheck` passes
- Dashboard tests pass (43/43)
