### PR TITLE
fix(channel): ACK Channex webhook test stubs without booking revision

### DIFF
--- a/apps/api/src/modules/channel/adapters/channex/channex-inbound.controller.ts
+++ b/apps/api/src/modules/channel/adapters/channex/channex-inbound.controller.ts
@@ -87,11 +87,16 @@ export class ChannexInboundController {
       }
 
       // Prefer embedded revision payload (send_data=true); otherwise pull the feed.
+      // Channex "Send test message" often posts a stub/data wrapper without a real
+      // booking revision — ACK those with 200 so webhook delivery succeeds.
       const revision = this.extractRevision(body);
       if (revision) {
         const mapped = mapChannexRevisionToHaip(revision, propertyId);
         if (!mapped) {
-          return res.status(400).json({ error: 'Unreadable booking revision' });
+          this.logger.warn(
+            `Channex webhook: no usable booking revision for property_id=${propertyId} — acking`,
+          );
+          return res.status(200).json({ ok: true, ack: 'no_usable_revision' });
         }
         await this.inboundReservationService.processInboundReservation(connection.id, mapped);
       } else {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Channex **Send test message** often posts a `data` wrapper without a full booking revision. Staging was returning `400 Unreadable booking revision`, which fails webhook delivery checks.

## Change

When a revision-shaped payload cannot be mapped to a HAIP booking, ACK with `200 { ok: true, ack: "no_usable_revision" }` instead of 400.

## Deployed

Staging API image `84c6a0c05d9d5cd0d08f5afe982c65fa35867491` already running on `haip-cloud-api-staging`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18af08b-56bf-4b4a-844e-6c9fd06d092a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18af08b-56bf-4b4a-844e-6c9fd06d092a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

