### PR TITLE
feat(rates-bi): LOS/occupancy pricing + pickup report (supersedes #196)

### DIFF
--- a/apps/api/src/modules/booking-engine/booking-engine.service.ts
+++ b/apps/api/src/modules/booking-engine/booking-engine.service.ts
@@ -161,6 +161,7 @@ export class BookingEngineService {
     const { effectiveRate, currency } = await this.ratePlanService.calculateDerivedRate(
       dto.ratePlanId,
       propertyId,
+      { nights, checkIn: dto.checkIn, checkOut: dto.checkOut, stayDate: dto.checkIn },
     );
 
     // Per-night tax via the real tax engine (not a flat property rate).

--- a/apps/api/src/modules/rate-plan/dto/create-rate-plan.dto.ts
+++ b/apps/api/src/modules/rate-plan/dto/create-rate-plan.dto.ts
@@ -12,8 +12,11 @@ import {
   MaxLength,
   Length,
   ValidateIf,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { LosAdjustmentDto, OccupancyBandDto } from './rate-adjustment.dto';
 
 export class CreateRatePlanDto {
   @ApiProperty()
@@ -116,4 +119,24 @@ export class CreateRatePlanDto {
   @IsOptional()
   @IsInt()
   sortOrder?: number;
+
+  @ApiPropertyOptional({
+    type: [LosAdjustmentDto],
+    description: 'LOS pricing tiers (e.g. 7+/14+/21+ night discounts)',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => LosAdjustmentDto)
+  losAdjustments?: LosAdjustmentDto[];
+
+  @ApiPropertyOptional({
+    type: [OccupancyBandDto],
+    description: 'Occupancy-based pricing bands',
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => OccupancyBandDto)
+  occupancyBands?: OccupancyBandDto[];
 }

--- a/apps/api/src/modules/rate-plan/dto/effective-rate-query.dto.ts
+++ b/apps/api/src/modules/rate-plan/dto/effective-rate-query.dto.ts
@@ -1,0 +1,27 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsInt, IsOptional, Min } from 'class-validator';
+
+export class EffectiveRateQueryDto {
+  @ApiPropertyOptional({ description: 'Length of stay in nights (alternative to checkIn/checkOut)' })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  nights?: number;
+
+  @ApiPropertyOptional({ description: 'Stay arrival date (ISO) — used for occupancy lookup' })
+  @IsOptional()
+  @IsDateString()
+  checkIn?: string;
+
+  @ApiPropertyOptional({ description: 'Stay departure date (ISO) — derives nights when nights omitted' })
+  @IsOptional()
+  @IsDateString()
+  checkOut?: string;
+
+  @ApiPropertyOptional({
+    description: 'Specific stay night for occupancy-based pricing (defaults to checkIn)',
+  })
+  @IsOptional()
+  @IsDateString()
+  stayDate?: string;
+}

--- a/apps/api/src/modules/rate-plan/dto/rate-adjustment.dto.ts
+++ b/apps/api/src/modules/rate-plan/dto/rate-adjustment.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber, IsInt, Min, Max } from 'class-validator';
+
+export class RateAdjustmentRuleDto {
+  @ApiProperty({ enum: ['percentage', 'fixed'] })
+  @IsEnum(['percentage', 'fixed'])
+  adjustmentType!: 'percentage' | 'fixed';
+
+  @ApiProperty({ description: 'Negative = discount, positive = surcharge' })
+  @IsNumber()
+  adjustmentValue!: number;
+}
+
+export class LosAdjustmentDto extends RateAdjustmentRuleDto {
+  @ApiProperty({ example: 7, description: 'Minimum stay length (nights) to trigger this tier' })
+  @IsInt()
+  @Min(1)
+  minNights!: number;
+}
+
+export class OccupancyBandDto extends RateAdjustmentRuleDto {
+  @ApiProperty({ example: 0 })
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  occupancyPctMin!: number;
+
+  @ApiProperty({ example: 50 })
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  occupancyPctMax!: number;
+}

--- a/apps/api/src/modules/rate-plan/rate-plan.controller.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.controller.ts
@@ -16,6 +16,7 @@ import { CreateRatePlanDto } from './dto/create-rate-plan.dto';
 import { UpdateRatePlanDto } from './dto/update-rate-plan.dto';
 import { CreateRateRestrictionDto } from './dto/create-rate-restriction.dto';
 import { UpdateRateRestrictionDto } from './dto/update-rate-restriction.dto';
+import { EffectiveRateQueryDto } from './dto/effective-rate-query.dto';
 
 @ApiTags('rate-plans')
 @Controller('rate-plans')
@@ -51,14 +52,21 @@ export class RatePlanController {
   }
 
   @Get(':id/effective-rate')
-  @ApiOperation({ summary: 'Calculate effective rate (resolves derived rate chain)' })
+  @ApiOperation({
+    summary: 'Calculate effective rate (derived chain + LOS + occupancy adjustments)',
+  })
   @ApiQuery({ name: 'propertyId', required: true })
+  @ApiQuery({ name: 'nights', required: false, description: 'Length of stay in nights' })
+  @ApiQuery({ name: 'checkIn', required: false, description: 'Arrival date (ISO)' })
+  @ApiQuery({ name: 'checkOut', required: false, description: 'Departure date (ISO)' })
+  @ApiQuery({ name: 'stayDate', required: false, description: 'Stay night for occupancy lookup' })
   @ApiResponse({ status: 200, description: 'Effective rate calculated' })
   getEffectiveRate(
     @Param('id', ParseUUIDPipe) id: string,
     @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @Query() context: EffectiveRateQueryDto,
   ) {
-    return this.ratePlanService.calculateDerivedRate(id, propertyId);
+    return this.ratePlanService.calculateDerivedRate(id, propertyId, context);
   }
 
   @Patch(':id')

--- a/apps/api/src/modules/rate-plan/rate-plan.service.spec.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.service.spec.ts
@@ -169,6 +169,87 @@ describe('RatePlanService', () => {
       const result = await service.calculateDerivedRate('rp-big-001', 'prop-001');
       expect(result.effectiveRate).toBe(0);
     });
+
+    it('should apply LOS adjustment when nights provided', async () => {
+      const losPlan = {
+        ...mockBarRate,
+        losAdjustments: [
+          { minNights: 7, adjustmentType: 'percentage', adjustmentValue: -10 },
+          { minNights: 14, adjustmentType: 'percentage', adjustmentValue: -15 },
+        ],
+      };
+      const mockDb = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => resolve([losPlan]),
+            }),
+          }),
+        }),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          RatePlanService,
+          { provide: DRIZZLE, useValue: mockDb },
+        ],
+      }).compile();
+      const service = module.get<RatePlanService>(RatePlanService);
+
+      const shortStay = await service.calculateDerivedRate('rp-bar-001', 'prop-001', { nights: 3 });
+      expect(shortStay.effectiveRate).toBe(200);
+      expect(shortStay.losAdjustment).toBeNull();
+
+      const weekStay = await service.calculateDerivedRate('rp-bar-001', 'prop-001', { nights: 7 });
+      expect(weekStay.effectiveRate).toBe(180);
+      expect(weekStay.losAdjustment?.minNights).toBe(7);
+
+      const twoWeeks = await service.calculateDerivedRate('rp-bar-001', 'prop-001', { nights: 14 });
+      expect(twoWeeks.effectiveRate).toBe(170);
+      expect(twoWeeks.losAdjustment?.minNights).toBe(14);
+    });
+
+    it('should apply occupancy band when stayDate provided', async () => {
+      const occPlan = {
+        ...mockBarRate,
+        occupancyBands: [
+          { occupancyPctMin: 0, occupancyPctMax: 60, adjustmentType: 'percentage', adjustmentValue: -5 },
+          { occupancyPctMin: 61, occupancyPctMax: 100, adjustmentType: 'percentage', adjustmentValue: 10 },
+        ],
+      };
+
+      const mockDb = {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              then: (resolve: any) => resolve([occPlan]),
+            }),
+          }),
+        }),
+        insert: vi.fn(),
+        update: vi.fn(),
+        delete: vi.fn(),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          RatePlanService,
+          { provide: DRIZZLE, useValue: mockDb },
+        ],
+      }).compile();
+      const service = module.get<RatePlanService>(RatePlanService);
+      vi.spyOn(service, 'getStayOccupancyPct').mockResolvedValue(80);
+
+      const result = await service.calculateDerivedRate('rp-bar-001', 'prop-001', {
+        stayDate: '2026-08-15',
+      });
+      expect(result.effectiveRate).toBe(220);
+      expect(result.occupancyPct).toBe(80);
+      expect(result.occupancyAdjustment?.adjustmentValue).toBe(10);
+    });
   });
 
   describe('create', () => {

--- a/apps/api/src/modules/rate-plan/rate-plan.service.ts
+++ b/apps/api/src/modules/rate-plan/rate-plan.service.ts
@@ -4,13 +4,32 @@ import {
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
-import { eq, and, lte, gte } from 'drizzle-orm';
-import { ratePlans, rateRestrictions, roomTypes, cancellationPolicies, groupProfiles } from '@telivityhaip/database';
+import { eq, and, lte, gte, sql } from 'drizzle-orm';
+import { ratePlans, rateRestrictions, roomTypes, cancellationPolicies, groupProfiles, properties, rooms, reservations } from '@telivityhaip/database';
 import { DRIZZLE } from '../../database/database.module';
 import { CreateRatePlanDto } from './dto/create-rate-plan.dto';
 import { UpdateRatePlanDto } from './dto/update-rate-plan.dto';
 import { CreateRateRestrictionDto } from './dto/create-rate-restriction.dto';
 import { UpdateRateRestrictionDto } from './dto/update-rate-restriction.dto';
+import { EffectiveRateQueryDto } from './dto/effective-rate-query.dto';
+import {
+  applyRateAdjustment,
+  nightsBetween,
+  selectLosAdjustment,
+  selectOccupancyBand,
+  type LosAdjustment,
+  type OccupancyBand,
+} from './rate-pricing.util';
+
+export interface EffectiveRateResult {
+  effectiveRate: number;
+  currency: string;
+  baseRate: number;
+  nights?: number;
+  occupancyPct?: number;
+  losAdjustment?: LosAdjustment | null;
+  occupancyAdjustment?: OccupancyBand | null;
+}
 
 @Injectable()
 export class RatePlanService {
@@ -221,38 +240,112 @@ export class RatePlanService {
   }
 
   /**
-   * Calculate the effective rate for a derived rate plan.
-   * Follows the parent chain to get the base amount, then applies the adjustment.
+   * Calculate the effective rate for a rate plan.
+   * Resolves derived chains, then applies LOS and occupancy-based adjustments
+   * when stay context (nights / dates) is provided.
    */
   async calculateDerivedRate(
     id: string,
     propertyId: string,
-  ): Promise<{ effectiveRate: number; currency: string }> {
+    context?: EffectiveRateQueryDto,
+  ): Promise<EffectiveRateResult> {
     const ratePlan = await this.findById(id, propertyId);
 
+    let baseRate: number;
     if (ratePlan.type !== 'derived' || !ratePlan.parentRatePlanId) {
-      return {
-        effectiveRate: Number(ratePlan.baseAmount),
-        currency: ratePlan.currencyCode,
-      };
+      baseRate = Number(ratePlan.baseAmount);
+    } else {
+      const parent = await this.findById(ratePlan.parentRatePlanId, propertyId);
+      const parentAmount = Number(parent.baseAmount);
+      const adjustmentValue = Number(ratePlan.derivedAdjustmentValue);
+
+      if (ratePlan.derivedAdjustmentType === 'percentage') {
+        baseRate = parentAmount * (1 + adjustmentValue / 100);
+      } else {
+        baseRate = parentAmount + adjustmentValue;
+      }
     }
 
-    const parent = await this.findById(ratePlan.parentRatePlanId, propertyId);
-    const parentAmount = Number(parent.baseAmount);
-    const adjustmentValue = Number(ratePlan.derivedAdjustmentValue);
+    let effectiveRate = baseRate;
+    let nights = context?.nights;
+    if (!nights && context?.checkIn && context?.checkOut) {
+      nights = nightsBetween(context.checkIn, context.checkOut);
+    }
 
-    let effectiveRate: number;
-    if (ratePlan.derivedAdjustmentType === 'percentage') {
-      effectiveRate = parentAmount * (1 + adjustmentValue / 100);
-    } else {
-      // fixed adjustment
-      effectiveRate = parentAmount + adjustmentValue;
+    const losAdjustment = selectLosAdjustment(
+      ratePlan.losAdjustments as LosAdjustment[] | null,
+      nights ?? 0,
+    );
+    if (losAdjustment) {
+      effectiveRate = applyRateAdjustment(effectiveRate, losAdjustment);
+    }
+
+    const stayDate = context?.stayDate ?? context?.checkIn;
+    let occupancyPct: number | undefined;
+    let occupancyAdjustment: OccupancyBand | null = null;
+    if (stayDate && ratePlan.occupancyBands?.length) {
+      occupancyPct = await this.getStayOccupancyPct(propertyId, stayDate);
+      occupancyAdjustment = selectOccupancyBand(
+        ratePlan.occupancyBands as OccupancyBand[],
+        occupancyPct,
+      );
+      if (occupancyAdjustment) {
+        effectiveRate = applyRateAdjustment(effectiveRate, occupancyAdjustment);
+      }
     }
 
     return {
       effectiveRate: Math.max(0, Number(effectiveRate.toFixed(2))),
       currency: ratePlan.currencyCode,
+      baseRate: Math.max(0, Number(baseRate.toFixed(2))),
+      ...(nights ? { nights } : {}),
+      ...(occupancyPct != null ? { occupancyPct: Math.round(occupancyPct * 100) / 100 } : {}),
+      losAdjustment: losAdjustment ?? null,
+      occupancyAdjustment: occupancyAdjustment ?? null,
     };
+  }
+
+  /**
+   * Projected occupancy % for a stay date (confirmed/in-house reservations).
+   */
+  async getStayOccupancyPct(propertyId: string, stayDate: string): Promise<number> {
+    const [property] = await this.db
+      .select({ totalRooms: properties.totalRooms })
+      .from(properties)
+      .where(eq(properties.id, propertyId));
+    const totalRooms = property?.totalRooms ?? 0;
+
+    const roomStatusCounts = await this.db
+      .select({
+        status: rooms.status,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(rooms)
+      .where(and(eq(rooms.propertyId, propertyId), eq(rooms.isActive, true)))
+      .groupBy(rooms.status);
+
+    let unavailableRooms = 0;
+    for (const row of roomStatusCounts) {
+      if (row.status === 'out_of_order' || row.status === 'out_of_service') {
+        unavailableRooms += row.count;
+      }
+    }
+    const availableRooms = totalRooms - unavailableRooms;
+
+    const [soldResult] = await this.db
+      .select({ count: sql<number>`count(distinct ${reservations.id})::int` })
+      .from(reservations)
+      .where(
+        and(
+          eq(reservations.propertyId, propertyId),
+          sql`${reservations.status} not in ('cancelled', 'no_show')`,
+          lte(reservations.arrivalDate, stayDate),
+          sql`${reservations.departureDate} > ${stayDate}`,
+        ),
+      );
+
+    const roomsSold = soldResult?.count ?? 0;
+    return availableRooms > 0 ? (roomsSold / availableRooms) * 100 : 0;
   }
 
   // --- Rate Restrictions ---

--- a/apps/api/src/modules/rate-plan/rate-pricing.util.spec.ts
+++ b/apps/api/src/modules/rate-plan/rate-pricing.util.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyRateAdjustment,
+  nightsBetween,
+  selectLosAdjustment,
+  selectOccupancyBand,
+} from './rate-pricing.util';
+
+describe('rate-pricing.util', () => {
+  const losTiers = [
+    { minNights: 7, adjustmentType: 'percentage' as const, adjustmentValue: -5 },
+    { minNights: 14, adjustmentType: 'percentage' as const, adjustmentValue: -10 },
+    { minNights: 21, adjustmentType: 'percentage' as const, adjustmentValue: -15 },
+  ];
+
+  it('selects the highest qualifying LOS tier', () => {
+    expect(selectLosAdjustment(losTiers, 6)).toBeNull();
+    expect(selectLosAdjustment(losTiers, 7)?.adjustmentValue).toBe(-5);
+    expect(selectLosAdjustment(losTiers, 13)?.adjustmentValue).toBe(-5);
+    expect(selectLosAdjustment(losTiers, 14)?.adjustmentValue).toBe(-10);
+    expect(selectLosAdjustment(losTiers, 21)?.adjustmentValue).toBe(-15);
+    expect(selectLosAdjustment(losTiers, 30)?.adjustmentValue).toBe(-15);
+  });
+
+  it('selects occupancy band by percentage range', () => {
+    const bands = [
+      { occupancyPctMin: 0, occupancyPctMax: 50, adjustmentType: 'percentage' as const, adjustmentValue: -10 },
+      { occupancyPctMin: 51, occupancyPctMax: 80, adjustmentType: 'percentage' as const, adjustmentValue: 0 },
+      { occupancyPctMin: 81, occupancyPctMax: 100, adjustmentType: 'percentage' as const, adjustmentValue: 15 },
+    ];
+    expect(selectOccupancyBand(bands, 40)?.adjustmentValue).toBe(-10);
+    expect(selectOccupancyBand(bands, 65)?.adjustmentValue).toBe(0);
+    expect(selectOccupancyBand(bands, 90)?.adjustmentValue).toBe(15);
+    expect(selectOccupancyBand(bands, 101)).toBeNull();
+  });
+
+  it('applies percentage and fixed adjustments', () => {
+    expect(applyRateAdjustment(200, { adjustmentType: 'percentage', adjustmentValue: -10 })).toBe(180);
+    expect(applyRateAdjustment(200, { adjustmentType: 'fixed', adjustmentValue: -25 })).toBe(175);
+    expect(applyRateAdjustment(200, { adjustmentType: 'percentage', adjustmentValue: 12 })).toBeCloseTo(224);
+  });
+
+  it('computes nights between dates', () => {
+    expect(nightsBetween('2026-08-01', '2026-08-08')).toBe(7);
+    expect(nightsBetween('2026-08-01', '2026-08-02')).toBe(1);
+  });
+});

--- a/apps/api/src/modules/rate-plan/rate-pricing.util.ts
+++ b/apps/api/src/modules/rate-plan/rate-pricing.util.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure rate-pricing helpers for LOS and occupancy-based adjustments.
+ */
+
+export interface RateAdjustmentRule {
+  adjustmentType: 'percentage' | 'fixed';
+  adjustmentValue: number;
+}
+
+export interface LosAdjustment extends RateAdjustmentRule {
+  minNights: number;
+}
+
+export interface OccupancyBand extends RateAdjustmentRule {
+  occupancyPctMin: number;
+  occupancyPctMax: number;
+}
+
+/** Pick the highest qualifying LOS tier (e.g. 21+ beats 14+ beats 7+). */
+export function selectLosAdjustment(
+  adjustments: LosAdjustment[] | null | undefined,
+  nights: number,
+): LosAdjustment | null {
+  if (!adjustments?.length || !(nights > 0)) return null;
+
+  const qualifying = adjustments
+    .filter((a) => nights >= a.minNights)
+    .sort((a, b) => b.minNights - a.minNights);
+
+  return qualifying[0] ?? null;
+}
+
+/** Pick the band that contains occupancyPct (0–100 scale). */
+export function selectOccupancyBand(
+  bands: OccupancyBand[] | null | undefined,
+  occupancyPct: number,
+): OccupancyBand | null {
+  if (!bands?.length) return null;
+
+  return (
+    bands.find(
+      (b) => occupancyPct >= b.occupancyPctMin && occupancyPct <= b.occupancyPctMax,
+    ) ?? null
+  );
+}
+
+export function applyRateAdjustment(
+  baseRate: number,
+  rule: RateAdjustmentRule,
+): number {
+  if (rule.adjustmentType === 'percentage') {
+    return baseRate * (1 + rule.adjustmentValue / 100);
+  }
+  return baseRate + rule.adjustmentValue;
+}
+
+export function nightsBetween(checkIn: string, checkOut: string): number {
+  return Math.ceil(
+    (new Date(checkOut).getTime() - new Date(checkIn).getTime()) / 86_400_000,
+  );
+}

--- a/apps/api/src/modules/reports/reports.controller.ts
+++ b/apps/api/src/modules/reports/reports.controller.ts
@@ -43,6 +43,7 @@ export class ReportsController {
         'financial-summary',
         'trial-balance',
         'occupancy-trend',
+        'pickup',
       ],
     };
   }
@@ -102,6 +103,21 @@ export class ReportsController {
     @Query('endDate') endDate: string,
   ) {
     return this.reportsService.getOccupancyTrend(propertyId, startDate, endDate);
+  }
+
+  @Get('/pickup')
+  @ApiOperation({ summary: 'Pickup report — room nights gained/lost for a stay date' })
+  @ApiQuery({ name: 'propertyId', required: true })
+  @ApiQuery({ name: 'stayDate', required: true, description: 'Stay night to measure pickup for' })
+  @ApiQuery({ name: 'from', required: true, description: 'Start of booking window (ISO date)' })
+  @ApiQuery({ name: 'to', required: true, description: 'End of booking window (ISO date)' })
+  async getPickup(
+    @Query('propertyId', ParseUUIDPipe) propertyId: string,
+    @Query('stayDate') stayDate: string,
+    @Query('from') from: string,
+    @Query('to') to: string,
+  ) {
+    return this.reportsService.getPickup(propertyId, stayDate, from, to);
   }
 
   @Get('/portfolio/financial-summary')

--- a/apps/api/src/modules/reports/reports.service.spec.ts
+++ b/apps/api/src/modules/reports/reports.service.spec.ts
@@ -400,4 +400,41 @@ describe('ReportsService', () => {
     expect(result.summary.totalRevenue).toBe(10000);
     expect(result.summary.totalRoomNights).toBe(100);
   });
+
+  it('should compute pickup baseline, current, and daily net', async () => {
+    const db = createMockDb([
+      [{ count: 40 }],
+      [{ count: 47 }],
+      [
+        { date: '2026-07-01', roomNights: 5 },
+        { date: '2026-07-02', roomNights: 3 },
+      ],
+      [{ date: '2026-07-02', roomNights: 1 }],
+    ]);
+    const module = await Test.createTestingModule({
+      providers: [
+        ReportsService,
+        { provide: DRIZZLE, useValue: db },
+      ],
+    }).compile();
+    service = module.get(ReportsService);
+
+    const result = await service.getPickup(
+      'prop-001',
+      '2026-08-15',
+      '2026-07-01',
+      '2026-07-07',
+    );
+
+    expect(result.stayDate).toBe('2026-08-15');
+    expect(result.baseline.roomNights).toBe(40);
+    expect(result.current.roomNights).toBe(47);
+    expect(result.pickup.roomNights).toBe(7);
+    expect(result.daily).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ date: '2026-07-01', roomNightsAdded: 5, netPickup: 5 }),
+        expect.objectContaining({ date: '2026-07-02', roomNightsAdded: 3, roomNightsLost: 1, netPickup: 2 }),
+      ]),
+    );
+  });
 });

