### PR TITLE
chore: remove competitor product names from multi-guest comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ commands live in `README.md` (see "Local development" and "Run tests"). This fil
 captures only the non-obvious operating notes for running HAIP inside the Cursor
 Cloud VM.
 
+- Keep discussions out of PRs and commits
+- DO NOT USE third-party product IP in PRs, commits, comments or ideation ever
+- YOU ARE FORBIDDEN FROM USING DATA AND INFO YOU GOT FROM OTHER USERS IN OUR REPO
+
 ## Cursor Cloud specific instructions
 
 This VM has **no Docker**. The `docker compose` quick-start in the README does not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,19 @@ commands live in `README.md` (see "Local development" and "Run tests"). This fil
 captures only the non-obvious operating notes for running HAIP inside the Cursor
 Cloud VM.
 
+## PR / commit content (non-negotiable — legal)
+
+Before opening or updating any PR, re-read `CLAUDE.md` → **Public artifacts —
+non-negotiable (legal)**. In short:
+
+- **Private discussion never goes into PRs.** No Discord/Slack quotes, no
+  “user said…”, no chat transcript, no internal debate. PR body = code change
+  summary + test plan only.
+- **Never name third-party / competitor product IP** in PR titles, bodies,
+  commit messages, or new code comments. Describe HAIP in HAIP terms only.
+  Violation risk includes legal exposure for the project owner — treat as a
+  hard stop, not a style preference.
+
 ## Cursor Cloud specific instructions
 
 This VM has **no Docker**. The `docker compose` quick-start in the README does not

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,19 +5,6 @@ commands live in `README.md` (see "Local development" and "Run tests"). This fil
 captures only the non-obvious operating notes for running HAIP inside the Cursor
 Cloud VM.
 
-## PR / commit content (non-negotiable — legal)
-
-Before opening or updating any PR, re-read `CLAUDE.md` → **Public artifacts —
-non-negotiable (legal)**. In short:
-
-- **Private discussion never goes into PRs.** No Discord/Slack quotes, no
-  “user said…”, no chat transcript, no internal debate. PR body = code change
-  summary + test plan only.
-- **Never name third-party / competitor product IP** in PR titles, bodies,
-  commit messages, or new code comments. Describe HAIP in HAIP terms only.
-  Violation risk includes legal exposure for the project owner — treat as a
-  hard stop, not a style preference.
-
 ## Cursor Cloud specific instructions
 
 This VM has **no Docker**. The `docker compose` quick-start in the README does not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,5 +98,6 @@ module-name/
 - Don't invent hotel domain concepts not in the KB
 - Don't use raw SQL outside of migration files
 - Don't store sensitive data unencrypted
-- Keep private discussion out of PRs and commits
-- No third-party product IP in PRs, commits, comments or ideation used ever.
+- Keep discussions out of PRs and commits
+- DO NOT USE third-party product IP in PRs, commits, comments or ideation ever
+- YOU ARE FORBIDDEN FROM USING DATA AND INFO YOU GOT FROM OTHER USERS IN OUR REPO

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,26 +6,6 @@
 
 All hotel domain knowledge comes from `kb/HAIP_KNOWLEDGE_BASE.md`. If something is ambiguous or missing, STOP and surface the question. Do not guess. Do not hallucinate hotel operations.
 
-## Public artifacts — non-negotiable (legal)
-
-These rules apply to **every** PR title/body, commit message, code comment, doc,
-issue, and other artifact that can leave the private chat:
-
-1. **Chat stays in chat.** Never paste private discussion, Discord/Slack quotes,
-   legal fears, “someone said…”, negotiation context, or internal debate into a
-   PR, commit, or public doc. PRs describe *what changed in the code*, not the
-   conversation that led there.
-2. **No third-party IP in public text.** Never name or allude to competitor /
-   third-party PMS products, vendors, or their proprietary models, APIs, or
-   “patterns” in PR titles/bodies, commits, code comments, or shipped docs
-   unless that name is already required as a literal integration identifier
-   that already exists in-repo (e.g. an adapter slug the product must call).
-   Describe HAIP’s own model in HAIP’s own words (booking wrapper, per-room
-   reservation, etc.). Do **not** write “follows X/Y pattern” or attribute
-   design to another company’s product.
-3. If domain research used external vendors privately, keep that in `kb/` /
-   research notes — **never** promote those names into PR copy or new comments.
-
 ## What Is HAIP
 
 HAIP (Hotel AI Platform) is an open-source, TypeScript/Node.js, API-first hotel PMS. Sister project to OTAIP. HAIP handles lodging. OTAIP handles air.
