### PR TITLE
fix(api): effective-rate query whitelist + vacant_clean→vacant_dirty transition

### DIFF
--- a/apps/api/src/modules/rate-plan/dto/effective-rate-query.dto.ts
+++ b/apps/api/src/modules/rate-plan/dto/effective-rate-query.dto.ts
@@ -1,7 +1,16 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, Min } from 'class-validator';
+import { IsDateString, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
 
 export class EffectiveRateQueryDto {
+  // The controller also binds propertyId via @Query('propertyId'), but the
+  // global ValidationPipe validates the WHOLE query object against this DTO —
+  // without this field every call 400s with "property propertyId should not
+  // exist" (forbidNonWhitelisted). Day Zero P0.
+  @ApiPropertyOptional({ description: 'Property ID (also bound by the controller)' })
+  @IsOptional()
+  @IsUUID()
+  propertyId?: string;
+
   @ApiPropertyOptional({ description: 'Length of stay in nights (alternative to checkIn/checkOut)' })
   @IsOptional()
   @IsInt()

--- a/apps/api/src/modules/room/room-status.service.ts
+++ b/apps/api/src/modules/room/room-status.service.ts
@@ -20,7 +20,9 @@ type RoomStatus =
   | 'out_of_service';
 
 const VALID_TRANSITIONS: Record<RoomStatus, RoomStatus[]> = {
-  vacant_clean: ['occupied', 'out_of_order', 'out_of_service'],
+  // KB 5.2 chain: vacant_clean → vacant_dirty is the documented "clean room
+  // found dirty" path — the desk must be able to send a room back to HK.
+  vacant_clean: ['occupied', 'vacant_dirty', 'out_of_order', 'out_of_service'],
   vacant_dirty: ['clean', 'out_of_order'],
   clean: ['inspected', 'vacant_clean', 'out_of_order'],
   inspected: ['guest_ready', 'out_of_order'],


### PR DESCRIPTION
## Summary

Two Day Zero P0s from the haip-qa staging run (`friction/runs/2026-08-05-day-zero-r2/`), both root-caused in Cloud's SPA↔engine contract audit:

**1. Effective Rate Calculator always 400s.** `RatePlanController.getEffectiveRate` binds `@Query('propertyId', ParseUUIDPipe)` separately AND `@Query() context: EffectiveRateQueryDto`. The global `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true })` validates the entire query object against the DTO — `propertyId` is not a DTO field, so every call failed with `400 "property propertyId should not exist"`. Added optional `propertyId` to the DTO.

**2. `vacant_clean → vacant_dirty` rejected.** The KB 5.2 chain documents "Vacant Clean → Vacant Dirty" (clean room found dirty — desk sends it back to HK), but `VALID_TRANSITIONS` in `room-status.service.ts` didn't allow it. Cloud's Rooms UI offered the button (matching the KB) and the engine 400'd. Added.

## Test plan

- [x] `vitest run src/modules/room src/modules/rate-plan` — 45/45 pass (incl. room-status.service.spec 16/16)
- [ ] Staging: Rate Plans → Effective Rate Calculator → Calculate returns a rate; Rooms → vacant_clean room → "→ vacant dirty" persists

Companion Cloud SPA PR: TelivityAI/haip-cloud#52 (Day Zero P0 batch).