--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -771,4 +771,113 @@ export class ReportsService {
       byProperty,
     };
   }
+
+  /**
+   * Pickup report — room nights on a stay date gained or lost over a booking window.
+   * Compares on-the-books room nights at the start vs end of the period, with a
+   * daily breakdown of additions (by createdAt) and losses (by cancelledAt).
+   */
+  async getPickup(propertyId: string, stayDate: string, from: string, to: string) {
+    const coversStayDate = and(
+      eq(reservations.propertyId, propertyId),
+      lte(reservations.arrivalDate, stayDate),
+      sql`${reservations.departureDate} > ${stayDate}`,
+    );
+
+    const activeAsOf = (asOfDate: string) =>
+      and(
+        coversStayDate,
+        sql`${reservations.createdAt}::date <= ${asOfDate}`,
+        sql`(${reservations.cancelledAt} is null or ${reservations.cancelledAt}::date > ${asOfDate})`,
+        sql`${reservations.status} not in ('no_show')`,
+      );
+
+    const [baselineRow] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(reservations)
+      .where(
+        and(
+          coversStayDate,
+          sql`${reservations.createdAt}::date < ${from}`,
+          sql`(${reservations.cancelledAt} is null or ${reservations.cancelledAt}::date >= ${from})`,
+          sql`${reservations.status} not in ('cancelled', 'no_show')`,
+        ),
+      );
+
+    const [currentRow] = await this.db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(reservations)
+      .where(activeAsOf(to));
+
+    const baselineRoomNights = baselineRow?.count ?? 0;
+    const currentRoomNights = currentRow?.count ?? 0;
+
+    const dailyAdded = await this.db
+      .select({
+        date: sql<string>`${reservations.createdAt}::date`,
+        roomNights: sql<number>`count(*)::int`,
+      })
+      .from(reservations)
+      .where(
+        and(
+          coversStayDate,
+          sql`${reservations.createdAt}::date >= ${from}`,
+          sql`${reservations.createdAt}::date <= ${to}`,
+          sql`${reservations.status} not in ('cancelled', 'no_show')`,
+        ),
+      )
+      .groupBy(sql`${reservations.createdAt}::date`)
+      .orderBy(sql`${reservations.createdAt}::date`);
+
+    const dailyLost = await this.db
+      .select({
+        date: sql<string>`${reservations.cancelledAt}::date`,
+        roomNights: sql<number>`count(*)::int`,
+      })
+      .from(reservations)
+      .where(
+        and(
+          coversStayDate,
+          eq(reservations.status, 'cancelled' as any),
+          sql`${reservations.cancelledAt}::date >= ${from}`,
+          sql`${reservations.cancelledAt}::date <= ${to}`,
+        ),
+      )
+      .groupBy(sql`${reservations.cancelledAt}::date`)
+      .orderBy(sql`${reservations.cancelledAt}::date`);
+
+    const dailyMap = new Map<string, { roomNightsAdded: number; roomNightsLost: number }>();
+
+    for (const row of dailyAdded) {
+      const dateKey = typeof row.date === 'string' ? row.date : new Date(row.date).toISOString().split('T')[0]!;
+      const entry = dailyMap.get(dateKey) ?? { roomNightsAdded: 0, roomNightsLost: 0 };
+      entry.roomNightsAdded = row.roomNights;
+      dailyMap.set(dateKey, entry);
+    }
+
+    for (const row of dailyLost) {
+      const dateKey = typeof row.date === 'string' ? row.date : new Date(row.date).toISOString().split('T')[0]!;
+      const entry = dailyMap.get(dateKey) ?? { roomNightsAdded: 0, roomNightsLost: 0 };
+      entry.roomNightsLost = row.roomNights;
+      dailyMap.set(dateKey, entry);
+    }
+
+    const daily = [...dailyMap.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([date, counts]) => ({
+        date,
+        roomNightsAdded: counts.roomNightsAdded,
+        roomNightsLost: counts.roomNightsLost,
+        netPickup: counts.roomNightsAdded - counts.roomNightsLost,
+      }));
+
+    return {
+      stayDate,
+      period: { from, to },
+      baseline: { roomNights: baselineRoomNights },
+      current: { roomNights: currentRoomNights },
+      pickup: { roomNights: currentRoomNights - baselineRoomNights },
+      daily,
+    };
+  }
 }

