### PR TITLE
feat(channel): rate_override for Channex date-specific rates

### DIFF
--- a/apps/api/src/modules/channel/ari.service.ts
+++ b/apps/api/src/modules/channel/ari.service.ts
@@ -176,18 +176,26 @@ export class AriService {
           const dateStr = d.toISOString().split('T')[0]!;
           const baseRate = new Decimal(ratePlan.baseAmount).toNumber();
 
+          // Find applicable restriction for this date (string-compare ISO dates)
+          const restriction = restrictions.find((r: any) => {
+            const rs = String(r.startDate).slice(0, 10);
+            const re = String(r.endDate).slice(0, 10);
+            return rs <= dateStr && re >= dateStr;
+          });
+
+          const overrideRaw = restriction?.rateOverride;
+          const amount =
+            overrideRaw != null && overrideRaw !== ''
+              ? new Decimal(overrideRaw).toNumber()
+              : baseRate;
+
           rateItems.push({
             channelRoomCode: roomMapping.channelRoomCode,
             channelRateCode: rateMapping.channelRateCode,
             date: dateStr,
-            amount: baseRate,
+            amount,
             currencyCode: ratePlan.currencyCode,
           });
-
-          // Find applicable restriction for this date
-          const restriction = restrictions.find(
-            (r: any) => r.startDate <= dateStr && r.endDate >= dateStr,
-          );
 
           restrictionItems.push({
             channelRoomCode: roomMapping.channelRoomCode,

--- a/apps/api/src/modules/rate-plan/dto/create-rate-restriction.dto.ts
+++ b/apps/api/src/modules/rate-plan/dto/create-rate-restriction.dto.ts
@@ -5,8 +5,11 @@ import {
   IsBoolean,
   IsObject,
   IsDateString,
+  IsNumber,
   Min,
+  ValidateIf,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class CreateRateRestrictionDto {
@@ -48,6 +51,18 @@ export class CreateRateRestrictionDto {
   @IsOptional()
   @IsBoolean()
   isClosed?: boolean;
+
+  @ApiPropertyOptional({
+    example: 333.0,
+    description: 'Absolute nightly rate for dates in this window (overrides plan base amount on ARI push). Null clears.',
+    nullable: true,
+  })
+  @IsOptional()
+  @ValidateIf((_, v) => v !== null && v !== undefined)
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  rateOverride?: number | null;
 
   @ApiPropertyOptional({
     example: { friday: 20, saturday: 30 },

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -245,6 +245,7 @@ async function main() {
       closed_to_arrival boolean NOT NULL DEFAULT false,
       closed_to_departure boolean NOT NULL DEFAULT false,
       is_closed boolean NOT NULL DEFAULT false,
+      rate_override numeric(12,2),
       day_of_week_overrides jsonb,
       created_at timestamptz NOT NULL DEFAULT now(),
       updated_at timestamptz NOT NULL DEFAULT now()
@@ -1382,6 +1383,7 @@ async function main() {
     `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS hk_observed_persons integer`,
     `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS hk_observed_at timestamptz`,
     `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS hk_observed_by uuid`,
+    `ALTER TABLE rate_restrictions ADD COLUMN IF NOT EXISTS rate_override numeric(12,2)`,
   ];
   for (const a of alters) {
     await db.execute(sql.raw(a));

--- a/packages/database/src/schema/rate-plan.ts
+++ b/packages/database/src/schema/rate-plan.ts
@@ -104,6 +104,10 @@ export const rateRestrictions = pgTable('rate_restrictions', {
   closedToDeparture: boolean('closed_to_departure').notNull().default(false), // CTD
   isClosed: boolean('is_closed').notNull().default(false), // Rate not available at all
 
+  // Absolute rate for dates in this window (Channex cert / yield overrides). When set,
+  // channel ARI push uses this instead of rate_plans.base_amount for covered nights.
+  rateOverride: numeric('rate_override', { precision: 12, scale: 2 }),
+
   // Day-of-week overrides (KB 5.3: weekend premium, weekday discount)
   dayOfWeekOverrides: jsonb('day_of_week_overrides').$type<Record<string, number>>(), // { "friday": 20, "saturday": 30 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds optional `rate_override` on `rate_restrictions` and uses it in `AriService.pushRates` so date-window prices (Channex cert tests 2–8) push correctly instead of always using plan `baseAmount`.

## Test plan

- [ ] Staging migrate adds `rate_restrictions.rate_override`
- [ ] Create restriction with rateOverride → ARI push uses that amount for covered nights
- [ ] Restriction without override still uses baseAmount

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c18af08b-56bf-4b4a-844e-6c9fd06d092a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c18af08b-56bf-4b4a-844e-6c9fd06d092a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

