### PR TITLE
feat: self-service Connect API credential management

### DIFF
--- a/apps/api/src/modules/connect/connect-credentials.controller.ts
+++ b/apps/api/src/modules/connect/connect-credentials.controller.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { AuditActorCtx, type AuditActor } from '../../common/audit/audit-actor';
+import { RequirePermissions } from '../auth/permissions.decorator';
+import { Roles } from '../auth/roles.decorator';
+import { ConnectCredentialsService } from './connect-credentials.service';
+import { CreateConnectCredentialDto } from './dto/connect-credential.dto';
+
+@ApiTags('admin')
+@Controller('admin/connect/credentials')
+@Roles('admin')
+export class ConnectCredentialsController {
+  constructor(private readonly credentialsService: ConnectCredentialsService) {}
+
+  @Get()
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'List Connect API credentials for a property' })
+  @ApiQuery({ name: 'propertyId', required: true, type: String })
+  @ApiResponse({ status: 200, description: 'Credential metadata without plaintext keys or hashes' })
+  list(@Query('propertyId', new ParseUUIDPipe()) propertyId: string) {
+    return this.credentialsService.list(propertyId);
+  }
+
+  @Post()
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Create a Connect API credential; raw key returned once' })
+  @ApiQuery({ name: 'propertyId', required: true, type: String })
+  @ApiResponse({ status: 201, description: 'Credential metadata plus one-time raw key' })
+  create(
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+    @Body() dto: CreateConnectCredentialDto,
+    @AuditActorCtx() actor: AuditActor,
+  ) {
+    return this.credentialsService.create(propertyId, dto, actor);
+  }
+
+  @Post(':id/rotate')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Rotate a Connect API credential; new raw key returned once' })
+  @ApiQuery({ name: 'propertyId', required: true, type: String })
+  @ApiResponse({ status: 200, description: 'Credential metadata plus one-time raw key' })
+  rotate(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+    @AuditActorCtx() actor: AuditActor,
+  ) {
+    return this.credentialsService.rotate(id, propertyId, actor);
+  }
+
+  @Delete(':id')
+  @RequirePermissions('settings.manage')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Revoke a Connect API credential' })
+  @ApiQuery({ name: 'propertyId', required: true, type: String })
+  @ApiResponse({ status: 200, description: 'Credential revoked' })
+  revoke(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+    @AuditActorCtx() actor: AuditActor,
+  ) {
+    return this.credentialsService.revoke(id, propertyId, actor);
+  }
+}