--- a/apps/dashboard/src/locales/en.json
+++ b/apps/dashboard/src/locales/en.json
@@ -655,6 +655,8 @@
     "tabs": {
       "analytics": "Analytics",
       "dashboard": "Dashboard",
+      "lostFound": "Lost & Found",
+      "serviceRequests": "Service Requests",
       "tasks": "Tasks"
     },
     "taskForRoom": "Task — Room {{number}}",
@@ -667,7 +669,42 @@
     },
     "tasksCompleted": "Tasks Completed",
     "title": "Housekeeping",
-    "type": "Type"
+    "type": "Type",
+    "lostFound": {
+      "title": "Lost & Found",
+      "tagCode": "Tag",
+      "description": "Description",
+      "foundAt": "Found",
+      "disposeAfter": "Dispose after",
+      "noItems": "No items logged",
+      "logItem": "Log item",
+      "statuses": {
+        "held": "Held",
+        "returned": "Returned",
+        "disposed": "Disposed"
+      }
+    },
+    "serviceRequests": {
+      "title": "Service Requests",
+      "createTask": "Create task",
+      "noRequests": "No service requests",
+      "newRequest": "New request",
+      "statuses": {
+        "open": "Open",
+        "in_progress": "In Progress",
+        "done": "Done",
+        "cancelled": "Cancelled"
+      },
+      "types": {
+        "maintenance": "Maintenance",
+        "turndown": "Turndown",
+        "deep_clean": "Deep Clean",
+        "checkout": "Checkout",
+        "stayover": "Stayover",
+        "inspection": "Inspection",
+        "service_request": "General"
+      }
+    }
   },
   "import": {
     "choose": "1. Choose what to import",
@@ -827,6 +864,10 @@
         "manage": "Assign / Inspect Housekeeping",
         "read": "View Housekeeping"
       },
