### PR TITLE
Guest journey depth: pre-register API + SMS messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to HAIP are documented here. This project adheres to
 > Version numbers and release tags are assigned automatically by the release
 > workflow on merge — this section is intentionally left as _Unreleased_.
 
+### Added — Guest journey depth (Slice 6)
+
+- **Advance check-in / pre-register** — `POST /reservations/:id/pre-register?propertyId=` (staff,
+  `confirmed`/`assigned` only) and `POST /booking-engine/bookings/:confirmationNumber/pre-register`
+  (guest self-service behind booking key). Persists registration card + ID fields without changing
+  reservation status; emits `reservation.pre_registered`.
+- **SMS on reservation messages** — `ComposeMessageDto.channel` (`email` | `sms`, default email);
+  SMS path uses `NotificationService.sendSms` with the same GDPR marketing opt-out as email.
+- **Dashboard** — channel selector on reservation guest-message compose.
+- **Docs** — README Slice 6 depth vs polish (#182); HAIP_BUILD_PLAN notes remaining Slice 6 items.
+
 ### Added — Guest journey (ops + lifecycle triggers)
 
 - **Guest-comms event listener** — `reservation.created` / `checked_in` / `checked_out`

--- a/HAIP_BUILD_PLAN.md
+++ b/HAIP_BUILD_PLAN.md
@@ -35,7 +35,8 @@ Open-source, API-first hotel PMS (Apache 2.0).
 - Production deployment path (compose, container images, docs)
 - Full dashboard localization (page-level i18n)
 - End-to-end + money-path test coverage
-- Guest journey (lifecycle guest-comms triggers, communications ops, registration settings, messaging UI)
+- Guest journey polish — [#182](https://github.com/telivityai/haip/pull/182) (lifecycle triggers, communications desk, registration settings, email compose)
+- Guest journey depth — advance pre-register API, SMS on reservation messages _(WhatsApp provider, guest app, kiosk UI still later)_
 
 Contributions welcome — open an issue or a draft PR to claim an area, and tag a
 maintainer to coordinate before starting larger work.

--- a/README.md
+++ b/README.md
@@ -240,6 +240,19 @@ Recent backlog deliveries, mapped to the feature sections below. Each slice is a
 | 3 | **Front desk stay ops** | [#181](https://github.com/telivityai/haip/pull/181) | Arrivals / in-house queues, walk-in, in-house room move, registration card at check-in, operational notes at the desk. See **Reservation Management**. |
 | 4 | **A/R & cashier polish** | [#180](https://github.com/telivityai/haip/pull/180) | List cash drawers/sessions, A/R ledger CRUD + aging UX, folio→A/R from folio detail, reverse-transfer picker. See **Accounting & Cashiering** and **Folio & Billing**. |
 | 5 | **Commercial profiles** | [#180](https://github.com/telivityai/haip/pull/180) (also [#179](https://github.com/telivityai/haip/pull/179)) | Standing-account billing terms on group profiles; link A/R ledgers and negotiated rates; Commercial dashboard page. See **Groups & Commercial Profiles**. |
+| 6 | **Guest journey (polish)** | [#182](https://github.com/telivityai/haip/pull/182) | Lifecycle guest-comms triggers, communications desk, registration settings toggle, check-in ID fields, guest profile marketing/ID, reservation email compose UI. See **Guest Engagement Agents** and **Reservation Management**. |
+| 6b | **Guest journey (depth)** | _(in progress)_ | Advance check-in / pre-register API (staff + booking engine), SMS channel on reservation messages. WhatsApp provider, guest app, and kiosk UI remain planned. See **Reservation Management**. |
+
+### Guest journey — polish vs depth
+
+**Slice 6 polish** ([#182](https://github.com/telivityai/haip/pull/182)) shipped the operational layer: event-driven guest-comms drafts on reservation lifecycle changes, a communications desk for draft review, `guestRegistrationRequired` in Settings, ID capture fields at check-in, guest profile company/marketing/ID display, and email compose from reservation detail.
+
+**Slice 6 depth** (this branch) adds guest self-service and multi-channel ops without auto check-in:
+
+- **Pre-register** — guests or staff can submit registration card + ID data before arrival; reservation stays `confirmed`/`assigned` until desk check-in.
+- **SMS messaging** — front desk can send SMS (not just email) from reservation detail when the guest has a phone on file; marketing consent rules match email.
+
+Still planned for a later Slice 6 cut: WhatsApp provider integration, dedicated guest mobile app, and kiosk check-in UI.
 
 ### Direct Booking Engine (commission-free)
 - A **public, guest-facing booking API** (`/api/v1/booking-engine/*`) a hotel puts behind its own website — search → quote → book → pay → confirm — capturing direct reservations with **zero OTA commission**.
@@ -259,10 +272,11 @@ Recent backlog deliveries, mapped to the feature sections below. Each slice is a
 - Room assignment with automatic status transitions
 - **Front desk stay ops** — arrivals / in-house queues (multi-status filters), walk-in create→assign→check-in, in-house **room move** (`PATCH …/move-room`, respects `doNotMove`), operational notes at the desk and on reservation detail
 - **Guest registration at check-in** — registration card fields + `registrationSigned`; required when the property has `guestRegistrationRequired`
+- **Advance check-in / pre-register** — `POST …/pre-register` (staff or booking-engine guest) captures registration + ID without checking in; emits `reservation.pre_registered`
 - Group check-in (batch operations)
 - Bulk actions across multiple reservations (check-in / check-out / cancel) with per-reservation success/error results
 - Reservation notes with active-count tracking
-- Guest messaging from a reservation (GDPR marketing opt-out enforced)
+- Guest messaging from a reservation (email or SMS; GDPR marketing opt-out enforced)
 - Unassigned-reservation finder (confirmed/assigned reservations with no room)
 - Batch reservation import with per-row error handling
 - Express checkout

--- a/apps/api/src/modules/booking-engine/booking-engine.controller.ts
+++ b/apps/api/src/modules/booking-engine/booking-engine.controller.ts
@@ -19,6 +19,7 @@ import { BeSearchDto } from './dto/be-search.dto';
 import { BeQuoteDto } from './dto/be-quote.dto';
 import { BeCreateBookingDto } from './dto/be-create-booking.dto';
 import { BeCancelDto } from './dto/be-cancel.dto';
+import { PreRegisterDto } from '../reservation/dto/pre-register.dto';
 
 /**
  * Public, guest-facing direct booking API — `/api/v1/booking-engine/*`.
@@ -93,5 +94,19 @@ export class BookingEngineController {
     @Req() req: any,
   ) {
     return this.service.cancel(this.propertyId(req), confirmationNumber, dto.reason);
+  }
+
+  @Post('bookings/:confirmationNumber/pre-register')
+  @ApiOperation({
+    summary:
+      'Advance check-in / pre-register — capture registration card and ID without checking in',
+  })
+  @ApiResponse({ status: 200, description: 'Registration fields saved; status unchanged' })
+  async preRegister(
+    @Param('confirmationNumber') confirmationNumber: string,
+    @Body() dto: PreRegisterDto,
+    @Req() req: any,
+  ) {
+    return this.service.preRegister(this.propertyId(req), confirmationNumber, dto);
   }
 }

--- a/apps/api/src/modules/booking-engine/booking-engine.service.ts
+++ b/apps/api/src/modules/booking-engine/booking-engine.service.ts
@@ -20,6 +20,7 @@ import { BookingEngineConfigService } from './booking-engine-config.service';
 import type { BeSearchDto } from './dto/be-search.dto';
 import type { BeQuoteDto } from './dto/be-quote.dto';
 import type { BeCreateBookingDto } from './dto/be-create-booking.dto';
+import type { PreRegisterDto } from '../reservation/dto/pre-register.dto';
 
 /**
  * Orchestrates the guest-facing direct booking flow. Adds NO new hotel domain
@@ -497,6 +498,43 @@ export class BookingEngineService {
       confirmationNumber,
       reservationId: reservation.id,
       status: updated.status,
+    };
+  }
+
+  async preRegister(propertyId: string, confirmationNumber: string, dto: PreRegisterDto) {
+    const [booking] = await this.db
+      .select()
+      .from(bookings)
+      .where(
+        and(
+          eq(bookings.confirmationNumber, confirmationNumber),
+          eq(bookings.propertyId, propertyId),
+        ),
+      );
+    if (!booking) {
+      throw new ForbiddenException('Booking key is not scoped to this booking');
+    }
+    const [reservation] = await this.db
+      .select()
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.bookingId, booking.id),
+          eq(reservations.propertyId, propertyId),
+        ),
+      );
+    if (!reservation) {
+      throw new BadRequestException('Reservation not found for this booking');
+    }
+
+    const updated = await this.reservationService.preRegister(reservation.id, propertyId, dto);
+
+    return {
+      confirmationNumber,
+      reservationId: updated.id,
+      status: updated.status,
+      registrationSignedAt: updated.registrationSignedAt,
+      registrationSubmittedAt: updated.registrationSubmittedAt,
     };
   }
 

--- a/apps/api/src/modules/reservation/dto/compose-message.dto.ts
+++ b/apps/api/src/modules/reservation/dto/compose-message.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsOptional, IsUUID, IsBoolean, MinLength } from 'class-validator';
+import { IsString, IsOptional, IsUUID, IsBoolean, MinLength, IsIn, ValidateIf } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class ComposeMessageDto {
@@ -6,12 +6,22 @@ export class ComposeMessageDto {
   @IsUUID()
   propertyId!: string;
 
-  @ApiProperty({ description: 'Email subject line' })
+  @ApiPropertyOptional({
+    description: 'Delivery channel (defaults to email)',
+    enum: ['email', 'sms'],
+    default: 'email',
+  })
+  @IsOptional()
+  @IsIn(['email', 'sms'])
+  channel?: 'email' | 'sms';
+
+  @ApiPropertyOptional({ description: 'Email subject line (required for email channel)' })
+  @ValidateIf((o) => o.channel !== 'sms')
   @IsString()
   @MinLength(1)
-  subject!: string;
+  subject?: string;
 
-  @ApiProperty({ description: 'Message body (used as both html and text)' })
+  @ApiProperty({ description: 'Message body (used as both html and text for email)' })
   @IsString()
   @MinLength(1)
   body!: string;

--- a/apps/api/src/modules/reservation/dto/pre-register.dto.ts
+++ b/apps/api/src/modules/reservation/dto/pre-register.dto.ts
@@ -1,0 +1,12 @@
+import { PickType } from '@nestjs/swagger';
+import { CheckInDto } from './check-in.dto';
+
+/** Advance check-in / pre-register — registration + ID fields only (no status change). */
+export class PreRegisterDto extends PickType(CheckInDto, [
+  'registrationSigned',
+  'registrationData',
+  'idType',
+  'idNumber',
+  'idCountry',
+  'idExpiry',
+] as const) {}

--- a/apps/api/src/modules/reservation/pre-register.spec.ts
+++ b/apps/api/src/modules/reservation/pre-register.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { WEBHOOK_EVENTS } from '@telivityhaip/shared';
+import { ReservationService } from './reservation.service';
+import { AvailabilityService } from './availability.service';
+import { FolioService } from '../folio/folio.service';
+import { RoomStatusService } from '../room/room-status.service';
+import { PaymentService } from '../payment/payment.service';
+import { WebhookService } from '../webhook/webhook.service';
+import { AncillaryService } from '../ancillary/ancillary.service';
+import { PolicyService } from '../policy/policy.service';
+import { DepositSettlementService } from '../accounting/deposit-settlement.service';
+import { DRIZZLE } from '../../database/database.module';
+
+const mockReservation = {
+  id: 'res-001',
+  propertyId: 'prop-001',
+  bookingId: 'book-001',
+  guestId: 'guest-001',
+  roomTypeId: 'rt-001',
+  roomId: 'room-001',
+  status: 'assigned',
+  totalAmount: '500.00',
+  currencyCode: 'USD',
+};
+
+const mockUpdatedReservation = {
+  ...mockReservation,
+  registrationSignedAt: new Date(),
+  registrationSubmittedAt: new Date(),
+  guestIdDocument: {
+    type: 'passport',
+    encryptedNumber: '***REDACTED***',
+    iv: '',
+    authTag: '',
+    country: 'US',
+    expiry: '2030-01-01',
+  },
+};
+
+const mockWebhookService = { emit: vi.fn() };
+
+function createPreRegisterDb(reservation: any = mockReservation, updated = mockUpdatedReservation) {
+  return {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(() => {
+          const chain = {
+            then: (resolve: (v: unknown) => void) => resolve([reservation]),
+          };
+          return chain;
+        }),
+      }),
+    })),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([updated]),
+        }),
+      }),
+    }),
+  };
+}
+
+async function createService(db: any) {
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      ReservationService,
+      { provide: DRIZZLE, useValue: db },
+      { provide: AvailabilityService, useValue: {} },
+      { provide: FolioService, useValue: {} },
+      { provide: RoomStatusService, useValue: {} },
+      { provide: PaymentService, useValue: {} },
+      { provide: WebhookService, useValue: mockWebhookService },
+      { provide: AncillaryService, useValue: {} },
+      { provide: PolicyService, useValue: {} },
+      { provide: DepositSettlementService, useValue: {} },
+    ],
+  }).compile();
+  return module.get<ReservationService>(ReservationService);
+}
+
+describe('ReservationService.preRegister', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reservation.pre_registered is in WEBHOOK_EVENTS catalog', () => {
+    expect(WEBHOOK_EVENTS['reservation.pre_registered']).toBe('reservation.pre_registered');
+  });
+
+  it('persists registration fields without changing status', async () => {
+    const db = createPreRegisterDb();
+    const svc = await createService(db);
+
+    const result = await svc.preRegister('res-001', 'prop-001', {
+      registrationSigned: true,
+      registrationData: { signature: 'Jane Doe' },
+      idType: 'passport',
+      idNumber: 'P1234567',
+      idCountry: 'US',
+      idExpiry: '2030-01-01',
+    });
+
+    expect(result).toEqual(mockUpdatedReservation);
+    expect(db.update).toHaveBeenCalled();
+    expect(mockWebhookService.emit).toHaveBeenCalledWith(
+      'reservation.pre_registered',
+      'reservation',
+      'res-001',
+      expect.objectContaining({
+        registrationSigned: true,
+        hasRegistrationData: true,
+        hasIdDocument: true,
+      }),
+      'prop-001',
+    );
+  });
+
+  it('allows confirmed reservations', async () => {
+    const confirmed = { ...mockReservation, status: 'confirmed' };
+    const db = createPreRegisterDb(confirmed, { ...confirmed, registrationSignedAt: new Date() });
+    const svc = await createService(db);
+
+    await expect(
+      svc.preRegister('res-001', 'prop-001', { registrationSigned: true }),
+    ).resolves.toBeDefined();
+  });
+
+  it('rejects when reservation not found', async () => {
+    const db = createPreRegisterDb(null as any);
+    db.select = vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockImplementation(() => ({
+          then: (resolve: (v: unknown) => void) => resolve([]),
+        })),
+      }),
+    }));
+    const svc = await createService(db);
+
+    await expect(
+      svc.preRegister('res-001', 'prop-001', { registrationSigned: true }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects when status is not confirmed or assigned', async () => {
+    const checkedIn = { ...mockReservation, status: 'checked_in' };
+    const db = createPreRegisterDb(checkedIn);
+    const svc = await createService(db);
+
+    await expect(
+      svc.preRegister('res-001', 'prop-001', { registrationSigned: true }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/modules/reservation/reservation-messaging.service.spec.ts
+++ b/apps/api/src/modules/reservation/reservation-messaging.service.spec.ts
@@ -3,12 +3,16 @@ import { NotFoundException, BadRequestException, ForbiddenException } from '@nes
 import { ReservationMessagingService } from './reservation-messaging.service';
 import { WebhookService } from '../webhook/webhook.service';
 import { EmailService } from '../agent/guest-comms/email.service';
+import { NotificationService } from '../notifications/notification.service';
 import { DRIZZLE } from '../../database/database.module';
 
 const mockReservation = { id: 'res-001', propertyId: 'prop-001', guestId: 'guest-001' };
 
 const mockWebhookService = { emit: vi.fn() };
 const mockEmailService = { send: vi.fn().mockResolvedValue({ sent: false, error: 'SMTP not configured' }) };
+const mockNotificationService = {
+  sendSms: vi.fn().mockResolvedValue({ sent: false, provider: 'console', error: 'SMS not configured' }),
+};
 
 function createMockDb(selectReturns: any[][]) {
   const selects = [...selectReturns];
@@ -30,6 +34,7 @@ async function createService(db: any) {
       ReservationMessagingService,
       { provide: DRIZZLE, useValue: db },
       { provide: EmailService, useValue: mockEmailService },
+      { provide: NotificationService, useValue: mockNotificationService },
       { provide: WebhookService, useValue: mockWebhookService },
     ],
   }).compile();
@@ -40,14 +45,23 @@ describe('ReservationMessagingService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEmailService.send.mockResolvedValue({ sent: false, error: 'SMTP not configured' });
+    mockNotificationService.sendSms.mockResolvedValue({
+      sent: false,
+      provider: 'console',
+      error: 'SMS not configured',
+    });
   });
 
-  it('sends and emits reservation.message_sent', async () => {
+  it('sends email and emits reservation.message_sent', async () => {
     const guest = { id: 'guest-001', email: 'guest@example.com', gdprConsentMarketing: false };
     const db = createMockDb([[mockReservation], [guest]]);
     const svc = await createService(db);
 
-    const result = await svc.composeMessage('prop-001', 'res-001', { propertyId: 'prop-001', subject: 'Hi', body: 'Welcome' });
+    const result = await svc.composeMessage('prop-001', 'res-001', {
+      propertyId: 'prop-001',
+      subject: 'Hi',
+      body: 'Welcome',
+    });
 
     expect(mockEmailService.send).toHaveBeenCalledWith({
       to: 'guest@example.com',
@@ -55,14 +69,60 @@ describe('ReservationMessagingService', () => {
       html: 'Welcome',
       text: 'Welcome',
     });
-    expect(result.sent).toBe(false); // draft when SMTP unconfigured
+    expect(result.sent).toBe(false);
     expect(mockWebhookService.emit).toHaveBeenCalledWith(
       'reservation.message_sent',
       'reservation',
       'res-001',
-      expect.objectContaining({ to: 'guest@example.com' }),
+      expect.objectContaining({ channel: 'email', to: 'guest@example.com' }),
       'prop-001',
     );
+  });
+
+  it('sends SMS and emits reservation.message_sent with channel sms', async () => {
+    const guest = {
+      id: 'guest-001',
+      email: 'guest@example.com',
+      phone: '+15551230000',
+      gdprConsentMarketing: false,
+    };
+    const db = createMockDb([[mockReservation], [guest]]);
+    const svc = await createService(db);
+
+    const result = await svc.composeMessage('prop-001', 'res-001', {
+      propertyId: 'prop-001',
+      channel: 'sms',
+      body: 'Your room is ready',
+    });
+
+    expect(mockNotificationService.sendSms).toHaveBeenCalledWith(
+      'prop-001',
+      '+15551230000',
+      'Your room is ready',
+    );
+    expect(mockEmailService.send).not.toHaveBeenCalled();
+    expect(result.sent).toBe(false);
+    expect(mockWebhookService.emit).toHaveBeenCalledWith(
+      'reservation.message_sent',
+      'reservation',
+      'res-001',
+      expect.objectContaining({ channel: 'sms', to: '+15551230000' }),
+      'prop-001',
+    );
+  });
+
+  it('rejects SMS when guest has no phone', async () => {
+    const guest = { id: 'guest-001', email: 'guest@example.com', phone: null, gdprConsentMarketing: true };
+    const db = createMockDb([[mockReservation], [guest]]);
+    const svc = await createService(db);
+    await expect(
+      svc.composeMessage('prop-001', 'res-001', {
+        propertyId: 'prop-001',
+        channel: 'sms',
+        body: 'Hello',
+      }),
+    ).rejects.toThrow(BadRequestException);
+    expect(mockNotificationService.sendSms).not.toHaveBeenCalled();
   });
 
   it('rejects when reservation not in property', async () => {
@@ -73,7 +133,7 @@ describe('ReservationMessagingService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('rejects when guest has no email', async () => {
+  it('rejects when guest has no email on email channel', async () => {
     const guest = { id: 'guest-001', email: null, gdprConsentMarketing: true };
     const db = createMockDb([[mockReservation], [guest]]);
     const svc = await createService(db);
@@ -82,12 +142,37 @@ describe('ReservationMessagingService', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('blocks marketing message when guest opted out (GDPR)', async () => {
+  it('blocks marketing SMS when guest opted out (GDPR)', async () => {
+    const guest = {
+      id: 'guest-001',
+      email: 'guest@example.com',
+      phone: '+15551230000',
+      gdprConsentMarketing: false,
+    };
+    const db = createMockDb([[mockReservation], [guest]]);
+    const svc = await createService(db);
+    await expect(
+      svc.composeMessage('prop-001', 'res-001', {
+        propertyId: 'prop-001',
+        channel: 'sms',
+        body: 'Promo',
+        isMarketing: true,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+    expect(mockNotificationService.sendSms).not.toHaveBeenCalled();
+  });
+
+  it('blocks marketing email when guest opted out (GDPR)', async () => {
     const guest = { id: 'guest-001', email: 'guest@example.com', gdprConsentMarketing: false };
     const db = createMockDb([[mockReservation], [guest]]);
     const svc = await createService(db);
     await expect(
-      svc.composeMessage('prop-001', 'res-001', { propertyId: 'prop-001', subject: 's', body: 'b', isMarketing: true }),
+      svc.composeMessage('prop-001', 'res-001', {
+        propertyId: 'prop-001',
+        subject: 's',
+        body: 'b',
+        isMarketing: true,
+      }),
     ).rejects.toThrow(ForbiddenException);
     expect(mockEmailService.send).not.toHaveBeenCalled();
   });
@@ -96,7 +181,12 @@ describe('ReservationMessagingService', () => {
     const guest = { id: 'guest-001', email: 'guest@example.com', gdprConsentMarketing: true };
     const db = createMockDb([[mockReservation], [guest]]);
     const svc = await createService(db);
-    await svc.composeMessage('prop-001', 'res-001', { propertyId: 'prop-001', subject: 's', body: 'b', isMarketing: true });
+    await svc.composeMessage('prop-001', 'res-001', {
+      propertyId: 'prop-001',
+      subject: 's',
+      body: 'b',
+      isMarketing: true,
+    });
     expect(mockEmailService.send).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/modules/reservation/reservation-messaging.service.ts
+++ b/apps/api/src/modules/reservation/reservation-messaging.service.ts
@@ -10,15 +10,15 @@ import { reservations, guests } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { WebhookService } from '../webhook/webhook.service';
 import { EmailService } from '../agent/guest-comms/email.service';
+import { NotificationService } from '../notifications/notification.service';
 import { ComposeMessageDto } from './dto/compose-message.dto';
 
 /**
  * Guest messaging from a reservation (Tier 4 — Reservation Operations Polish).
  *
- * Resolves the reservation's guest (tenant-scoped) and sends an email via the
- * shared EmailService. When SMTP is unconfigured EmailService returns a draft
- * result ({ sent: false }) rather than throwing. Marketing messages respect the
- * guest's GDPR marketing opt-out.
+ * Resolves the reservation's guest (tenant-scoped) and sends via email or SMS.
+ * When SMTP/SMS is unconfigured the provider returns a draft result ({ sent: false })
+ * rather than throwing. Marketing messages respect the guest's GDPR marketing opt-out.
  *
  * Out of scope: persistent message log (no message-log table) — compose/send only.
  */
@@ -27,10 +27,13 @@ export class ReservationMessagingService {
   constructor(
     @Inject(DRIZZLE) private readonly db: any,
     private readonly emailService: EmailService,
+    private readonly notificationService: NotificationService,
     private readonly webhookService: WebhookService,
   ) {}
 
   async composeMessage(propertyId: string, reservationId: string, dto: ComposeMessageDto) {
+    const channel = dto.channel ?? 'email';
+
     // Tenant-scoped reservation lookup.
     const [reservation] = await this.db
       .select()
@@ -52,14 +55,42 @@ export class ReservationMessagingService {
     if (!guest) {
       throw new NotFoundException(`Guest ${reservation.guestId} not found`);
     }
-    if (!guest.email) {
-      throw new BadRequestException('Guest has no email address on file');
-    }
 
     if (dto.isMarketing === true && guest.gdprConsentMarketing === false) {
       throw new ForbiddenException(
         'Guest has not consented to marketing communications (GDPR opt-out)',
       );
+    }
+
+    if (channel === 'sms') {
+      if (!guest.phone) {
+        throw new BadRequestException('Guest has no phone number on file');
+      }
+
+      const result = await this.notificationService.sendSms(propertyId, guest.phone, dto.body);
+
+      await this.webhookService.emit(
+        'reservation.message_sent',
+        'reservation',
+        reservationId,
+        {
+          reservationId,
+          channel: 'sms',
+          to: guest.phone,
+          sent: result.sent,
+          isMarketing: dto.isMarketing ?? false,
+        },
+        propertyId,
+      );
+
+      return result;
+    }
+
+    if (!dto.subject?.trim()) {
+      throw new BadRequestException('Subject is required for email messages');
+    }
+    if (!guest.email) {
+      throw new BadRequestException('Guest has no email address on file');
     }
 
     const result = await this.emailService.send({
@@ -75,6 +106,7 @@ export class ReservationMessagingService {
       reservationId,
       {
         reservationId,
+        channel: 'email',
         to: guest.email,
         subject: dto.subject,
         sent: result.sent,

--- a/apps/api/src/modules/reservation/reservation.controller.ts
+++ b/apps/api/src/modules/reservation/reservation.controller.ts
@@ -24,6 +24,7 @@ import { CancelReservationDto } from './dto/cancel-reservation.dto';
 import { SearchAvailabilityDto } from './dto/search-availability.dto';
 import { ListReservationsDto } from './dto/list-reservations.dto';
 import { CheckInDto } from './dto/check-in.dto';
+import { PreRegisterDto } from './dto/pre-register.dto';
 import { CheckOutDto } from './dto/check-out.dto';
 import { GroupCheckInDto } from './dto/group-check-in.dto';
 import { BulkActionDto } from './dto/bulk-action.dto';
@@ -233,6 +234,22 @@ export class ReservationController {
     return this.reservationService.markNoShow(id, propertyId);
   }
 
+  @Post(':id/pre-register')
+  @Roles('admin', 'front_desk')
+  @ApiOperation({
+    summary:
+      'Advance check-in / pre-register — capture registration card and ID without checking in',
+  })
+  @ApiQuery({ name: 'propertyId', required: true })
+  @ApiResponse({ status: 200, description: 'Registration fields saved; status unchanged' })
+  preRegister(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @Body() dto: PreRegisterDto,
+  ) {
+    return this.reservationService.preRegister(id, propertyId, dto);
+  }
+
   @Patch(':id/check-in')
   @Roles('admin', 'front_desk')
   @ApiOperation({ summary: 'Check in reservation with optional ID capture, deposit auth, room override' })
@@ -299,7 +316,7 @@ export class ReservationController {
 
   @Post(':id/messages')
   @Roles('admin', 'front_desk')
-  @ApiOperation({ summary: 'Compose and send an email to the reservation guest (GDPR-aware)' })
+  @ApiOperation({ summary: 'Compose and send an email or SMS to the reservation guest (GDPR-aware)' })
   @ApiResponse({ status: 201, description: 'Email send/draft result' })
   composeMessage(
     @Param('id', ParseUUIDPipe) id: string,

--- a/apps/api/src/modules/reservation/reservation.module.ts
+++ b/apps/api/src/modules/reservation/reservation.module.ts
@@ -13,6 +13,7 @@ import { WebhookModule } from '../webhook/webhook.module';
 import { AncillaryModule } from '../ancillary/ancillary.module';
 import { AccountingModule } from '../accounting/accounting.module';
 import { PolicyModule } from '../policy/policy.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { PolicyModule } from '../policy/policy.module';
     forwardRef(() => AncillaryModule),
     AccountingModule,
     PolicyModule,
+    NotificationsModule,
   ],
   controllers: [ReservationController],
   providers: [

--- a/apps/api/src/modules/reservation/reservation.service.ts
+++ b/apps/api/src/modules/reservation/reservation.service.ts
@@ -26,6 +26,7 @@ import { MoveRoomDto } from './dto/move-room.dto';
 import { CancelReservationDto } from './dto/cancel-reservation.dto';
 import { ListReservationsDto } from './dto/list-reservations.dto';
 import { CheckInDto } from './dto/check-in.dto';
+import { PreRegisterDto } from './dto/pre-register.dto';
 import { CheckOutDto } from './dto/check-out.dto';
 import { GroupCheckInDto } from './dto/group-check-in.dto';
 import { BulkActionDto } from './dto/bulk-action.dto';
@@ -384,6 +385,65 @@ export class ReservationService {
         roomTypeId: updated.roomTypeId,
       },
       updated.propertyId,
+    );
+
+    return updated;
+  }
+
+  /**
+   * Advance check-in / pre-register — persist registration card + ID fields without
+   * transitioning the reservation to checked_in.
+   */
+  async preRegister(id: string, propertyId: string, dto: PreRegisterDto = {}) {
+    const reservation = await this.findByIdRaw(id, propertyId);
+
+    if (!['confirmed', 'assigned'].includes(reservation.status)) {
+      throw new BadRequestException(
+        `Pre-register is only allowed for confirmed or assigned reservations (current: ${reservation.status})`,
+      );
+    }
+
+    const now = new Date();
+
+    let guestIdDocument: Record<string, string> | undefined;
+    if (dto.idNumber) {
+      const encrypted = this.encryptIdNumber(dto.idNumber);
+      guestIdDocument = {
+        type: dto.idType ?? 'unknown',
+        encryptedNumber: encrypted.encrypted,
+        iv: encrypted.iv,
+        authTag: encrypted.authTag,
+        country: dto.idCountry ?? '',
+        expiry: dto.idExpiry ?? '',
+      };
+    }
+
+    const updateData: Record<string, unknown> = {
+      updatedAt: now,
+    };
+    if (guestIdDocument) updateData['guestIdDocument'] = guestIdDocument;
+    if (dto.registrationSigned) updateData['registrationSignedAt'] = now;
+    if (dto.registrationData) {
+      updateData['registrationData'] = dto.registrationData;
+      updateData['registrationSubmittedAt'] = now;
+    }
+
+    const [updated] = await this.db
+      .update(reservations)
+      .set(updateData)
+      .where(and(eq(reservations.id, id), eq(reservations.propertyId, propertyId)))
+      .returning();
+
+    await this.webhookService.emit(
+      'reservation.pre_registered',
+      'reservation',
+      updated.id,
+      {
+        registrationSigned: dto.registrationSigned ?? false,
+        hasRegistrationData: !!dto.registrationData,
+        hasIdDocument: !!guestIdDocument,
+      },
+      propertyId,
     );
 
     return updated;

--- a/apps/dashboard/src/locales/en.json
+++ b/apps/dashboard/src/locales/en.json
@@ -975,12 +975,17 @@
     "addOpsNote": "Add a front-desk note…",
     "saveNote": "Save note",
     "guestMessage": "Guest message",
+    "messageChannel": "Channel",
+    "messageChannelEmail": "Email",
+    "messageChannelSms": "SMS",
     "messageSubject": "Subject",
     "messageBody": "Message body",
     "marketingMessage": "Marketing message (requires guest consent)",
     "sendMessage": "Send message",
     "messageSent": "Message sent",
     "messageDrafted": "Message drafted (SMTP not configured or send deferred)",
+    "smsSent": "SMS sent",
+    "smsDrafted": "SMS drafted (provider not configured or send deferred)",
     "messageFailed": "Failed to send message"
   },
   "revenue": {

--- a/apps/dashboard/src/locales/pt-BR.json
+++ b/apps/dashboard/src/locales/pt-BR.json
@@ -894,12 +894,17 @@
     "viewFolio": "Ver conta",
     "viewGuest": "Ver hóspede",
     "guestMessage": "Mensagem ao hóspede",
+    "messageChannel": "Canal",
+    "messageChannelEmail": "E-mail",
+    "messageChannelSms": "SMS",
     "messageSubject": "Assunto",
     "messageBody": "Corpo da mensagem",
     "marketingMessage": "Mensagem de marketing (exige consentimento do hóspede)",
     "sendMessage": "Enviar mensagem",
     "messageSent": "Mensagem enviada",
     "messageDrafted": "Mensagem rascunhada (SMTP não configurado ou envio adiado)",
+    "smsSent": "SMS enviado",
+    "smsDrafted": "SMS rascunhado (provedor não configurado ou envio adiado)",
     "messageFailed": "Falha ao enviar mensagem"
   },
   "revenue": {

--- a/apps/dashboard/src/pages/Reservations.tsx
+++ b/apps/dashboard/src/pages/Reservations.tsx
@@ -651,6 +651,7 @@ function ReservationMessageCompose({
   propertyId: string;
 }) {
   const { t } = useTranslation();
+  const [channel, setChannel] = useState<'email' | 'sms'>('email');
   const [subject, setSubject] = useState('');
   const [body, setBody] = useState('');
   const [isMarketing, setIsMarketing] = useState(false);
@@ -660,13 +661,18 @@ function ReservationMessageCompose({
     mutationFn: () =>
       api.post(`/v1/reservations/${reservationId}/messages`, {
         propertyId,
-        subject: subject.trim(),
+        channel,
+        ...(channel === 'email' ? { subject: subject.trim() } : {}),
         body: body.trim(),
         isMarketing,
       }),
     onSuccess: (res) => {
       const sent = res.data?.sent ?? res.data?.data?.sent;
-      setStatus(sent ? t('reservations.messageSent') : t('reservations.messageDrafted'));
+      if (channel === 'sms') {
+        setStatus(sent ? t('reservations.smsSent') : t('reservations.smsDrafted'));
+      } else {
+        setStatus(sent ? t('reservations.messageSent') : t('reservations.messageDrafted'));
+      }
       setSubject('');
       setBody('');
     },
@@ -676,16 +682,32 @@ function ReservationMessageCompose({
     },
   });
 
+  const canSend =
+    body.trim().length > 0 && (channel === 'sms' || subject.trim().length > 0) && !send.isPending;
+
   return (
     <div className="space-y-2 border-t border-gray-100 pt-4">
       <p className="text-xs font-medium text-telivity-mid-grey">{t('reservations.guestMessage')}</p>
-      <input
-        type="text"
-        value={subject}
-        onChange={(e) => setSubject(e.target.value)}
-        placeholder={t('reservations.messageSubject')}
-        className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
-      />
+      <label className="block text-xs text-telivity-navy">
+        <span className="sr-only">{t('reservations.messageChannel')}</span>
+        <select
+          value={channel}
+          onChange={(e) => setChannel(e.target.value as 'email' | 'sms')}
+          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+        >
+          <option value="email">{t('reservations.messageChannelEmail')}</option>
+          <option value="sms">{t('reservations.messageChannelSms')}</option>
+        </select>
+      </label>
+      {channel === 'email' && (
+        <input
+          type="text"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          placeholder={t('reservations.messageSubject')}
+          className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+        />
+      )}
       <textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}
@@ -705,7 +727,7 @@ function ReservationMessageCompose({
       <button
         type="button"
         onClick={() => send.mutate()}
-        disabled={!subject.trim() || !body.trim() || send.isPending}
+        disabled={!canSend}
         className="w-full bg-telivity-teal text-white rounded-lg px-3 py-1.5 text-xs font-semibold disabled:opacity-50"
       >
         {t('reservations.sendMessage')}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export const WEBHOOK_EVENTS = {
   'reservation.modified': 'reservation.modified',
   'reservation.cancelled': 'reservation.cancelled',
   'reservation.checked_in': 'reservation.checked_in',
+  'reservation.pre_registered': 'reservation.pre_registered',
   'reservation.checked_out': 'reservation.checked_out',
   'reservation.no_show': 'reservation.no_show',
   'reservation.note_added': 'reservation.note_added',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues **Slice 6** beyond polish (#182) toward the full plan:

- **Pre-register** — staff `POST /reservations/:id/pre-register` + booking-engine guest route; writes registration/ID fields **without** checking in
- **SMS messaging** — `channel: email|sms` on reservation messages via existing `NotificationService`
- Docs note WhatsApp / guest app / kiosk UI still later

## Test plan
- [x] `pre-register.spec.ts` + messaging SMS specs
- [ ] CI green
- [ ] Optional reviewer: pre-register via booking confirmation; send SMS message to guest with phone

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