--- a/apps/api/src/modules/connect/connect-credentials.service.spec.ts
+++ b/apps/api/src/modules/connect/connect-credentials.service.spec.ts
@@ -1,0 +1,214 @@
+import { NotFoundException } from '@nestjs/common';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hashConnectKey } from '../auth/api-key.guard';
+import { ConnectCredentialsService } from './connect-credentials.service';
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...conditions: any[]) => ({ op: 'and', conditions })),
+  desc: vi.fn((column: unknown) => ({ op: 'desc', column })),
+  eq: vi.fn((column: unknown, value: unknown) => ({ op: 'eq', column, value })),
+}));
+
+vi.mock('@telivityhaip/database', () => ({
+  auditLogs: {
+    __table: 'auditLogs',
+    propertyId: 'audit.propertyId',
+    action: 'audit.action',
+    entityType: 'audit.entityType',
+    entityId: 'audit.entityId',
+    description: 'audit.description',
+    newValue: 'audit.newValue',
+  },
+  connectCredentials: {
+    __table: 'connectCredentials',
+    id: 'credential.id',
+    propertyId: 'credential.propertyId',
+    label: 'credential.label',
+    scopes: 'credential.scopes',
+    keyHash: 'credential.keyHash',
+    isActive: 'credential.isActive',
+    lastUsedAt: 'credential.lastUsedAt',
+    createdAt: 'credential.createdAt',
+    revokedAt: 'credential.revokedAt',
+  },
+}));
+
+const PROP = '11111111-1111-4111-8111-111111111111';
+const OTHER_PROP = '22222222-2222-4222-8222-222222222222';
+const CRED = '33333333-3333-4333-8333-333333333333';
+const CREATED_AT = new Date('2026-01-01T00:00:00Z');
+
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    id: CRED,
+    propertyId: PROP,
+    label: 'Integration gateway',
+    scopes: ['search', 'book'],
+    isActive: true,
+    lastUsedAt: null,
+    createdAt: CREATED_AT,
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function createMockDb() {
+  const state = {
+    selectRows: [] as any[],
+    insertRows: [] as any[],
+    updateRows: [] as any[],
+    insertValues: [] as any[],
+    updateSet: undefined as any,
+    whereArgs: [] as any[],
+    auditValues: [] as any[],
+  };
+
+  const db: any = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((whereArg: any) => {
+          state.whereArgs.push(whereArg);
+          return {
+            orderBy: vi.fn(() => Promise.resolve(state.selectRows)),
+            limit: vi.fn(() => Promise.resolve(state.selectRows)),
+            then: (resolve: any, reject: any) =>
+              Promise.resolve(state.selectRows).then(resolve, reject),
+          };
+        }),
+      })),
+    })),
+    insert: vi.fn((table: unknown) => ({
+      values: vi.fn((values: any) => {
+        state.insertValues.push(values);
+        if ((table as any)?.__table === 'auditLogs') {
+          state.auditValues.push(values);
+          return Promise.resolve();
+        }
+        return {
+          returning: vi.fn(() => Promise.resolve(state.insertRows)),
+        };
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: any) => {
+        state.updateSet = values;
+        return {
+          where: vi.fn((whereArg: any) => {
+            state.whereArgs.push(whereArg);
+            return {
+              returning: vi.fn(() => Promise.resolve(state.updateRows)),
+            };
+          }),
+        };
+      }),
+    })),
+  };
+
+  return { db, state };
+}
+
+describe('ConnectCredentialsService', () => {
+  let mock: ReturnType<typeof createMockDb>;
+  let service: ConnectCredentialsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mock = createMockDb();
+    service = new ConnectCredentialsService(mock.db);
+  });
+
+  it('lists credential metadata without plaintext keys or hashes', async () => {
+    mock.state.selectRows = [row()];
+
+    const result = await service.list(PROP);
+
+    expect(result).toEqual([
+      {
+        id: CRED,
+        name: 'Integration gateway',
+        propertyId: PROP,
+        scopes: ['search', 'book'],
+        createdAt: CREATED_AT,
+        lastUsedAt: null,
+        revoked: false,
+      },
+    ]);
+    expect(result[0]).not.toHaveProperty('key');
+    expect(result[0]).not.toHaveProperty('keyHash');
+    expect(mock.state.whereArgs[0]).toEqual({
+      op: 'eq',
+      column: 'credential.propertyId',
+      value: PROP,
+    });
+  });
+
+  it('creates a credential, stores only the sha256 hash, and audits redacted metadata', async () => {
+    mock.state.insertRows = [row()];
+
+    const result = await service.create(
+      PROP,
+      { name: 'Integration gateway', scopes: ['search', 'book'] },
+      { userId: 'user-1', userEmail: 'admin@example.com', ipAddress: '127.0.0.1' },
+    );
+
+    expect(result.key).toMatch(/^ck_live_/);
+    expect(result).not.toHaveProperty('keyHash');
+    expect(mock.state.insertValues[0]).toMatchObject({
+      propertyId: PROP,
+      label: 'Integration gateway',
+      scopes: ['search', 'book'],
+      keyHash: hashConnectKey(result.key),
+    });
+    expect(mock.state.insertValues[0]).not.toHaveProperty('key');
+    expect(mock.state.auditValues[0]).toMatchObject({
+      propertyId: PROP,
+      action: 'create',
+      entityType: 'connect_credential',
+      entityId: CRED,
+      description: 'connect_credential.created',
+      userId: 'user-1',
+      userEmail: 'admin@example.com',
+      ipAddress: '127.0.0.1',
+    });
+    expect(mock.state.auditValues[0].newValue).not.toHaveProperty('key');
+    expect(mock.state.auditValues[0].newValue).not.toHaveProperty('keyHash');
+  });
+
+  it('revokes credentials using id and propertyId tenant scope', async () => {
+    mock.state.updateRows = [row({ isActive: false, revokedAt: new Date('2026-01-02T00:00:00Z') })];
+
+    const result = await service.revoke(CRED, PROP);
+
+    expect(result).toEqual({ revoked: true, id: CRED });
+    expect(mock.state.updateSet).toMatchObject({ isActive: false });
+    expect(mock.state.updateSet.revokedAt).toBeInstanceOf(Date);
+    expect(mock.state.whereArgs[0]).toEqual({
+      op: 'and',
+      conditions: [
+        { op: 'eq', column: 'credential.id', value: CRED },
+        { op: 'eq', column: 'credential.propertyId', value: PROP },
+      ],
+    });
+    expect(mock.state.auditValues[0]).toMatchObject({
+      propertyId: PROP,
+      action: 'delete',
+      entityType: 'connect_credential',
+      entityId: CRED,
+      description: 'connect_credential.revoked',
+    });
+  });
+
+  it('does not revoke a credential in another tenant', async () => {
+    mock.state.updateRows = [];
+
+    await expect(service.revoke(CRED, OTHER_PROP)).rejects.toBeInstanceOf(NotFoundException);
+    expect(mock.state.whereArgs[0]).toEqual({
+      op: 'and',
+      conditions: [
+        { op: 'eq', column: 'credential.id', value: CRED },
+        { op: 'eq', column: 'credential.propertyId', value: OTHER_PROP },
+      ],
+    });
+    expect(mock.state.auditValues).toEqual([]);
+  });
+});

