### PR TITLE
fix(ci): publish GHCR API image as amd64 only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,7 @@ jobs:
     needs: release
     if: needs.release.outputs.skip == 'false'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -175,9 +176,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -189,13 +187,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push API image (amd64 + arm64)
+      - name: Build and push API image (amd64)
         uses: docker/build-push-action@v6
         with:
           context: .
           file: apps/api/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           provenance: false
           build-args: |
             VITE_AUTH_ENABLED=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Release job **Publish API image to GHCR** was cancelled after ~6h because `linux/arm64` hung on `pnpm install` under QEMU. CI and Auto Release had already succeeded.

## Change

In `.github/workflows/release.yml`:

- Drop `docker/setup-qemu-action`
- Publish `linux/amd64` only (matches Cloud ECS)
- Rename step to `Build and push API image (amd64)`
- Add `timeout-minutes: 30` on the publish job

## Verify after merge

Next push to `main` that creates a release should finish the GHCR publish in minutes instead of hanging until cancel.

Refs: https://github.com/TelivityAI/haip/actions/runs/30838413961/job/91770039368

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c1cf631-3145-414e-b1f0-0718719b2642?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c1cf631-3145-414e-b1f0-0718719b2642&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

