### PR TITLE
fix(reports): occupancy-trend 500 from bad table alias r

### DIFF
--- a/apps/api/src/modules/reports/reports.service.ts
+++ b/apps/api/src/modules/reports/reports.service.ts
@@ -440,7 +440,8 @@ export class ReportsService {
     const dailyRoomsSold = await this.db
       .select({
         date: sql<string>`d.d::date`,
-        count: sql<number>`count(distinct r.id)::int`,
+        // Must use the drizzle table ref — alias "r" is not in the generated FROM.
+        count: sql<number>`count(distinct ${reservations.id})::int`,
       })
       .from(sql`generate_series(${startDate}::date, ${endDate}::date, '1 day'::interval) as d(d)`)
       .leftJoin(
@@ -894,7 +895,8 @@ export class ReportsService {
     const dailyOnBooks = await this.db
       .select({
         date: sql<string>`d.d::date`,
-        count: sql<number>`count(distinct r.id)::int`,
+        // Must use the drizzle table ref — alias "r" is not in the generated FROM.
+        count: sql<number>`count(distinct ${reservations.id})::int`,
       })
       .from(sql`generate_series(${startDate}::date, ${endDate}::date, '1 day'::interval) as d(d)`)
       .leftJoin(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
`GET /api/v1/reports/occupancy-trend` returned **500** with:
`missing FROM-clause entry for table "r"`

Staging Reports UI showed **Failed to load data** when Occupancy Trend was selected.

## Fix
Replace hardcoded `count(distinct r.id)` with `count(distinct ${reservations.id})` in:
- `getOccupancyTrend`
- `getBookingPace` (same bug)

## Test plan
- [ ] Deploy image to staging ECS
- [ ] `GET /api/v1/reports/occupancy-trend?...` returns 200
- [ ] Occupancy Trend chart renders in SPA (paired with haip-cloud unwrapReport fix)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c1cf631-3145-414e-b1f0-0718719b2642?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c1cf631-3145-414e-b1f0-0718719b2642&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