--- a/apps/api/src/modules/connect/connect-credentials.service.ts
+++ b/apps/api/src/modules/connect/connect-credentials.service.ts
@@ -1,0 +1,174 @@
+import { BadRequestException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
+import { and, desc, eq } from 'drizzle-orm';
+import { auditLogs, connectCredentials } from '@telivityhaip/database';
+import { actorFields, type AuditActor } from '../../common/audit/audit-actor';
+import { DRIZZLE } from '../../database/database.module';
+import { hashConnectKey } from '../auth/api-key.guard';
+import type { CreateConnectCredentialDto } from './dto/connect-credential.dto';
+
+export interface ConnectCredentialMetadata {
+  id: string;
+  name: string;
+  propertyId: string;
+  scopes: string[];
+  createdAt: Date;
+  lastUsedAt: Date | null;
+  revoked: boolean;
+}
+
+function generateConnectKey(): string {
+  return `ck_live_${randomBytes(32).toString('base64url')}`;
+}
+
+@Injectable()
+export class ConnectCredentialsService {
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  private toMetadata(row: any): ConnectCredentialMetadata {
+    return {
+      id: row.id,
+      name: row.label,
+      propertyId: row.propertyId,
+      scopes: Array.isArray(row.scopes) ? row.scopes : [],
+      createdAt: row.createdAt,
+      lastUsedAt: row.lastUsedAt ?? null,
+      revoked: row.isActive === false || row.revokedAt != null,
+    };
+  }
+
+  async list(propertyId: string): Promise<ConnectCredentialMetadata[]> {
+    const rows = await this.db
+      .select({
+        id: connectCredentials.id,
+        label: connectCredentials.label,
+        propertyId: connectCredentials.propertyId,
+        scopes: connectCredentials.scopes,
+        isActive: connectCredentials.isActive,
+        lastUsedAt: connectCredentials.lastUsedAt,
+        createdAt: connectCredentials.createdAt,
+        revokedAt: connectCredentials.revokedAt,
+      })
+      .from(connectCredentials)
+      .where(eq(connectCredentials.propertyId, propertyId))
+      .orderBy(desc(connectCredentials.createdAt));
+
+    return rows.map((row: any) => this.toMetadata(row));
+  }
+
+  async create(
+    propertyId: string,
+    dto: CreateConnectCredentialDto,
+    actor?: AuditActor,
+  ): Promise<ConnectCredentialMetadata & { key: string }> {
+    const key = generateConnectKey();
+    const [row] = await this.db
+      .insert(connectCredentials)
+      .values({
+        propertyId,
+        label: dto.name,
+        scopes: dto.scopes ?? [],
+        keyHash: hashConnectKey(key),
+      })
+      .returning({
+        id: connectCredentials.id,
+        label: connectCredentials.label,
+        propertyId: connectCredentials.propertyId,
+        scopes: connectCredentials.scopes,
+        isActive: connectCredentials.isActive,
+        lastUsedAt: connectCredentials.lastUsedAt,
+        createdAt: connectCredentials.createdAt,
+        revokedAt: connectCredentials.revokedAt,
+      });
+
+    const metadata = this.toMetadata(row);
+    await this.audit('create', propertyId, row.id, 'connect_credential.created', metadata, actor);
+    return { ...metadata, key };
+  }
+
+  async rotate(
+    id: string,
+    propertyId: string,
+    actor?: AuditActor,
+  ): Promise<ConnectCredentialMetadata & { key: string }> {
+    const [existing] = await this.db
+      .select({
+        id: connectCredentials.id,
+        isActive: connectCredentials.isActive,
+        revokedAt: connectCredentials.revokedAt,
+      })
+      .from(connectCredentials)
+      .where(and(eq(connectCredentials.id, id), eq(connectCredentials.propertyId, propertyId)))
+      .limit(1);
+    if (!existing) {
+      throw new NotFoundException(`Connect credential ${id} not found`);
+    }
+    if (existing.isActive === false || existing.revokedAt != null) {
+      throw new BadRequestException('Revoked credentials cannot be rotated');
+    }
+
+    const key = generateConnectKey();
+    const [row] = await this.db
+      .update(connectCredentials)
+      .set({ keyHash: hashConnectKey(key) })
+      .where(and(eq(connectCredentials.id, id), eq(connectCredentials.propertyId, propertyId)))
+      .returning({
+        id: connectCredentials.id,
+        label: connectCredentials.label,
+        propertyId: connectCredentials.propertyId,
+        scopes: connectCredentials.scopes,
+        isActive: connectCredentials.isActive,
+        lastUsedAt: connectCredentials.lastUsedAt,
+        createdAt: connectCredentials.createdAt,
+        revokedAt: connectCredentials.revokedAt,
+      });
+
+    const metadata = this.toMetadata(row);
+    await this.audit('update', propertyId, id, 'connect_credential.rotated', metadata, actor);
+    return { ...metadata, key };
+  }
+
+  async revoke(id: string, propertyId: string, actor?: AuditActor) {
+    const [row] = await this.db
+      .update(connectCredentials)
+      .set({ isActive: false, revokedAt: new Date() })
+      .where(and(eq(connectCredentials.id, id), eq(connectCredentials.propertyId, propertyId)))
+      .returning({
+        id: connectCredentials.id,
+        label: connectCredentials.label,
+        propertyId: connectCredentials.propertyId,
+        scopes: connectCredentials.scopes,
+        isActive: connectCredentials.isActive,
+        lastUsedAt: connectCredentials.lastUsedAt,
+        createdAt: connectCredentials.createdAt,
+        revokedAt: connectCredentials.revokedAt,
+      });
+
+    if (!row) {
+      throw new NotFoundException(`Connect credential ${id} not found`);
+    }
+
+    const metadata = this.toMetadata(row);
+    await this.audit('delete', propertyId, id, 'connect_credential.revoked', metadata, actor);
+    return { revoked: true, id };
+  }
+
+  private async audit(
+    action: 'create' | 'update' | 'delete',
+    propertyId: string,
+    entityId: string,
+    description: string,
+    newValue: ConnectCredentialMetadata,
+    actor?: AuditActor,
+  ) {
+    await this.db.insert(auditLogs).values({
+      propertyId,
+      action,
+      entityType: 'connect_credential',
+      entityId,
+      description,
+      newValue,
+      ...actorFields(actor),
+    });
+  }
+}

--- a/apps/api/src/modules/connect/connect.module.ts
+++ b/apps/api/src/modules/connect/connect.module.ts
@@ -5,6 +5,8 @@ import { ConnectContentService } from './connect-content.service';
 import { ConnectBookingService } from './connect-booking.service';
 import { ConnectEventsService } from './connect-events.service';
 import { ConnectInsightsService } from './connect-insights.service';
+import { ConnectCredentialsController } from './connect-credentials.controller';
+import { ConnectCredentialsService } from './connect-credentials.service';
 import { ReservationModule } from '../reservation/reservation.module';
 import { WebhookModule } from '../webhook/webhook.module';
 import { AuthModule } from '../auth/auth.module';
@@ -13,13 +15,14 @@ import { PolicyModule } from '../policy/policy.module';
 
 @Module({
   imports: [ReservationModule, WebhookModule, AuthModule, RatePlanModule, PolicyModule],
-  controllers: [ConnectController],
+  controllers: [ConnectController, ConnectCredentialsController],
   providers: [
     ConnectSearchService,
     ConnectContentService,
     ConnectBookingService,
     ConnectEventsService,
     ConnectInsightsService,
+    ConnectCredentialsService,
   ],
   exports: [ConnectSearchService, ConnectBookingService],
 })

--- a/apps/api/src/modules/connect/dto/connect-credential.dto.ts
+++ b/apps/api/src/modules/connect/dto/connect-credential.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateConnectCredentialDto {
+  @ApiProperty({ example: 'Integration gateway' })
+  @IsString()
+  @MaxLength(200)
+  name!: string;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description: 'Opaque capability labels stored as credential metadata',
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @MaxLength(100, { each: true })
+  scopes?: string[];
+}

--- a/packages/database/src/migrations/0012_connect_credential_scopes.sql
+++ b/packages/database/src/migrations/0012_connect_credential_scopes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "connect_credentials"
+  ADD COLUMN IF NOT EXISTS "scopes" jsonb NOT NULL DEFAULT '[]'::jsonb;

--- a/packages/database/src/schema/connect.ts
+++ b/packages/database/src/schema/connect.ts
@@ -74,6 +74,7 @@ export const connectCredentials = pgTable('connect_credentials', {
   id: uuid('id').primaryKey().defaultRandom(),
   propertyId: uuid('property_id').notNull().references(() => properties.id),
   label: varchar('label', { length: 200 }).notNull(),
+  scopes: jsonb('scopes').$type<string[]>().notNull().default([]),
   // sha256(raw key), hex-encoded. Raw key shown to the operator ONCE on creation.
   keyHash: varchar('key_hash', { length: 64 }).notNull().unique(),
   isActive: boolean('is_active').notNull().default(true),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Self-service **Connect API credentials** for property admins:

- Create / list / rotate / revoke endpoints (JWT-authenticated; plaintext key returned once on create/rotate)
- Keys stored as sha256 only; all queries scoped by `propertyId`
- Audit logging on mutations; Swagger on controller
- Migration `0012_connect_credential_scopes.sql` for scopes support

## Test plan

- [x] `vitest` connect-credentials + api-key.guard (12 tests)
- [x] API typecheck
- [ ] Manual: create key → call Connect with `x-api-key` → revoke → 401
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