+      "ops": {
+        "manage": "Manage Property Ops",
+        "read": "View Property Ops"
+      },
       "media": {
         "manage": "Manage Property Photos"
       },
@@ -917,6 +958,15 @@
     "noTrend": "No trend data available",
     "occupancy": "Occupancy",
     "occupancyTrend": "Occupancy Trend",
+    "pickup": "Pickup",
+    "stayDate": "Stay Date",
+    "baselineRoomNights": "Baseline Room Nights",
+    "currentRoomNights": "Current Room Nights",
+    "netPickup": "Net Pickup",
+    "dailyPickup": "Daily Pickup",
+    "added": "Added",
+    "lost": "Lost",
+    "noPickup": "No pickup activity in this period",
     "occupied": "Occupied",
     "otherRevenue": "Other Revenue",
     "portfolioNotice": "Daily revenue and occupancy trend are per-property reports.",
@@ -1141,7 +1191,14 @@
     "selectProperty": "Select a property to view rooms",
     "selectType": "Select type",
     "title": "Rooms",
-    "type": "Type"
+    "type": "Type",
+    "discrepancies": {
+      "title": "Room status discrepancies",
+      "none": "No discrepancies for this date",
+      "occupiedWithoutReservation": "Occupied without in-house reservation",
+      "vacantWithReservation": "Vacant with in-house reservation",
+      "count": "{{count}} discrepancy(ies)"
+    }
   },
   "search": {
     "allPropertiesPlaceholder": "Search all properties…",

--- a/apps/dashboard/src/locales/pt-BR.json
+++ b/apps/dashboard/src/locales/pt-BR.json
@@ -579,6 +579,8 @@
     "tabs": {
       "analytics": "Análises",
       "dashboard": "Painel",
+      "lostFound": "Achados e perdidos",
+      "serviceRequests": "Solicitações de serviço",
       "tasks": "Tarefas"
     },
     "taskForRoom": "Tarefa — Quarto {{number}}",
@@ -591,7 +593,42 @@
     },
     "tasksCompleted": "Tarefas concluídas",
     "title": "Governança",
