### PR TITLE
fix(dashboard): keep room photo controls admin-only

### DIFF
--- a/apps/dashboard/src/pages/Rooms.tsx
+++ b/apps/dashboard/src/pages/Rooms.tsx
@@ -95,7 +95,7 @@ function RoomDetailPanel({
   // but every media route is admin-only. In the demo (auth off) hasRole
   // returns true so admins see all editing controls.
   const canManageAmenities = hasRole('admin', 'general_manager', 'front_desk', 'housekeeping_manager');
-  const canManagePhotos = hasRole('admin', 'general_manager');
+  const canManagePhotos = hasRole('admin');
 
   // Main photo: the room's own primary, falling back to the room type's primary
   // (rooms usually inherit their type's photos rather than having their own).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Room photo edit controls stay admin-only so the UI matches media write routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ddad7d4-bcf0-4e01-9486-5b5f4000c98d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ddad7d4-bcf0-4e01-9486-5b5f4000c98d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

