### PR TITLE
docs: remove Brazil from fiscal/compliance public surface

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -13,7 +13,7 @@ Resources: [integration recipes](integrations/) and [webhooks](webhooks.md).
 
 ## Built for compliance, worldwide
 
-Selling rooms is global; receipts and guest registration are local law. HAIP treats government compliance as a first-class integration category across Europe and Latin America: fiscalization and e-invoicing (Italy SDI, Greece myDATA, Poland KSeF, Hungary NAV, Spain VeriFactu/SII, Portugal, Germany TSE, Austria RKSV, the Balkans, Mexico CFDI, Colombia DIAN, Brazil, Chile, Argentina and more) and mandatory guest registration (Serbia eTurista, Croatia eVisitor, Italy Alloggiati Web, Czechia Ubyport, Spain SES Hospedajes, Hungary VIZA, Finland traveller notification, Colombia SIRE, Brazil FNRH). Where a country has no mandate, or a mandate with no digital channel, that's documented too - no compliance theater.
+Selling rooms is global; receipts and guest registration are local law. HAIP treats government compliance as a first-class integration category across Europe and Latin America: fiscalization and e-invoicing (Italy SDI, Greece myDATA, Poland KSeF, Hungary NAV, Spain VeriFactu/SII, Portugal, Germany TSE, Austria RKSV, the Balkans, Mexico CFDI, Colombia DIAN, Chile, Argentina and more) and mandatory guest registration (Serbia eTurista, Croatia eVisitor, Italy Alloggiati Web, Czechia Ubyport, Spain SES Hospedajes, Hungary VIZA, Finland traveller notification, Colombia SIRE). Where a country has no mandate, or a mandate with no digital channel, that's documented too - no compliance theater.
 
 ## Integration catalog
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -27,8 +27,8 @@ Create a subscription with the events you want (wildcards supported):
 POST /api/v1/connect/subscriptions
 {
   "propertyId": "0d0af5aa-…",
-  "subscriberId": "br-compliance-service",
-  "subscriberName": "Brazil Compliance Service",
+  "subscriberId": "rs-compliance-service",
+  "subscriberName": "Serbia Compliance Service",
   "callbackUrl": "https://compliance.example.com/haip-events",
   "events": ["reservation.checked_in", "reservation.checked_out", "invoice.*"],
   "secret": "a-long-random-hmac-secret-you-keep"
@@ -128,14 +128,14 @@ recommended safety net for compliance-critical integrations.
 
 ## Fiscal documents (`invoice.*`)
 
-For jurisdictions that require official tax documents (e.g. NFS-e tax notes in
-Brazil), HAIP stores a **fiscal document reference** on the folio and emits
+For jurisdictions that require official tax documents (e.g. SUF/ESIR fiscal
+receipts in Serbia), HAIP stores a **fiscal document reference** on the folio and emits
 `invoice.*` events. Core contains no regional tax logic — issuance is
 performed by an external integration:
 
 1. Staff (or an automation) requests a document:
    `POST /api/v1/folios/:folioId/fiscal-documents`
-   `{ "propertyId": "…", "documentType": "nfse", "metadata": { … } }`
+   `{ "propertyId": "…", "documentType": "serbia_suf_esir", "metadata": { … } }`
    → HAIP emits **`invoice.requested`** (entity: `fiscal_document`).
 2. Your integration receives the event, fetches the folio and charges, and
    issues the document against the government/tax-authority API.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Carve Brazil out for the local contributor. Worldwide country packs remain. Serbia is one pack, not the only pack.

Retarget this same PR head to `cursor/integrations-fiscal-no-brazil-ci-aeea` (repo freezes refs after first push).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