-    "type": "Tipo"
+    "type": "Tipo",
+    "lostFound": {
+      "title": "Achados e perdidos",
+      "tagCode": "Etiqueta",
+      "description": "Descrição",
+      "foundAt": "Encontrado em",
+      "disposeAfter": "Descartar após",
+      "noItems": "Nenhum item registrado",
+      "logItem": "Registrar item",
+      "statuses": {
+        "held": "Em guarda",
+        "returned": "Devolvido",
+        "disposed": "Descartado"
+      }
+    },
+    "serviceRequests": {
+      "title": "Solicitações de serviço",
+      "createTask": "Criar tarefa",
+      "noRequests": "Nenhuma solicitação",
+      "newRequest": "Nova solicitação",
+      "statuses": {
+        "open": "Aberta",
+        "in_progress": "Em andamento",
+        "done": "Concluída",
+        "cancelled": "Cancelada"
+      },
+      "types": {
+        "maintenance": "Manutenção",
+        "turndown": "Serviço noturno",
+        "deep_clean": "Limpeza profunda",
+        "checkout": "Saída",
+        "stayover": "Permanência",
+        "inspection": "Inspeção",
+        "service_request": "Geral"
+      }
+    }
   },
   "import": {
     "choose": "1. Escolha o que importar",
@@ -750,6 +787,10 @@
         "manage": "Atribuir / inspecionar a governança",
         "read": "Ver governança"
       },