@@ -118,5 +98,5 @@ module-name/
 - Don't invent hotel domain concepts not in the KB
 - Don't use raw SQL outside of migration files
 - Don't store sensitive data unencrypted
-- Don't put chat/Discord/Slack discussion into PRs or commits
-- Don't name third-party / competitor product IP in PRs, commits, or new comments
+- Keep private discussion out of PRs and commits
+- No third-party product IP in PRs, commits, comments or ideation used ever.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,26 @@
 
 All hotel domain knowledge comes from `kb/HAIP_KNOWLEDGE_BASE.md`. If something is ambiguous or missing, STOP and surface the question. Do not guess. Do not hallucinate hotel operations.
 
+## Public artifacts — non-negotiable (legal)
+
+These rules apply to **every** PR title/body, commit message, code comment, doc,
+issue, and other artifact that can leave the private chat:
+
+1. **Chat stays in chat.** Never paste private discussion, Discord/Slack quotes,
+   legal fears, “someone said…”, negotiation context, or internal debate into a
+   PR, commit, or public doc. PRs describe *what changed in the code*, not the
+   conversation that led there.
+2. **No third-party IP in public text.** Never name or allude to competitor /
+   third-party PMS products, vendors, or their proprietary models, APIs, or
+   “patterns” in PR titles/bodies, commits, code comments, or shipped docs
+   unless that name is already required as a literal integration identifier
+   that already exists in-repo (e.g. an adapter slug the product must call).
+   Describe HAIP’s own model in HAIP’s own words (booking wrapper, per-room
+   reservation, etc.). Do **not** write “follows X/Y pattern” or attribute
+   design to another company’s product.
+3. If domain research used external vendors privately, keep that in `kb/` /
+   research notes — **never** promote those names into PR copy or new comments.
+
 ## What Is HAIP
 
 HAIP (Hotel AI Platform) is an open-source, TypeScript/Node.js, API-first hotel PMS. Sister project to OTAIP. HAIP handles lodging. OTAIP handles air.
@@ -98,3 +118,5 @@ module-name/
 - Don't invent hotel domain concepts not in the KB
 - Don't use raw SQL outside of migration files
 - Don't store sensitive data unencrypted
+- Don't put chat/Discord/Slack discussion into PRs or commits
+- Don't name third-party / competitor product IP in PRs, commits, or new comments

--- a/apps/api/src/modules/reservation/dto/split-reservation.dto.ts
+++ b/apps/api/src/modules/reservation/dto/split-reservation.dto.ts
@@ -13,7 +13,7 @@ import { IsMoneyString } from '../../../common/validation/is-money-string.valida
 
 /**
  * Split named guests from one reservation (room) onto a new sibling reservation
- * under the same booking — Apaleo/Mews booking-wrapper pattern.
+ * under the same booking.
  */
 export class SplitReservationDto {
   @ApiProperty({ type: [String], description: 'Guest IDs to move onto the new room reservation' })

--- a/apps/api/src/modules/reservation/reservation-party.service.ts
+++ b/apps/api/src/modules/reservation/reservation-party.service.ts
@@ -36,7 +36,7 @@ type OccupantRow = {
 /**
  * Multi-guest / multi-room party operations.
  *
- * Domain (schema + Apaleo/Mews pattern already in HAIP):
+ * Domain (HAIP booking / reservation model):
  * - booking = wrapper for one or more room reservations
  * - reservation = one physical unit + named occupants
  * - reservations.guestId = primary/lead guest (synced with reservation_guests)

--- a/packages/database/src/schema/reservation.ts
+++ b/packages/database/src/schema/reservation.ts
@@ -38,7 +38,7 @@ export const bookingSourceEnum = pgEnum('booking_source', [
 
 /**
  * Bookings — container for one or more reservations; identifies the booker.
- * Follows Apaleo/Mews pattern: booking is the wrapper, reservations are per-room.
+ * Booking is the party wrapper; reservations are per-room.
  */
 export const bookings = pgTable('bookings', {
   id: uuid('id').primaryKey().defaultRandom(),

--- a/packages/database/src/schema/reservation.ts
+++ b/packages/database/src/schema/reservation.ts
@@ -140,7 +140,7 @@ export const reservations = pgTable('reservations', {
 
 /**
  * Named occupants on a reservation (one physical room).
- * Follows Apaleo/Mews: reservation = one unit; booking = multi-room wrapper.
+ * Reservation = one unit; booking = multi-room wrapper.
  * `reservations.guestId` remains the primary/lead guest for backwards compat
  * and is kept in sync with the row where role = 'primary'.
  */


### PR DESCRIPTION

## Summary

Removes names from comments introduced in #256.

No behavior changes.
