### PR TITLE
fix: honest shipped/adapter statuses for Wave 1–2 integrations

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -19,6 +19,19 @@ Selling rooms is global; receipts and guest registration are local law. HAIP tre
 
 19 categories, ~230 integrations, phased: automation/notifications/email/BI/standards first; vendor adapters next; certified distribution and country compliance as onboarding/market entry demand.
 
+### Catalog status (registry)
+
+The property Integrations dashboard / `GET /api/v1/admin/integrations` uses four statuses — **not** “only shipped counts”:
+
+| Status | Meaning |
+|--------|---------|
+| `shipped` | In-product path you can enable (payments, channels, locks, SMS/email, etc.) |
+| `adapter` | Provider key wired (often console/demo until partner credentials / authority clients) |
+| `recipe` | Works today via docs + existing REST/webhooks/CSV/SQL — no vendor SDK required |
+| `planned` | Partner/cert or country pack not started yet |
+
+The flat list below is the full public surface. Registry seed status is the maturity filter on top of that list.
+
 ### Channel Managers
 
 - **pmsXchange (SiteMinder)** - Channel manager connectivity for rates, availability, restrictions, reservations, and inventory updates through SiteMinder's PMS exchange model.

--- a/docs/integrations/wave3-partner-surface.md
+++ b/docs/integrations/wave3-partner-surface.md
@@ -2,6 +2,8 @@
 
 Wave 3 items are **new surface / partner processes**: start partner applications and certification where required; implement adapters when credentials and domain docs exist. They appear in the integration registry as `planned` (or `adapter` when a console handoff key is wired).
 
+Status meanings: see [INTEGRATIONS.md — Catalog status](../INTEGRATIONS.md#catalog-status-registry). `shipped` = in-product path; `adapter` often means console until partner/authority clients; `recipe` = docs on existing APIs; `planned` = not started.
+
 After `pnpm migrate` / push-schema, browse `GET /api/v1/admin/integrations` (and the property Integrations dashboard).
 
 ## Category buckets (146)

--- a/packages/database/src/schema/integration-registry-seed.ts
+++ b/packages/database/src/schema/integration-registry-seed.ts
@@ -13,7 +13,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'pmsxchange-siteminder',
     category: 'Channel Managers',
     name: 'pmsXchange (SiteMinder)',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/INTEGRATIONS.md#channel-managers',
     adapterKey: 'siteminder',
     description:
@@ -23,7 +23,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'derbysoft-property-connector',
     category: 'Channel Managers',
     name: 'DerbySoft Property Connector',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/INTEGRATIONS.md#channel-managers',
     adapterKey: 'derbysoft',
     description:
@@ -33,7 +33,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'beds24',
     category: 'Channel Managers',
     name: 'Beds24',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/channel-beds24-channex.md',
     adapterKey: 'beds24',
     description:
@@ -43,7 +43,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'channex',
     category: 'Channel Managers',
     name: 'Channex',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/channel-beds24-channex.md',
     adapterKey: 'channex',
     description:
@@ -343,7 +343,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'adyen',
     category: 'Payments',
     name: 'Adyen',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/payments-adyen-mollie-square-braintree.md',
     adapterKey: 'adyen',
     description:
@@ -353,7 +353,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'mollie',
     category: 'Payments',
     name: 'Mollie',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/payments-adyen-mollie-square-braintree.md',
     adapterKey: 'mollie',
     description:
@@ -363,7 +363,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'square',
     category: 'Payments',
     name: 'Square',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/payments-adyen-mollie-square-braintree.md',
     adapterKey: 'square',
     description:
@@ -373,7 +373,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'braintree',
     category: 'Payments',
     name: 'Braintree standalone',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/payments-adyen-mollie-square-braintree.md',
     adapterKey: 'braintree',
     description:
@@ -393,7 +393,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'infobip-omnichannel',
     category: 'Guest Messaging',
     name: 'Infobip Omnichannel',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/messaging-infobip-vonage-telegram.md',
     adapterKey: 'infobip',
     description:
@@ -403,7 +403,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'vonage-messages',
     category: 'Guest Messaging',
     name: 'Vonage Messages',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/messaging-infobip-vonage-telegram.md',
     adapterKey: 'vonage',
     description:
@@ -413,7 +413,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'telegram-bot',
     category: 'Guest Messaging',
     name: 'Telegram Bot',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/messaging-infobip-vonage-telegram.md',
     adapterKey: 'telegram',
     description:
@@ -423,7 +423,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'bird',
     category: 'Guest Messaging',
     name: 'Bird',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/bird-sms.md',
     adapterKey: 'bird',
     description:
@@ -523,7 +523,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'sendgrid',
     category: 'Email, Marketing & CRM',
     name: 'SendGrid',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/sendgrid-email.md',
     adapterKey: 'sendgrid',
     description:
@@ -623,7 +623,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'google-business-profile-reviews',
     category: 'Reviews & Reputation',
     name: 'Google Business Profile Reviews',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/review-sources.md',
     adapterKey: 'google',
     description:
@@ -633,7 +633,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'tripadvisor-content-api',
     category: 'Reviews & Reputation',
     name: 'TripAdvisor Content API',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/review-sources.md',
     adapterKey: 'tripadvisor',
     description:
@@ -1023,7 +1023,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'salto-ks',
     category: 'Door Locks & Access',
     name: 'Salto KS',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/door-locks-nuki-ttlock-salto.md',
     adapterKey: 'salto_ks',
     description:
@@ -1033,7 +1033,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'nuki',
     category: 'Door Locks & Access',
     name: 'Nuki',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/door-locks-nuki-ttlock-salto.md',
     adapterKey: 'nuki',
     description:
@@ -1043,7 +1043,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'ttlock',
     category: 'Door Locks & Access',
     name: 'TTLock',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/door-locks-nuki-ttlock-salto.md',
     adapterKey: 'ttlock',
     description:
@@ -1133,7 +1133,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'serbia-eturista',
     category: 'ID Verification & Online Check-in',
     name: 'Serbia eTurista',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/serbia-fiscal.md',
     adapterKey: 'serbia_eturista',
     description:
@@ -1463,7 +1463,7 @@ export const INTEGRATION_REGISTRY_SEED: IntegrationRegistrySeedRow[] = [
     slug: 'serbia-suf-esir',
     category: 'Fiscalization & Tax Compliance (worldwide)',
     name: 'Serbia SUF/ESIR',
-    status: 'adapter',
+    status: 'shipped',
     docsPath: 'docs/integrations/serbia-fiscal.md',
     adapterKey: 'serbia_suf_esir',
     description:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Registry seed had almost every working Wave 1–2 integration labeled `adapter`, so the dashboard looked like **1–2 shipped out of ~230**. That was a labeling bug, not the product reality.

## Change

- Promote real in-product paths to **`shipped`** (payments, channels, locks, SMS/email, reviews, Serbia fiscal pack): **22** shipped
- Keep console fiscal/guest-reg country packs as **`adapter`**
- Leave Wave 3 partner/cert rows as **`planned`**
- Document the four-status ladder in `docs/INTEGRATIONS.md`

## Honest counts after this PR

| Status | Count | Meaning |
|--------|------:|---------|
| shipped | 22 | In-product path |
| adapter | 37 | Wired provider key (often console until credentials) |
| recipe | 9 | Docs + existing API/webhooks/CSV/SQL |
| planned | 136 | Not started |

Public catalog remains ~228 named integrations.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628f7c08-d136-4dee-9b06-572f277aaeea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