+      "ops": {
+        "manage": "Gerenciar operações da propriedade",
+        "read": "Ver operações da propriedade"
+      },
       "media": {
         "manage": "Gerenciar fotos"
       },
@@ -840,6 +881,15 @@
     "noTrend": "Não há dados de tendência disponíveis",
     "occupancy": "Ocupação",
     "occupancyTrend": "Tendência de ocupação",
+    "pickup": "Pickup",
+    "stayDate": "Data da estadia",
+    "baselineRoomNights": "Diárias base",
+    "currentRoomNights": "Diárias atuais",
+    "netPickup": "Pickup líquido",
+    "dailyPickup": "Pickup diário",
+    "added": "Adicionadas",
+    "lost": "Perdidas",
+    "noPickup": "Sem atividade de pickup no período",
     "occupied": "Ocupados",
     "otherRevenue": "Outras receitas",
     "portfolioNotice": "A receita diária e a tendência de ocupação são relatórios por propriedade.",
@@ -1060,7 +1110,14 @@
     "selectProperty": "Selecione uma propriedade para ver os quartos",
     "selectType": "Selecione o tipo",
     "title": "Quartos",
-    "type": "Tipo"
+    "type": "Tipo",
+    "discrepancies": {
+      "title": "Divergências de status do quarto",
+      "none": "Nenhuma divergência para esta data",
+      "occupiedWithoutReservation": "Ocupado sem reserva em casa",
+      "vacantWithReservation": "Vago com reserva em casa",
+      "count": "{{count}} divergência(s)"
+    }
   },
   "search": {
     "allPropertiesPlaceholder": "Pesquisar todas as propriedades…",

--- a/apps/dashboard/src/pages/RatePlans.tsx
+++ b/apps/dashboard/src/pages/RatePlans.tsx
@@ -480,7 +480,6 @@ function RatePlanDetail() {
   const { t } = useTranslation();
   const { propertyId } = useProperty();
   const { id } = useParams<{ id: string }>();
-  const { propertyId } = useProperty();
   const navigate = useNavigate();
   const [testDate, setTestDate] = useState('');
   const [testNights, setTestNights] = useState('7');
@@ -495,24 +494,18 @@ function RatePlanDetail() {
   const plan: RatePlan | null = data?.data ?? data ?? null;
 
   const testMutation = useMutation({
-<<<<<<< HEAD
     mutationFn: () => {
       requirePropertyId(propertyId);
       return api.get(`/v1/rate-plans/${id}/effective-rate`, {
-        params: { propertyId, date: testDate || undefined },
-      });
-    },
-=======
-    mutationFn: () =>
-      api.get(`/v1/rate-plans/${id}/effective-rate`, {
         params: {
           propertyId,
-          checkIn: testDate,
+          date: testDate || undefined,
+          checkIn: testDate || undefined,
           nights: Number(testNights) || 1,
-          stayDate: testDate,
+          stayDate: testDate || undefined,
         },
-      }),
->>>>>>> 97e186b (feat(rates-bi): LOS/occupancy pricing and pickup report)
+      });
+    },
     onSuccess: (res) => {
       const payload = res.data?.data ?? res.data;
       setEffectiveRate(payload?.effectiveRate ?? null);
@@ -560,16 +553,10 @@ function RatePlanDetail() {
 
         <div className="bg-white rounded-xl shadow-sm p-6">
           <h2 className="text-sm font-semibold text-telivity-navy mb-3">{t('ratePlans.calculator')}</h2>
-<<<<<<< HEAD
-          <div className="flex gap-2">
-            <input type="date" value={testDate} onChange={(e) => setTestDate(e.target.value)} className="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
-            <button onClick={() => testMutation.mutate()} disabled={testMutation.isPending} className="bg-telivity-teal text-white rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-50">{t('ratePlans.calculate')}</button>
-=======
           <div className="flex gap-2 flex-wrap">
             <input type="date" value={testDate} onChange={(e) => setTestDate(e.target.value)} className="flex-1 min-w-[140px] border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
             <input type="number" min={1} value={testNights} onChange={(e) => setTestNights(e.target.value)} placeholder="Nights" className="w-24 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
             <button onClick={() => testMutation.mutate()} disabled={!testDate || !propertyId || testMutation.isPending} className="bg-telivity-teal text-white rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-50">{t('ratePlans.calculate')}</button>
->>>>>>> 97e186b (feat(rates-bi): LOS/occupancy pricing and pickup report)
           </div>
           {effectiveRate != null && (
             <div className="mt-4 bg-telivity-light-grey rounded-lg p-4 text-center">

--- a/apps/dashboard/src/pages/RatePlans.tsx
+++ b/apps/dashboard/src/pages/RatePlans.tsx
@@ -478,10 +478,12 @@ function RestrictionsPanel({ ratePlanId }: { ratePlanId: string }) {
 // ---- Rate Plan Detail ----
 function RatePlanDetail() {
   const { t } = useTranslation();
+  const { propertyId } = useProperty();
   const { id } = useParams<{ id: string }>();
   const { propertyId } = useProperty();
   const navigate = useNavigate();
   const [testDate, setTestDate] = useState('');
+  const [testNights, setTestNights] = useState('7');
   const [effectiveRate, setEffectiveRate] = useState<number | null>(null);
 
   const { data } = useQuery({
@@ -493,12 +495,24 @@ function RatePlanDetail() {
   const plan: RatePlan | null = data?.data ?? data ?? null;
 
   const testMutation = useMutation({
+<<<<<<< HEAD
     mutationFn: () => {
       requirePropertyId(propertyId);
       return api.get(`/v1/rate-plans/${id}/effective-rate`, {
         params: { propertyId, date: testDate || undefined },
       });
     },
+=======
+    mutationFn: () =>
+      api.get(`/v1/rate-plans/${id}/effective-rate`, {
+        params: {
+          propertyId,
+          checkIn: testDate,
+          nights: Number(testNights) || 1,
+          stayDate: testDate,
+        },
+      }),
+>>>>>>> 97e186b (feat(rates-bi): LOS/occupancy pricing and pickup report)
     onSuccess: (res) => {
       const payload = res.data?.data ?? res.data;
       setEffectiveRate(payload?.effectiveRate ?? null);
@@ -546,9 +560,16 @@ function RatePlanDetail() {
 
         <div className="bg-white rounded-xl shadow-sm p-6">
           <h2 className="text-sm font-semibold text-telivity-navy mb-3">{t('ratePlans.calculator')}</h2>
+<<<<<<< HEAD
           <div className="flex gap-2">
             <input type="date" value={testDate} onChange={(e) => setTestDate(e.target.value)} className="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
             <button onClick={() => testMutation.mutate()} disabled={testMutation.isPending} className="bg-telivity-teal text-white rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-50">{t('ratePlans.calculate')}</button>
+=======
+          <div className="flex gap-2 flex-wrap">
+            <input type="date" value={testDate} onChange={(e) => setTestDate(e.target.value)} className="flex-1 min-w-[140px] border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
+            <input type="number" min={1} value={testNights} onChange={(e) => setTestNights(e.target.value)} placeholder="Nights" className="w-24 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
+            <button onClick={() => testMutation.mutate()} disabled={!testDate || !propertyId || testMutation.isPending} className="bg-telivity-teal text-white rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-50">{t('ratePlans.calculate')}</button>
+>>>>>>> 97e186b (feat(rates-bi): LOS/occupancy pricing and pickup report)
           </div>
           {effectiveRate != null && (
             <div className="mt-4 bg-telivity-light-grey rounded-lg p-4 text-center">

--- a/apps/dashboard/src/pages/Reports.tsx
+++ b/apps/dashboard/src/pages/Reports.tsx
@@ -9,13 +9,14 @@ import { useProperty } from '../context/PropertyContext';
 import KpiCard from '../components/ui/KpiCard';
 import { useTranslation } from 'react-i18next';
 
-type ReportType = 'financial-summary' | 'occupancy' | 'daily-revenue' | 'occupancy-trend';
+type ReportType = 'financial-summary' | 'occupancy' | 'daily-revenue' | 'occupancy-trend' | 'pickup';
 
 const REPORT_OPTIONS: { value: ReportType; labelKey: string }[] = [
   { value: 'financial-summary', labelKey: 'financialSummary' },
   { value: 'occupancy', labelKey: 'occupancy' },
   { value: 'daily-revenue', labelKey: 'dailyRevenue' },
   { value: 'occupancy-trend', labelKey: 'occupancyTrend' },
+  { value: 'pickup', labelKey: 'pickup' },
 ];
 
 const DEMO_FAVORITES_KEY = 'haip.reportFavorites';
@@ -28,6 +29,9 @@ export default function Reports() {
   const [date, setDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [startDate, setStartDate] = useState(format(subDays(new Date(), 30), 'yyyy-MM-dd'));
   const [endDate, setEndDate] = useState(format(new Date(), 'yyyy-MM-dd'));
+  const [stayDate, setStayDate] = useState(format(subDays(new Date(), -30), 'yyyy-MM-dd'));
+  const [pickupFrom, setPickupFrom] = useState(format(subDays(new Date(), 7), 'yyyy-MM-dd'));
+  const [pickupTo, setPickupTo] = useState(format(new Date(), 'yyyy-MM-dd'));
 
   const { data: prefsData } = useQuery({
     queryKey: ['me', 'preferences'],
@@ -85,7 +89,7 @@ export default function Reports() {
     isPortfolioMode && (report === 'financial-summary' || report === 'occupancy');
 
   const { data } = useQuery({
-    queryKey: ['reports', portfolioReport ? 'portfolio' : report, propertyId, report === 'occupancy-trend' ? startDate : date, report === 'occupancy-trend' ? endDate : null],
+    queryKey: ['reports', portfolioReport ? 'portfolio' : report, propertyId, report === 'occupancy-trend' ? startDate : report === 'pickup' ? stayDate : date, report === 'occupancy-trend' ? endDate : report === 'pickup' ? pickupTo : null, report === 'pickup' ? pickupFrom : null],
     queryFn: () => {
       if (portfolioReport) {
         const path =
@@ -98,6 +102,10 @@ export default function Reports() {
       if (report === 'occupancy-trend') {
         params.startDate = startDate;
         params.endDate = endDate;
+      } else if (report === 'pickup') {
+        params.stayDate = stayDate;
+        params.from = pickupFrom;
+        params.to = pickupTo;
       } else {
         params.date = date;
       }
@@ -182,12 +190,12 @@ export default function Reports() {
             </button>
           </div>
         </div>
-        {report !== 'occupancy-trend' ? (
+        {report !== 'occupancy-trend' && report !== 'pickup' ? (
           <div>
             <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.date')}</label>
             <input type="date" value={date} onChange={(e) => setDate(e.target.value)} className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
           </div>
-        ) : (
+        ) : report === 'occupancy-trend' ? (
           <>
             <div>
               <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.from')}</label>
@@ -196,6 +204,21 @@ export default function Reports() {
             <div>
               <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.to')}</label>
               <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
+            </div>
+          </>
+        ) : (
+          <>
+            <div>
+              <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.stayDate')}</label>
+              <input type="date" value={stayDate} onChange={(e) => setStayDate(e.target.value)} className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.from')}</label>
+              <input type="date" value={pickupFrom} onChange={(e) => setPickupFrom(e.target.value)} className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('reports.to')}</label>
+              <input type="date" value={pickupTo} onChange={(e) => setPickupTo(e.target.value)} className="border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal" />
             </div>
           </>
         )}
@@ -338,6 +361,48 @@ export default function Reports() {
             </ResponsiveContainer>
           ) : (
             <p className="text-sm text-telivity-mid-grey">{t('reports.noTrend')}</p>
+          )}
+        </div>
+      )}
+
+      {/* Pickup */}
+      {report === 'pickup' && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <KpiCard title={t('reports.baselineRoomNights')} value={reportData.baseline?.roomNights ?? 0} icon={TrendingUp} />
+            <KpiCard title={t('reports.currentRoomNights')} value={reportData.current?.roomNights ?? 0} icon={TrendingUp} />
+            <KpiCard
+              title={t('reports.netPickup')}
+              value={reportData.pickup?.roomNights ?? 0}
+              icon={TrendingUp}
+            />
+          </div>
+          {Array.isArray(reportData.daily) && reportData.daily.length > 0 ? (
+            <div className="bg-white rounded-xl shadow-sm p-5 overflow-x-auto">
+              <h3 className="text-sm font-semibold text-telivity-navy mb-3">{t('reports.dailyPickup')}</h3>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-telivity-mid-grey border-b border-gray-100">
+                    <th className="pb-2 font-medium">{t('reports.date')}</th>
+                    <th className="pb-2 font-medium text-right">{t('reports.added')}</th>
+                    <th className="pb-2 font-medium text-right">{t('reports.lost')}</th>
+                    <th className="pb-2 font-medium text-right">{t('reports.netPickup')}</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(reportData.daily as Array<{ date: string; roomNightsAdded: number; roomNightsLost: number; netPickup: number }>).map((row) => (
+                    <tr key={row.date} className="border-b border-gray-50">
+                      <td className="py-2">{row.date}</td>
+                      <td className="py-2 text-right text-green-700">+{row.roomNightsAdded}</td>
+                      <td className="py-2 text-right text-red-600">-{row.roomNightsLost}</td>
+                      <td className="py-2 text-right font-medium">{row.netPickup >= 0 ? `+${row.netPickup}` : row.netPickup}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-telivity-mid-grey">{t('reports.noPickup')}</p>
           )}
         </div>
       )}

--- a/packages/database/src/migrations/0008_rates_bi_depth.sql
+++ b/packages/database/src/migrations/0008_rates_bi_depth.sql
@@ -1,0 +1,3 @@
+-- LOS and occupancy-based pricing on rate plans; revenue-management pickup reporting support.
+ALTER TABLE rate_plans ADD COLUMN IF NOT EXISTS los_adjustments jsonb;
+ALTER TABLE rate_plans ADD COLUMN IF NOT EXISTS occupancy_bands jsonb;

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -28,6 +28,9 @@ async function main() {
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'payment_status') THEN CREATE TYPE payment_status AS ENUM ('pending','authorized','captured','settled','refunded','partially_refunded','failed','voided'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'housekeeping_task_status') THEN CREATE TYPE housekeeping_task_status AS ENUM ('pending','assigned','in_progress','completed','inspected','skipped'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'housekeeping_task_type') THEN CREATE TYPE housekeeping_task_type AS ENUM ('checkout','stayover','deep_clean','inspection','turndown','maintenance'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'lost_and_found_status') THEN CREATE TYPE lost_and_found_status AS ENUM ('held','returned','disposed'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'service_request_status') THEN CREATE TYPE service_request_status AS ENUM ('open','in_progress','done','cancelled'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'service_request_type') THEN CREATE TYPE service_request_type AS ENUM ('maintenance','turndown','deep_clean','checkout','stayover','inspection','service_request'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'audit_run_status') THEN CREATE TYPE audit_run_status AS ENUM ('running','completed','failed','rolled_back'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'channel_status') THEN CREATE TYPE channel_status AS ENUM ('active','inactive','error','pending_setup'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'sync_direction') THEN CREATE TYPE sync_direction AS ENUM ('push','pull','bidirectional'); END IF; END $$`,
@@ -206,6 +209,8 @@ async function main() {
       valid_to date,
       is_active boolean NOT NULL DEFAULT true,
       channel_codes jsonb,
+      los_adjustments jsonb,
+      occupancy_bands jsonb,
       sort_order integer NOT NULL DEFAULT 0,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
@@ -369,6 +374,40 @@ async function main() {
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
     )`,
+    // lost_and_found_items
+    `CREATE TABLE IF NOT EXISTS lost_and_found_items (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      room_id uuid REFERENCES rooms(id),
+      reservation_id uuid REFERENCES reservations(id),
+      guest_id uuid REFERENCES guests(id),
+      description text NOT NULL,
+      tag_code varchar(50) NOT NULL,
+      status lost_and_found_status NOT NULL DEFAULT 'held',
+      found_at timestamptz NOT NULL DEFAULT now(),
+      dispose_after timestamptz NOT NULL,
+      notes text,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS lost_and_found_items_property_status_idx ON lost_and_found_items (property_id, status)`,
+    // service_requests
+    `CREATE TABLE IF NOT EXISTS service_requests (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      room_id uuid REFERENCES rooms(id),
+      reservation_id uuid REFERENCES reservations(id),
+      type service_request_type NOT NULL,
+      priority integer NOT NULL DEFAULT 0,
+      status service_request_status NOT NULL DEFAULT 'open',
+      title varchar(255) NOT NULL,
+      description text,
+      linked_task_id uuid REFERENCES housekeeping_tasks(id),
+      requested_by uuid,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`,
+    `CREATE INDEX IF NOT EXISTS service_requests_property_status_idx ON service_requests (property_id, status)`,
     // audit_runs
     `CREATE TABLE IF NOT EXISTS audit_runs (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1053,6 +1092,8 @@ async function main() {
     `ALTER TABLE group_profiles ADD COLUMN IF NOT EXISTS payment_terms_days varchar(10)`,
     `ALTER TABLE ar_ledgers ADD COLUMN IF NOT EXISTS group_profile_id uuid`,
     `ALTER TABLE rate_plans ADD COLUMN IF NOT EXISTS group_profile_id uuid`,
+    `ALTER TABLE rate_plans ADD COLUMN IF NOT EXISTS los_adjustments jsonb`,
+    `ALTER TABLE rate_plans ADD COLUMN IF NOT EXISTS occupancy_bands jsonb`,
   ];
   for (const a of alters) {
     await db.execute(sql.raw(a));

--- a/packages/database/src/schema/rate-plan.ts
+++ b/packages/database/src/schema/rate-plan.ts
@@ -58,6 +58,25 @@ export const ratePlans = pgTable('rate_plans', {
   // Channel distribution
   channelCodes: jsonb('channel_codes').$type<string[]>(), // Which channels this rate is distributed to
 
+  /** LOS pricing tiers: minNights → percent or fixed amount off base (7+/14+/21+ pattern). */
+  losAdjustments: jsonb('los_adjustments').$type<
+    Array<{
+      minNights: number;
+      adjustmentType: 'percentage' | 'fixed';
+      adjustmentValue: number;
+    }>
+  >(),
+
+  /** Occupancy-based pricing bands: occupancyPctMin/Max → adjustment. */
+  occupancyBands: jsonb('occupancy_bands').$type<
+    Array<{
+      occupancyPctMin: number;
+      occupancyPctMax: number;
+      adjustmentType: 'percentage' | 'fixed';
+      adjustmentValue: number;
+    }>
+  >(),
+
   // Metadata
   sortOrder: integer('sort_order').notNull().default(0),
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Rebased Slice 8/10 rates + BI depth onto current `main` (after #183). Supersedes conflicting #196.

- LOS tier and occupancy-band adjustments on rate plans (`losAdjustments`, `occupancyBands`)
- Effective-rate API accepts `nights` / `checkIn` / `stayDate` context
- `GET /reports/pickup` for stay-date room-night pickup
- Dashboard: nights in rate calculator; pickup report option
- Migration `0008_rates_bi_depth.sql`

## Test plan
- [ ] CI green
- [ ] Effective-rate with nights applies LOS tiers
- [ ] Pickup report returns room nights over window
- [ ] RatePlans detail calculator sends nights + propertyId

## Notes
- Closes/supersedes #196 (push-protected / conflicting after #183)
- If #197 (HK ops) merges first with its own `0008_*`, renumber this migration to `0009_*` before merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

