### PR TITLE
feat(migration): durable PMS migration engine foundation (TEL-67, TEL-70)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -36,6 +36,7 @@ import { GroupsModule } from './modules/groups/groups.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { BookingEngineModule } from './modules/booking-engine/booking-engine.module';
 import { ImportModule } from './modules/import/import.module';
+import { MigrationModule } from './modules/migration/migration.module';
 import { AccountingExportModule } from './modules/accounting-export/accounting-export.module';
 import { NotificationsModule } from './modules/notifications/notifications.module';
 import { ReviewsModule } from './modules/reviews/reviews.module';
@@ -90,6 +91,7 @@ const imports: any[] = [
   AdminModule,
   BookingEngineModule,
   ImportModule,
+  MigrationModule,
   AccountingExportModule,
   NotificationsModule,
   ReviewsModule,

--- a/apps/api/src/modules/migration/dto/create-migration-job.dto.ts
+++ b/apps/api/src/modules/migration/dto/create-migration-job.dto.ts
@@ -1,0 +1,57 @@
+import {
+  IsArray,
+  ArrayMinSize,
+  IsBoolean,
+  IsIn,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export const MIGRATION_ENTITIES = [
+  'guests',
+  'room-types',
+  'rooms',
+  'rate-plans',
+  'reservations',
+  'folio-balances',
+] as const;
+export type MigrationEntity = (typeof MIGRATION_ENTITIES)[number];
+
+/**
+ * One migration job = one entity batch inside a wider migration project.
+ * `projectRef` scopes idempotency + the legacy id map; rows carry
+ * `legacyId` so re-runs skip instead of duplicating.
+ */
+export class CreateMigrationJobDto {
+  @ApiProperty({ description: 'Property ID' })
+  @IsUUID()
+  propertyId!: string;
+
+  @ApiProperty({
+    description: 'External migration project reference (Remy project id or manual run label)',
+  })
+  @IsString()
+  @MaxLength(120)
+  projectRef!: string;
+
+  @ApiProperty({ enum: MIGRATION_ENTITIES })
+  @IsIn(MIGRATION_ENTITIES)
+  entity!: MigrationEntity;
+
+  @ApiProperty({
+    type: [Object],
+    description:
+      'Canonical rows for the entity. Every row SHOULD carry `legacyId`; reference fields may use `{ "legacyId": ... }` in place of HAIP UUIDs.',
+  })
+  @IsArray()
+  @ArrayMinSize(1)
+  rows!: Record<string, unknown>[];
+
+  @ApiPropertyOptional({ default: false, description: 'Validate only — process without writing' })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean;
+}

--- a/apps/api/src/modules/migration/migration-crypto.service.spec.ts
+++ b/apps/api/src/modules/migration/migration-crypto.service.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { MigrationCryptoService } from './migration-crypto.service';
+
+const KEY = 'test-credential-key-material';
+
+describe('MigrationCryptoService', () => {
+  let svc: MigrationCryptoService;
+
+  beforeEach(() => {
+    process.env['MIGRATION_CREDENTIAL_KEY'] = KEY;
+    delete process.env['MIGRATION_CREDENTIAL_KEY_PREVIOUS'];
+    svc = new MigrationCryptoService();
+    svc.onModuleInit();
+  });
+
+  afterEach(() => {
+    delete process.env['MIGRATION_CREDENTIAL_KEY'];
+  });
+
+  it('round-trips a secret', () => {
+    const { ciphertext, keyId } = svc.encrypt('mews-access-token-123');
+    expect(keyId).toBe('default');
+    expect(ciphertext).not.toContain('mews-access-token-123');
+    expect(svc.decrypt(ciphertext)).toBe('mews-access-token-123');
+  });
+
+  it('produces unique ciphertext per call (random IV)', () => {
+    const a = svc.encrypt('same-secret');
+    const b = svc.encrypt('same-secret');
+    expect(a.ciphertext).not.toBe(b.ciphertext);
+    expect(svc.decrypt(a.ciphertext)).toBe('same-secret');
+    expect(svc.decrypt(b.ciphertext)).toBe('same-secret');
+  });
+
+  it('fails closed when tampered (GCM auth tag)', () => {
+    const { ciphertext } = svc.encrypt('secret');
+    const parts = ciphertext.split('.');
+    const data = Buffer.from(parts[4]!, 'base64');
+    data[0] = data[0]! ^ 0xff;
+    parts[4] = data.toString('base64');
+    expect(() => svc.decrypt(parts.join('.'))).toThrow();
+  });
+
+  it('rejects unknown payload formats and key ids', () => {
+    expect(() => svc.decrypt('not-a-payload')).toThrow(/format/);
+    expect(() => svc.decrypt('v1.unknown.aa.bb.cc')).toThrow(/key id/);
+  });
+
+  it('is disabled without a configured key', () => {
+    delete process.env['MIGRATION_CREDENTIAL_KEY'];
+    const bare = new MigrationCryptoService();
+    bare.onModuleInit();
+    expect(bare.isEnabled()).toBe(false);
+    expect(() => bare.encrypt('x')).toThrow(/not configured/);
+  });
+
+  it('accepts hex keys and passphrases identically', () => {
+    const hex = Buffer.from('key-material-32-bytes-exactly!!!')
+      .toString('hex')
+      .padEnd(64, '0');
+    process.env['MIGRATION_CREDENTIAL_KEY'] = hex;
+    const hexSvc = new MigrationCryptoService();
+    hexSvc.onModuleInit();
+    const { ciphertext } = hexSvc.encrypt('payload');
+    expect(hexSvc.decrypt(ciphertext)).toBe('payload');
+  });
+});

--- a/apps/api/src/modules/migration/migration-crypto.service.ts
+++ b/apps/api/src/modules/migration/migration-crypto.service.ts
@@ -1,0 +1,86 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'crypto';
+
+/**
+ * AES-256-GCM for source-PMS credentials (TEL-70).
+ *
+ * Payload format: `v1.<kid>.<base64 iv>.<base64 tag>.<base64 ciphertext>`.
+ * The `kid` segment lets ops rotate MIGRATION_CREDENTIAL_KEY without losing
+ * existing rows — decryption tries the kid recorded on the row.
+ *
+ * Keys: `MIGRATION_CREDENTIAL_KEY` (current) and
+ * `MIGRATION_CREDENTIAL_KEY_PREVIOUS` (rotation). Any 32-byte value works;
+ * hex/base64/passphrase are all accepted and normalized with sha256.
+ */
+@Injectable()
+export class MigrationCryptoService implements OnModuleInit {
+  private readonly keys = new Map<string, Buffer>();
+  private currentKid = 'default';
+
+  onModuleInit() {
+    const primary = process.env['MIGRATION_CREDENTIAL_KEY'];
+    if (primary) {
+      this.keys.set(this.currentKid, this.normalize(primary));
+    }
+    const previous = process.env['MIGRATION_CREDENTIAL_KEY_PREVIOUS'];
+    if (previous) {
+      this.keys.set('previous', this.normalize(previous));
+    }
+  }
+
+  /** False when no key is configured — callers must fail closed. */
+  isEnabled(): boolean {
+    return this.keys.has(this.currentKid);
+  }
+
+  encrypt(plaintext: string): { ciphertext: string; keyId: string } {
+    const key = this.keys.get(this.currentKid);
+    if (!key) {
+      throw new Error(
+        'MIGRATION_CREDENTIAL_KEY is not configured — refusing to store credentials',
+      );
+    }
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const payload = [
+      'v1',
+      this.currentKid,
+      iv.toString('base64'),
+      tag.toString('base64'),
+      encrypted.toString('base64'),
+    ].join('.');
+    return { ciphertext: payload, keyId: this.currentKid };
+  }
+
+  decrypt(payload: string): string {
+    const parts = payload.split('.');
+    if (parts.length !== 5 || parts[0] !== 'v1') {
+      throw new Error('Unrecognized credential payload format');
+    }
+    const [, kid, ivB64, tagB64, dataB64] = parts;
+    const key = this.keys.get(kid!);
+    if (!key) {
+      throw new Error(`No decryption key for key id "${kid}"`);
+    }
+    const decipher = createDecipheriv('aes-256-gcm', key, Buffer.from(ivB64!, 'base64'));
+    decipher.setAuthTag(Buffer.from(tagB64!, 'base64'));
+    return Buffer.concat([
+      decipher.update(Buffer.from(dataB64!, 'base64')),
+      decipher.final(),
+    ]).toString('utf8');
+  }
+
+  private normalize(raw: string): Buffer {
+    // Accept hex (64 chars), base64 (32 bytes), or arbitrary passphrase.
+    if (/^[0-9a-fA-F]{64}$/.test(raw)) return Buffer.from(raw, 'hex');
+    try {
+      const b = Buffer.from(raw, 'base64');
+      if (b.length === 32) return b;
+    } catch {
+      /* fall through to passphrase hashing */
+    }
+    return createHash('sha256').update(raw, 'utf8').digest();
+  }
+}

--- a/apps/api/src/modules/migration/migration-id-map.service.ts
+++ b/apps/api/src/modules/migration/migration-id-map.service.ts
@@ -1,0 +1,80 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import { migrationLegacyIdMap } from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import type { MigrationEntity } from './dto/create-migration-job.dto';
+
+/**
+ * Legacy identity map — resolves source-PMS ids to HAIP uuids per project and
+ * makes re-runs idempotent: already-mapped legacy ids are skipped, never
+ * re-created. Every query is scoped by propertyId + projectRef (both come from
+ * the request/job, never derived from other entity lookups).
+ */
+@Injectable()
+export class MigrationIdMapService {
+  constructor(@Inject(DRIZZLE) private readonly db: any) {}
+
+  /** Bulk-load existing mappings for one entity into memory for a job run. */
+  async loadForEntity(
+    propertyId: string,
+    projectRef: string,
+    entity: MigrationEntity,
+  ): Promise<Map<string, string>> {
+    const rows = await this.db
+      .select({
+        legacyId: migrationLegacyIdMap.legacyId,
+        haipId: migrationLegacyIdMap.haipId,
+      })
+      .from(migrationLegacyIdMap)
+      .where(
+        and(
+          eq(migrationLegacyIdMap.propertyId, propertyId),
+          eq(migrationLegacyIdMap.projectRef, projectRef),
+          eq(migrationLegacyIdMap.entity, entity),
+        ),
+      );
+    return new Map(rows.map((r: { legacyId: string; haipId: string }) => [r.legacyId, r.haipId]));
+  }
+
+  /** Record one mapping. On conflict (concurrent/retry double-insert) the existing row wins. */
+  async record(
+    propertyId: string,
+    projectRef: string,
+    entity: MigrationEntity,
+    legacyId: string,
+    haipId: string,
+  ): Promise<void> {
+    await this.db
+      .insert(migrationLegacyIdMap)
+      .values({ propertyId, projectRef, entity, legacyId, haipId })
+      .onConflictDoNothing({
+        target: [
+          migrationLegacyIdMap.propertyId,
+          migrationLegacyIdMap.projectRef,
+          migrationLegacyIdMap.entity,
+          migrationLegacyIdMap.legacyId,
+        ],
+      });
+  }
+
+  /** Resolve a legacy id to a HAIP uuid. */
+  async resolve(
+    propertyId: string,
+    projectRef: string,
+    entity: MigrationEntity,
+    legacyId: string,
+  ): Promise<string | undefined> {
+    const [row] = await this.db
+      .select({ haipId: migrationLegacyIdMap.haipId })
+      .from(migrationLegacyIdMap)
+      .where(
+        and(
+          eq(migrationLegacyIdMap.propertyId, propertyId),
+          eq(migrationLegacyIdMap.projectRef, projectRef),
+          eq(migrationLegacyIdMap.entity, entity),
+          eq(migrationLegacyIdMap.legacyId, legacyId),
+        ),
+      );
+    return row?.haipId;
+  }
+}

--- a/apps/api/src/modules/migration/migration-queue.service.ts
+++ b/apps/api/src/modules/migration/migration-queue.service.ts
@@ -1,0 +1,112 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnModuleInit,
+  Optional,
+} from '@nestjs/common';
+import { Queue, Worker, type JobsOptions } from 'bullmq';
+import { MigrationService } from './migration.service';
+
+const QUEUE_NAME = 'haip-migration-jobs';
+const JOB_NAME = 'process-migration-job';
+const MAX_ATTEMPTS = 4;
+
+interface MigrationJobPayload {
+  jobId: string;
+  propertyId: string;
+}
+
+interface MigrationQueue {
+  add(name: string, data: MigrationJobPayload, options?: JobsOptions): Promise<unknown>;
+  close?(): Promise<void>;
+}
+
+interface MigrationWorker {
+  close(): Promise<void>;
+}
+
+/**
+ * BullMQ runner for migration jobs (TEL-67). Mirrors the webhook-delivery
+ * pattern: Redis-backed queue survives API restarts; on failure the job row
+ * stays `pending` at its checkpoint and the retry resumes from it. Unit tests
+ * inject a fake queue or call MigrationService.processJob directly.
+ */
+@Injectable()
+export class MigrationQueueService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(MigrationQueueService.name);
+  private readonly defaultJobOptions: JobsOptions = {
+    attempts: MAX_ATTEMPTS,
+    backoff: { type: 'exponential', delay: 15_000 },
+    removeOnComplete: true,
+    removeOnFail: false,
+  };
+  private ownsQueue = false;
+  private ownsWorker = false;
+
+  constructor(
+    private readonly migrationService: MigrationService,
+    @Optional() private queue?: MigrationQueue,
+    @Optional() private worker?: MigrationWorker,
+  ) {}
+
+  onModuleInit() {
+    if (process.env['NODE_ENV'] === 'test') return;
+    this.getQueue();
+    this.getWorker();
+  }
+
+  async onModuleDestroy() {
+    if (this.ownsWorker && this.worker) await this.worker.close();
+    if (this.ownsQueue && this.queue?.close) await this.queue.close();
+  }
+
+  async enqueue(jobId: string, propertyId: string) {
+    await this.getQueue().add(JOB_NAME, { jobId, propertyId }, this.defaultJobOptions);
+  }
+
+  private getQueue(): MigrationQueue {
+    if (!this.queue) {
+      this.queue = new Queue<MigrationJobPayload>(QUEUE_NAME, {
+        connection: this.redisConnection(),
+      });
+      this.ownsQueue = true;
+    }
+    return this.queue;
+  }
+
+  private getWorker(): MigrationWorker {
+    if (!this.worker) {
+      const worker = new Worker<MigrationJobPayload>(
+        QUEUE_NAME,
+        async (job) => this.migrationService.processJob(job.data.jobId, job.data.propertyId),
+        { connection: this.redisConnection() },
+      );
+      worker.on('error', (err) => {
+        this.logger.error(`Migration worker error: ${err?.message ?? err}`);
+      });
+      this.worker = worker;
+      this.ownsWorker = true;
+    }
+    return this.worker;
+  }
+
+  private redisConnection() {
+    const redisUrl = process.env['REDIS_URL'] ?? 'redis://localhost:6379';
+    const parsed = new URL(redisUrl);
+    const dbPath = parsed.pathname.replace(/^\//, '');
+    const db = dbPath ? Number(dbPath) : undefined;
+    if (db !== undefined && Number.isNaN(db)) {
+      throw new Error(`Invalid REDIS_URL database index: ${dbPath}`);
+    }
+    return {
+      host: parsed.hostname,
+      port: parsed.port ? Number(parsed.port) : 6379,
+      username: parsed.username ? decodeURIComponent(parsed.username) : undefined,
+      password: parsed.password ? decodeURIComponent(parsed.password) : undefined,
+      db,
+      tls: parsed.protocol === 'rediss:' ? {} : undefined,
+      maxRetriesPerRequest: null,
+    };
+  }
+}

--- a/apps/api/src/modules/migration/migration.controller.ts
+++ b/apps/api/src/modules/migration/migration.controller.ts
@@ -1,0 +1,105 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Query,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { ApiOperation, ApiProperty, ApiTags } from '@nestjs/swagger';
+import { IsString, MaxLength } from 'class-validator';
+import { Roles } from '../auth/roles.decorator';
+import { RequirePermissions } from '../auth/permissions.decorator';
+import { MigrationService } from './migration.service';
+import { MigrationQueueService } from './migration-queue.service';
+import { CreateMigrationJobDto } from './dto/create-migration-job.dto';
+
+class StoreCredentialDto {
+  @ApiProperty({ description: 'Source PMS key, e.g. "mews", "cloudbeds", "apaleo"' })
+  @IsString()
+  @MaxLength(60)
+  sourcePms!: string;
+
+  @ApiProperty({ description: 'API token / OAuth payload for the source PMS (stored encrypted)' })
+  @IsString()
+  secret!: string;
+}
+
+/**
+ * PMS migration — `/api/v1/migration/*` (TEL-67/70). Staff-facing,
+ * `settings.manage`. Jobs are durable + resumable; `propertyId` is required on
+ * every route and scopes every query (multi-tenancy).
+ *
+ * Credentials endpoints store ciphertext only — plaintext never appears in any
+ * response, log line, or audit row.
+ */
+@ApiTags('migration')
+@Controller('migration')
+@Roles('admin')
+export class MigrationController {
+  constructor(
+    private readonly migrationService: MigrationService,
+    private readonly queue: MigrationQueueService,
+  ) {}
+
+  @Post('jobs')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Create + enqueue a migration job (one entity batch)' })
+  async createJob(@Body() dto: CreateMigrationJobDto) {
+    const job = await this.migrationService.createJob(dto);
+    await this.queue.enqueue(job.id, dto.propertyId);
+    return this.migrationService.getJob(dto.propertyId, job.id);
+  }
+
+  @Get('jobs')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'List migration jobs for a property (optionally per project)' })
+  listJobs(
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+    @Query('projectRef') projectRef?: string,
+  ) {
+    return this.migrationService.listJobs(propertyId, projectRef);
+  }
+
+  @Get('jobs/:id')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Migration job status + counts + row errors' })
+  getJob(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+  ) {
+    return this.migrationService.getJob(propertyId, id);
+  }
+
+  @Post('jobs/:id/cancel')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Cancel a pending/running migration job' })
+  cancelJob(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+  ) {
+    return this.migrationService.cancelJob(propertyId, id);
+  }
+
+  @Post('credentials')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Store a source-PMS credential (AES-256-GCM at rest)' })
+  storeCredential(
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+    @Body() dto: StoreCredentialDto,
+  ) {
+    return this.migrationService.storeSourceCredential(propertyId, dto.sourcePms, dto.secret);
+  }
+
+  @Delete('credentials/:sourcePms')
+  @RequirePermissions('settings.manage')
+  @ApiOperation({ summary: 'Delete a stored source-PMS credential' })
+  deleteCredential(
+    @Param('sourcePms') sourcePms: string,
+    @Query('propertyId', new ParseUUIDPipe()) propertyId: string,
+  ) {
+    return this.migrationService.deleteSourceCredential(propertyId, sourcePms);
+  }
+}

--- a/apps/api/src/modules/migration/migration.module.ts
+++ b/apps/api/src/modules/migration/migration.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { MigrationController } from './migration.controller';
+import { MigrationService } from './migration.service';
+import { MigrationQueueService } from './migration-queue.service';
+import { MigrationIdMapService } from './migration-id-map.service';
+import { MigrationCryptoService } from './migration-crypto.service';
+import { GuestModule } from '../guest/guest.module';
+import { RoomModule } from '../room/room.module';
+import { RatePlanModule } from '../rate-plan/rate-plan.module';
+import { ReservationModule } from '../reservation/reservation.module';
+import { FolioModule } from '../folio/folio.module';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [GuestModule, RoomModule, RatePlanModule, ReservationModule, FolioModule, AuthModule],
+  controllers: [MigrationController],
+  providers: [MigrationService, MigrationQueueService, MigrationIdMapService, MigrationCryptoService],
+  exports: [MigrationService, MigrationIdMapService],
+})
+export class MigrationModule {}

--- a/apps/api/src/modules/migration/migration.service.spec.ts
+++ b/apps/api/src/modules/migration/migration.service.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MigrationService } from './migration.service';
+
+const PROP = 'aaaaaaaa-0000-4000-a000-000000000001';
+const PROJECT = 'proj-1';
+const RT_UUID = 'bbbbbbbb-0000-4000-a000-000000000002';
+const GUEST_UUID = 'cccccccc-0000-4000-a000-000000000003';
+const RP_UUID = 'dddddddd-0000-4000-a000-000000000004';
+
+// These tests drive processRow directly (row semantics: id-map skip, reference
+// resolution, dry-run, per-entity persist). Queue/checkpoint flow is covered by
+// the live smoke test; db access is not exercised here.
+describe('MigrationService', () => {
+  let svc: MigrationService;
+  let idMapSvc: any;
+  let guest: any;
+  let room: any;
+  let ratePlan: any;
+  let reservation: any;
+  let folio: any;
+  let cryptoSvc: any;
+
+  beforeEach(() => {
+    guest = { create: vi.fn().mockResolvedValue({ id: GUEST_UUID }) };
+    room = {
+      createRoomType: vi.fn().mockResolvedValue({ id: RT_UUID }),
+      createRoom: vi.fn().mockResolvedValue({ id: 'room-1' }),
+    };
+    ratePlan = { create: vi.fn().mockResolvedValue({ id: 'rp-1' }) };
+    reservation = { create: vi.fn().mockResolvedValue({ id: 'res-1' }) };
+    folio = {
+      create: vi.fn().mockResolvedValue({ id: 'folio-1' }),
+      postCharge: vi.fn().mockResolvedValue({ id: 'charge-1' }),
+    };
+    idMapSvc = {
+      loadForEntity: vi.fn().mockResolvedValue(new Map()),
+      record: vi.fn().mockResolvedValue(undefined),
+      resolve: vi.fn(),
+    };
+    cryptoSvc = { isEnabled: vi.fn().mockReturnValue(true) };
+    svc = new MigrationService(
+      {} as any,
+      guest,
+      room,
+      ratePlan,
+      reservation,
+      folio,
+      idMapSvc,
+      cryptoSvc,
+    );
+  });
+
+  it('skips rows whose legacyId is already mapped (idempotent re-run)', async () => {
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'guests',
+      row: { legacyId: 'OLD-1', firstName: 'Ada', lastName: 'Lovelace' },
+      index: 0,
+      dryRun: false,
+      known: new Map([['OLD-1', GUEST_UUID]]),
+    });
+    expect(outcome.status).toBe('skipped');
+    expect(outcome.haipId).toBe(GUEST_UUID);
+    expect(guest.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a guest and records the id mapping', async () => {
+    const known = new Map<string, string>();
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'guests',
+      row: { legacyId: 'OLD-9', firstName: 'Grace', lastName: 'Hopper' },
+      index: 0,
+      dryRun: false,
+      known,
+    });
+    expect(outcome.status).toBe('created');
+    expect(guest.create).toHaveBeenCalledWith(expect.objectContaining({ firstName: 'Grace' }));
+    expect(idMapSvc.record).toHaveBeenCalledWith(PROP, PROJECT, 'guests', 'OLD-9', GUEST_UUID);
+    expect(known.get('OLD-9')).toBe(GUEST_UUID);
+  });
+
+  it('dry-run validates without writing or recording mappings', async () => {
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'rooms',
+      row: { legacyId: 'R-101', roomTypeId: RT_UUID, number: '101' },
+      index: 0,
+      dryRun: true,
+      known: new Map(),
+    });
+    expect(outcome.status).toBe('validated');
+    expect(room.createRoom).not.toHaveBeenCalled();
+    expect(idMapSvc.record).not.toHaveBeenCalled();
+  });
+
+  it('resolves { legacyId } references through the id map', async () => {
+    idMapSvc.resolve.mockResolvedValue(RT_UUID);
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'rooms',
+      row: { legacyId: 'R-102', roomTypeId: { legacyId: 'OLD-RT' }, number: '102' },
+      index: 0,
+      dryRun: false,
+      known: new Map(),
+    });
+    expect(outcome.status).toBe('created');
+    expect(idMapSvc.resolve).toHaveBeenCalledWith(PROP, PROJECT, 'room-types', 'OLD-RT');
+    expect(room.createRoom).toHaveBeenCalledWith(expect.objectContaining({ roomTypeId: RT_UUID }));
+  });
+
+  it('fails the row (not the batch) on an unresolved reference', async () => {
+    idMapSvc.resolve.mockResolvedValue(undefined);
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'rooms',
+      row: { legacyId: 'R-103', roomTypeId: { legacyId: 'NOPE' }, number: '103' },
+      index: 2,
+      dryRun: false,
+      known: new Map(),
+    });
+    expect(outcome.status).toBe('failed');
+    expect(outcome.error).toMatch(/Unresolved roomTypeId/);
+    expect(room.createRoom).not.toHaveBeenCalled();
+  });
+
+  it('reservation rows default source and stash legacyId as externalConfirmation', async () => {
+    idMapSvc.resolve
+      .mockResolvedValueOnce(GUEST_UUID) // guestId
+      .mockResolvedValueOnce(RT_UUID) // roomTypeId
+      .mockResolvedValueOnce(RP_UUID); // ratePlanId
+    await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'reservations',
+      row: {
+        legacyId: 'MEWS-RES-1',
+        guestId: { legacyId: 'G1' },
+        roomTypeId: { legacyId: 'RT1' },
+        ratePlanId: { legacyId: 'RP1' },
+        arrivalDate: '2026-09-01',
+        departureDate: '2026-09-03',
+        totalAmount: '300.00',
+        currencyCode: 'USD',
+      },
+      index: 0,
+      dryRun: false,
+      known: new Map(),
+    });
+    expect(reservation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: 'direct',
+        externalConfirmation: 'MEWS-RES-1',
+        guestId: GUEST_UUID,
+        roomTypeId: RT_UUID,
+        ratePlanId: RP_UUID,
+      }),
+    );
+  });
+
+  it('folio-balances creates a guest folio with a single opening adjustment charge', async () => {
+    const outcome = await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'folio-balances',
+      row: { legacyId: 'FOL-1', guestId: GUEST_UUID, amount: '150.25', currencyCode: 'USD' },
+      index: 0,
+      dryRun: false,
+      known: new Map(),
+    });
+    expect(outcome.status).toBe('created');
+    expect(folio.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'guest', guestId: GUEST_UUID }),
+    );
+    expect(folio.postCharge).toHaveBeenCalledWith(
+      'folio-1',
+      expect.objectContaining({ type: 'adjustment', amount: '150.25', skipTaxCalculation: true }),
+    );
+  });
+
+  it('folio-balances with a negative/credit balance posts no charge', async () => {
+    await (svc as any).processRow({
+      propertyId: PROP,
+      projectRef: PROJECT,
+      entity: 'folio-balances',
+      row: { guestId: GUEST_UUID, amount: '-20.00', currencyCode: 'USD' },
+      index: 0,
+      dryRun: false,
+      known: new Map(),
+    });
+    expect(folio.create).toHaveBeenCalled();
+    expect(folio.postCharge).not.toHaveBeenCalled();
+  });
+
+  it('rejects credential storage when encryption is not configured', async () => {
+    cryptoSvc.isEnabled.mockReturnValue(false);
+    await expect(svc.storeSourceCredential(PROP, 'mews', 'secret')).rejects.toMatchObject({
+      message: expect.stringMatching(/not configured/),
+    });
+  });
+});

--- a/apps/api/src/modules/migration/migration.service.ts
+++ b/apps/api/src/modules/migration/migration.service.ts
@@ -1,0 +1,532 @@
+import {
+  BadRequestException,
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { and, desc, eq } from 'drizzle-orm';
+import {
+  migrationJobs,
+  migrationSourceCredentials,
+} from '@telivityhaip/database';
+import { DRIZZLE } from '../../database/database.module';
+import { GuestService } from '../guest/guest.service';
+import { RoomService } from '../room/room.service';
+import { RatePlanService } from '../rate-plan/rate-plan.service';
+import { ReservationService } from '../reservation/reservation.service';
+import { FolioService } from '../folio/folio.service';
+import { MigrationIdMapService } from './migration-id-map.service';
+import { MigrationCryptoService } from './migration-crypto.service';
+import type {
+  CreateMigrationJobDto,
+  MigrationEntity,
+} from './dto/create-migration-job.dto';
+
+/**
+ * Migration jobs (TEL-67) — durable, resumable, idempotent batch imports that
+ * Remy drives during a PMS migration project.
+ *
+ * Design notes:
+ * - Rows are staged on the job row itself (jsonb) so a worker can resume from
+ *   `processedRows` after a crash/restart with no external state.
+ * - Every row SHOULD carry `legacyId`. When it does, completion is recorded in
+ *   `migration_legacy_id_map` and re-runs skip instead of duplicating — the
+ *   "double approve" / "re-upload the same export" case becomes a safe no-op.
+ * - Reference fields (roomTypeId, ratePlanId, guestId, reservationId) may be
+ *   given as HAIP UUIDs or as `{ "legacyId": "<source id>" }`, resolved through
+ *   the id map for the same project.
+ * - Open folio balances are imported as a single `adjustment` opening-balance
+ *   charge on a fresh guest folio — closed-period history is NEVER replayed.
+ */
+
+interface RowOutcome {
+  index: number;
+  legacyId?: string;
+  status: 'created' | 'skipped' | 'failed' | 'validated';
+  haipId?: string;
+  error?: string;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+@Injectable()
+export class MigrationService {
+  private readonly logger = new Logger(MigrationService.name);
+
+  constructor(
+    @Inject(DRIZZLE) private readonly db: any,
+    private readonly guestService: GuestService,
+    private readonly roomService: RoomService,
+    private readonly ratePlanService: RatePlanService,
+    private readonly reservationService: ReservationService,
+    private readonly folioService: FolioService,
+    private readonly idMap: MigrationIdMapService,
+    private readonly crypto: MigrationCryptoService,
+  ) {}
+
+  /** Create a job row. The caller enqueues processing (queue service). */
+  async createJob(dto: CreateMigrationJobDto) {
+    if (dto.rows.length > 50_000) {
+      throw new BadRequestException(
+        'A single migration job is limited to 50,000 rows — split the batch',
+      );
+    }
+    const [job] = await this.db
+      .insert(migrationJobs)
+      .values({
+        propertyId: dto.propertyId,
+        projectRef: dto.projectRef,
+        entity: dto.entity,
+        rows: dto.rows,
+        totalRows: dto.rows.length,
+        dryRun: dto.dryRun ? 'true' : 'false',
+      })
+      .returning();
+    return job;
+  }
+
+  async getJob(propertyId: string, jobId: string) {
+    const [job] = await this.db
+      .select()
+      .from(migrationJobs)
+      .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+    if (!job) throw new NotFoundException(`Migration job ${jobId} not found`);
+    return this.publicView(job);
+  }
+
+  async listJobs(propertyId: string, projectRef?: string) {
+    const conditions = [eq(migrationJobs.propertyId, propertyId)];
+    if (projectRef) conditions.push(eq(migrationJobs.projectRef, projectRef));
+    const rows = await this.db
+      .select()
+      .from(migrationJobs)
+      .where(and(...conditions))
+      .orderBy(desc(migrationJobs.createdAt))
+      .limit(100);
+    return rows.map((j: any) => this.publicView(j));
+  }
+
+  async cancelJob(propertyId: string, jobId: string) {
+    const job = await this.getJob(propertyId, jobId);
+    if (job.status === 'completed' || job.status === 'completed_with_errors') {
+      throw new BadRequestException(`Job ${jobId} already finished — nothing to cancel`);
+    }
+    await this.db
+      .update(migrationJobs)
+      .set({ status: 'cancelled', updatedAt: new Date() })
+      .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+    return this.getJob(propertyId, jobId);
+  }
+
+  /**
+   * Process a job from its checkpoint. Called by the queue worker (and directly
+   * by tests). Chunks rows so the job row is periodically updated — a crash
+   * mid-job resumes from the last committed chunk.
+   */
+  async processJob(jobId: string, propertyId: string): Promise<void> {
+    const [job] = await this.db
+      .select()
+      .from(migrationJobs)
+      .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+
+    if (
+      !job ||
+      job.status === 'cancelled' ||
+      job.status === 'completed' ||
+      job.status === 'completed_with_errors'
+    ) {
+      return;
+    }
+
+    const dryRun = job.dryRun === 'true';
+    const rows = job.rows as Record<string, unknown>[];
+    const entity = job.entity as MigrationEntity;
+    const known = await this.idMap.loadForEntity(propertyId, job.projectRef, entity);
+    const errors: Array<{ index: number; legacyId?: string; error: string }> = Array.isArray(
+      job.errors,
+    )
+      ? [...(job.errors as any[])]
+      : [];
+
+    await this.db
+      .update(migrationJobs)
+      .set({
+        status: 'running',
+        startedAt: job.startedAt ?? new Date(),
+        attempts: (job.attempts ?? 0) + 1,
+        updatedAt: new Date(),
+      })
+      .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+
+    let created = job.createdCount ?? 0;
+    let skipped = job.skippedCount ?? 0;
+    let failed = job.failedCount ?? 0;
+    let cursor = job.processedRows ?? 0;
+    const CHUNK = 200;
+
+    try {
+      while (cursor < rows.length) {
+        const chunk = rows.slice(cursor, cursor + CHUNK);
+        for (let i = 0; i < chunk.length; i++) {
+          const index = cursor + i;
+          const outcome = await this.processRow({
+            propertyId,
+            projectRef: job.projectRef,
+            entity,
+            row: chunk[i]!,
+            index,
+            dryRun,
+            known,
+          });
+          if (outcome.status === 'failed') {
+            failed++;
+            errors.push({ index, legacyId: outcome.legacyId, error: outcome.error! });
+          } else if (outcome.status === 'skipped') {
+            skipped++;
+          } else {
+            created++;
+          }
+        }
+        cursor += chunk.length;
+        await this.db
+          .update(migrationJobs)
+          .set({
+            processedRows: cursor,
+            createdCount: created,
+            skippedCount: skipped,
+            failedCount: failed,
+            errors,
+            updatedAt: new Date(),
+          })
+          .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+      }
+
+      const terminal = failed > 0 ? 'completed_with_errors' : 'completed';
+      await this.db
+        .update(migrationJobs)
+        .set({ status: terminal, completedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+    } catch (err: any) {
+      this.logger.error(`Migration job ${jobId} failed at row ${cursor}: ${err?.message ?? err}`);
+      await this.db
+        .update(migrationJobs)
+        .set({
+          status: 'pending', // back to pending so the worker retry resumes from checkpoint
+          processedRows: cursor,
+          createdCount: created,
+          skippedCount: skipped,
+          failedCount: failed,
+          errors,
+          lastError: err?.message ?? 'Unknown error',
+          updatedAt: new Date(),
+        })
+        .where(and(eq(migrationJobs.id, jobId), eq(migrationJobs.propertyId, propertyId)));
+      throw err; // let BullMQ schedule the retry
+    }
+  }
+
+  private async processRow(ctx: {
+    propertyId: string;
+    projectRef: string;
+    entity: MigrationEntity;
+    row: Record<string, unknown>;
+    index: number;
+    dryRun: boolean;
+    known: Map<string, string>;
+  }): Promise<RowOutcome> {
+    const { propertyId, projectRef, entity, row, index, dryRun, known } = ctx;
+    const legacyId =
+      typeof row['legacyId'] === 'string' && row['legacyId'].trim() !== ''
+        ? row['legacyId'].trim()
+        : undefined;
+
+    try {
+      if (legacyId && known.has(legacyId)) {
+        return { index, legacyId, status: 'skipped', haipId: known.get(legacyId) };
+      }
+      const resolved = await this.resolveReferences(propertyId, projectRef, entity, row, dryRun);
+      const dto = this.buildDto(entity, resolved, propertyId);
+      if (dryRun) {
+        return { index, legacyId, status: 'validated' };
+      }
+      const created = await this.persist(entity, dto);
+      if (legacyId) {
+        await this.idMap.record(propertyId, projectRef, entity, legacyId, created.id);
+        known.set(legacyId, created.id);
+      }
+      return { index, legacyId, status: 'created', haipId: created.id };
+    } catch (err: any) {
+      return { index, legacyId, status: 'failed', error: err?.message ?? 'Unknown error' };
+    }
+  }
+
+  /**
+   * Replace `{ legacyId }` reference objects with HAIP uuids via the id map.
+   * Passthrough when the value is already a UUID. In dry-run, unresolved
+   * references are left undefined (validation covers required-field presence;
+   * referential integrity is proven by the live run's per-row errors).
+   */
+  private async resolveReferences(
+    propertyId: string,
+    projectRef: string,
+    entity: MigrationEntity,
+    row: Record<string, unknown>,
+    dryRun: boolean,
+  ): Promise<Record<string, unknown>> {
+    const refEntity: Record<string, MigrationEntity> = {
+      guestId: 'guests',
+      roomTypeId: 'room-types',
+      ratePlanId: 'rate-plans',
+      roomId: 'rooms',
+      reservationId: 'reservations',
+    };
+    const out: Record<string, unknown> = { ...row };
+    for (const field of Object.keys(refEntity)) {
+      const v = out[field];
+      if (
+        v &&
+        typeof v === 'object' &&
+        !Array.isArray(v) &&
+        typeof (v as any).legacyId === 'string'
+      ) {
+        const resolved = await this.idMap.resolve(
+          propertyId,
+          projectRef,
+          refEntity[field]!,
+          (v as any).legacyId,
+        );
+        if (!resolved) {
+          if (!dryRun) {
+            throw new BadRequestException(
+              `Unresolved ${field} legacyId "${(v as any).legacyId}" — import ${refEntity[field]} first`,
+            );
+          }
+          out[field] = undefined;
+        } else {
+          out[field] = resolved;
+        }
+      }
+    }
+    return out;
+  }
+
+  /** Canonical row → create DTO per entity. Throws on invalid values. */
+  private buildDto(
+    entity: MigrationEntity,
+    row: Record<string, unknown>,
+    propertyId: string,
+  ): Record<string, unknown> {
+    const str = (k: string) => {
+      const v = row[k];
+      return typeof v === 'string' && v.trim() !== '' ? v.trim() : undefined;
+    };
+    const req = (k: string) => {
+      const v = str(k);
+      if (v === undefined) throw new BadRequestException(`Missing required field "${k}"`);
+      return v;
+    };
+    const int = (k: string, required = false) => {
+      const raw = row[k];
+      if (raw === undefined || raw === null || raw === '') {
+        if (required) throw new BadRequestException(`Missing required field "${k}"`);
+        return undefined;
+      }
+      const n = Number(raw);
+      if (!Number.isInteger(n)) {
+        throw new BadRequestException(`Field "${k}" must be an integer (got "${String(raw)}")`);
+      }
+      return n;
+    };
+    const ref = (k: string, required = false) => {
+      const v = row[k];
+      if (v === undefined || v === null || v === '') {
+        if (required) throw new BadRequestException(`Missing required field "${k}"`);
+        return undefined;
+      }
+      if (typeof v !== 'string' || !UUID_RE.test(v)) {
+        throw new BadRequestException(
+          `Field "${k}" must be a HAIP uuid or { "legacyId": "..." }`,
+        );
+      }
+      return v;
+    };
+
+    switch (entity) {
+      case 'guests':
+        return {
+          firstName: req('firstName'),
+          lastName: req('lastName'),
+          email: str('email'),
+          phone: str('phone'),
+          companyName: str('companyName'),
+          loyaltyNumber: str('loyaltyNumber'),
+          nationality: str('nationality'),
+        };
+      case 'room-types':
+        return {
+          propertyId,
+          name: req('name'),
+          code: req('code'),
+          description: str('description'),
+          maxOccupancy: int('maxOccupancy', true),
+          defaultOccupancy: int('defaultOccupancy', true),
+          bedType: str('bedType'),
+          bedCount: int('bedCount'),
+        };
+      case 'rooms':
+        return {
+          propertyId,
+          roomTypeId: ref('roomTypeId', true),
+          number: req('number'),
+          floor: str('floor'),
+          building: str('building'),
+          isAccessible: row['isAccessible'] === true || row['isAccessible'] === 'true',
+          amenities: Array.isArray(row['amenities']) ? row['amenities'] : undefined,
+        };
+      case 'rate-plans':
+        return {
+          propertyId,
+          roomTypeId: ref('roomTypeId', true),
+          name: req('name'),
+          code: req('code'),
+          type: req('type'),
+          description: str('description'),
+          baseAmount: req('baseAmount'),
+          currencyCode: req('currencyCode'),
+          mealPlan: str('mealPlan'),
+        };
+      case 'reservations':
+        return {
+          propertyId,
+          guestId: ref('guestId', true),
+          arrivalDate: req('arrivalDate'),
+          departureDate: req('departureDate'),
+          roomTypeId: ref('roomTypeId', true),
+          ratePlanId: ref('ratePlanId', true),
+          totalAmount: req('totalAmount'),
+          currencyCode: req('currencyCode'),
+          source: str('source') ?? 'direct',
+          adults: int('adults'),
+          children: int('children'),
+          specialRequests: str('specialRequests'),
+          channelCode: str('channelCode'),
+          externalConfirmation: str('externalConfirmation') ?? str('legacyId'),
+        };
+      case 'folio-balances':
+        return {
+          propertyId,
+          reservationId: ref('reservationId'),
+          guestId: ref('guestId', true),
+          amount: req('amount'),
+          currencyCode: req('currencyCode'),
+          note: str('note'),
+        };
+    }
+  }
+
+  private async persist(
+    entity: MigrationEntity,
+    dto: Record<string, unknown>,
+  ): Promise<{ id: string }> {
+    switch (entity) {
+      case 'guests':
+        return this.guestService.create(dto as any);
+      case 'room-types':
+        return this.roomService.createRoomType(dto as any);
+      case 'rooms':
+        return this.roomService.createRoom(dto as any);
+      case 'rate-plans':
+        return this.ratePlanService.create(dto as any);
+      case 'reservations':
+        return this.reservationService.create(dto as any);
+      case 'folio-balances': {
+        // Opening balance: fresh guest folio + a single adjustment charge.
+        // Closed-period history is archived, never replayed into the ledger.
+        const folio = await this.folioService.create({
+          propertyId: dto['propertyId'],
+          reservationId: dto['reservationId'],
+          guestId: dto['guestId'],
+          type: 'guest',
+          currencyCode: dto['currencyCode'],
+          notes: `Migration opening balance${dto['note'] ? ` — ${dto['note']}` : ''}`,
+        } as any);
+        const amount = Number(dto['amount']);
+        if (amount > 0) {
+          await this.folioService.postCharge(folio.id, {
+            propertyId: dto['propertyId'],
+            type: 'adjustment',
+            description: 'Opening balance carried from previous PMS',
+            amount: dto['amount'],
+            currencyCode: dto['currencyCode'],
+            serviceDate: new Date().toISOString().slice(0, 10),
+            skipTaxCalculation: true,
+          } as any);
+        }
+        return folio;
+      }
+    }
+  }
+
+  // ── Source credential vault (TEL-70) ──────────────────────────────────────
+
+  async storeSourceCredential(
+    propertyId: string,
+    sourcePms: string,
+    secret: string,
+    createdBy?: string,
+  ) {
+    if (!this.crypto.isEnabled()) {
+      throw new BadRequestException(
+        'Credential storage is not configured on this environment (MIGRATION_CREDENTIAL_KEY missing)',
+      );
+    }
+    const { ciphertext, keyId } = this.crypto.encrypt(secret);
+    await this.db
+      .insert(migrationSourceCredentials)
+      .values({ propertyId, sourcePms, ciphertext, keyId, createdBy })
+      .onConflictDoUpdate({
+        target: [migrationSourceCredentials.propertyId, migrationSourceCredentials.sourcePms],
+        set: { ciphertext, keyId, rotatedAt: new Date(), updatedAt: new Date() },
+      });
+    return { propertyId, sourcePms, stored: true };
+  }
+
+  /** Server-side only — the runner uses this to call the source PMS. Never exposed via API. */
+  async readSourceCredential(propertyId: string, sourcePms: string): Promise<string | null> {
+    const [row] = await this.db
+      .select({ ciphertext: migrationSourceCredentials.ciphertext })
+      .from(migrationSourceCredentials)
+      .where(
+        and(
+          eq(migrationSourceCredentials.propertyId, propertyId),
+          eq(migrationSourceCredentials.sourcePms, sourcePms),
+        ),
+      );
+    if (!row) return null;
+    return this.crypto.decrypt(row.ciphertext);
+  }
+
+  async deleteSourceCredential(propertyId: string, sourcePms: string) {
+    await this.db
+      .delete(migrationSourceCredentials)
+      .where(
+        and(
+          eq(migrationSourceCredentials.propertyId, propertyId),
+          eq(migrationSourceCredentials.sourcePms, sourcePms),
+        ),
+      );
+    return { deleted: true };
+  }
+
+  /** Job view for API consumers — rows payload is large; expose counts + errors. */
+  private publicView(job: any) {
+    const { rows, ...rest } = job;
+    return {
+      ...rest,
+      dryRun: job.dryRun === 'true',
+      errors: Array.isArray(job.errors) ? (job.errors as unknown[]).slice(0, 500) : [],
+      errorCount: Array.isArray(job.errors) ? (job.errors as unknown[]).length : 0,
+    };
+  }
+}

--- a/packages/database/src/migrations/0019_pms_migration.sql
+++ b/packages/database/src/migrations/0019_pms_migration.sql
@@ -1,0 +1,62 @@
+-- PMS migration foundation (TEL-67/70): durable migration jobs, legacy id map,
+-- and encrypted-at-app source-PMS credential storage.
+-- Applied idempotently via push-schema.ts; this file documents the incremental DDL.
+
+CREATE TYPE migration_job_status AS ENUM
+  ('pending','running','completed','completed_with_errors','failed','cancelled');
+CREATE TYPE migration_entity AS ENUM
+  ('guests','room-types','rooms','rate-plans','reservations','folio-balances');
+
+CREATE TABLE IF NOT EXISTS migration_jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  project_ref varchar(120) NOT NULL,
+  entity migration_entity NOT NULL,
+  status migration_job_status NOT NULL DEFAULT 'pending',
+  rows jsonb NOT NULL,
+  total_rows integer NOT NULL,
+  processed_rows integer NOT NULL DEFAULT 0,
+  created_count integer NOT NULL DEFAULT 0,
+  skipped_count integer NOT NULL DEFAULT 0,
+  failed_count integer NOT NULL DEFAULT 0,
+  errors jsonb NOT NULL DEFAULT '[]'::jsonb,
+  dry_run varchar(5) NOT NULL DEFAULT 'false',
+  attempts integer NOT NULL DEFAULT 0,
+  last_error text,
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS migration_jobs_property_status_idx
+  ON migration_jobs (property_id, status);
+CREATE INDEX IF NOT EXISTS migration_jobs_project_ref_idx
+  ON migration_jobs (property_id, project_ref);
+
+CREATE TABLE IF NOT EXISTS migration_legacy_id_map (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  project_ref varchar(120) NOT NULL,
+  entity migration_entity NOT NULL,
+  legacy_id varchar(255) NOT NULL,
+  haip_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS migration_legacy_id_map_unique
+  ON migration_legacy_id_map (property_id, project_ref, entity, legacy_id);
+CREATE INDEX IF NOT EXISTS migration_legacy_id_map_lookup_idx
+  ON migration_legacy_id_map (property_id, project_ref, entity, haip_id);
+
+CREATE TABLE IF NOT EXISTS migration_source_credentials (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  property_id uuid NOT NULL REFERENCES properties(id),
+  source_pms varchar(60) NOT NULL,
+  ciphertext text NOT NULL,
+  key_id varchar(40) NOT NULL,
+  created_by varchar(255),
+  rotated_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS migration_source_credentials_unique
+  ON migration_source_credentials (property_id, source_pms);

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -84,6 +84,9 @@ async function main() {
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cancellation_penalty_type') THEN CREATE TYPE cancellation_penalty_type AS ENUM ('none','first_night','percentage','full'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'cancellation_deposit_handling') THEN CREATE TYPE cancellation_deposit_handling AS ENUM ('refund_if_refundable','always_forfeit','always_refund'); END IF; END $$`,
     `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'door_lock_credential_status') THEN CREATE TYPE door_lock_credential_status AS ENUM ('active','revoked'); END IF; END $$`,
+    // PMS migration (TEL-67/70)
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'migration_job_status') THEN CREATE TYPE migration_job_status AS ENUM ('pending','running','completed','completed_with_errors','failed','cancelled'); END IF; END $$`,
+    `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'migration_entity') THEN CREATE TYPE migration_entity AS ENUM ('guests','room-types','rooms','rate-plans','reservations','folio-balances'); END IF; END $$`,
   ];
 
   for (const e of enums) {
@@ -1356,6 +1359,74 @@ async function main() {
   await db.execute(sql.raw(`
     CREATE INDEX IF NOT EXISTS ical_blocks_feed_dates_idx
       ON ical_blocks (feed_id, start_date, end_date)`));
+
+  // PMS migration — durable jobs, legacy id map, source credentials (TEL-67/70)
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS migration_jobs (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      project_ref varchar(120) NOT NULL,
+      entity migration_entity NOT NULL,
+      status migration_job_status NOT NULL DEFAULT 'pending',
+      rows jsonb NOT NULL,
+      total_rows integer NOT NULL,
+      processed_rows integer NOT NULL DEFAULT 0,
+      created_count integer NOT NULL DEFAULT 0,
+      skipped_count integer NOT NULL DEFAULT 0,
+      failed_count integer NOT NULL DEFAULT 0,
+      errors jsonb NOT NULL DEFAULT '[]'::jsonb,
+      dry_run varchar(5) NOT NULL DEFAULT 'false',
+      attempts integer NOT NULL DEFAULT 0,
+      last_error text,
+      started_at timestamptz,
+      completed_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE INDEX IF NOT EXISTS migration_jobs_property_status_idx
+      ON migration_jobs (property_id, status)`));
+
+  await db.execute(sql.raw(`
+    CREATE INDEX IF NOT EXISTS migration_jobs_project_ref_idx
+      ON migration_jobs (property_id, project_ref)`));
+
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS migration_legacy_id_map (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      project_ref varchar(120) NOT NULL,
+      entity migration_entity NOT NULL,
+      legacy_id varchar(255) NOT NULL,
+      haip_id uuid NOT NULL,
+      created_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS migration_legacy_id_map_unique
+      ON migration_legacy_id_map (property_id, project_ref, entity, legacy_id)`));
+
+  await db.execute(sql.raw(`
+    CREATE INDEX IF NOT EXISTS migration_legacy_id_map_lookup_idx
+      ON migration_legacy_id_map (property_id, project_ref, entity, haip_id)`));
+
+  await db.execute(sql.raw(`
+    CREATE TABLE IF NOT EXISTS migration_source_credentials (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      property_id uuid NOT NULL REFERENCES properties(id),
+      source_pms varchar(60) NOT NULL,
+      ciphertext text NOT NULL,
+      key_id varchar(40) NOT NULL,
+      created_by varchar(255),
+      rotated_at timestamptz,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`));
+
+  await db.execute(sql.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS migration_source_credentials_unique
+      ON migration_source_credentials (property_id, source_pms)`));
 
   // Idempotent column additions for pre-existing databases
   const alters = [

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -261,3 +261,12 @@ export {
   icalFeeds,
   icalBlocks,
 } from './ical.js';
+
+// PMS migration — durable jobs, legacy id map, source credentials (TEL-67/70)
+export {
+  migrationJobStatusEnum,
+  migrationEntityEnum,
+  migrationJobs,
+  migrationLegacyIdMap,
+  migrationSourceCredentials,
+} from './migration.js';

--- a/packages/database/src/schema/migration.ts
+++ b/packages/database/src/schema/migration.ts
@@ -1,0 +1,136 @@
+import {
+  pgTable,
+  pgEnum,
+  uuid,
+  varchar,
+  text,
+  integer,
+  jsonb,
+  timestamp,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
+import { properties } from './property.js';
+
+/**
+ * PMS migration jobs — durable, resumable batch imports (TEL-67).
+ *
+ * A migration job is one entity-batch inside a wider migration project owned by
+ * Remy (project ids are external references — HAIP does not depend on the Remy
+ * DB). Rows are processed in chunks by a BullMQ worker; `processedRows` is the
+ * checkpoint cursor and `migration_legacy_id_map` makes re-runs idempotent.
+ */
+export const migrationJobStatusEnum = pgEnum('migration_job_status', [
+  'pending',
+  'running',
+  'completed',
+  'completed_with_errors',
+  'failed',
+  'cancelled',
+]);
+
+export const migrationEntityEnum = pgEnum('migration_entity', [
+  'guests',
+  'room-types',
+  'rooms',
+  'rate-plans',
+  'reservations',
+  'folio-balances',
+]);
+
+export const migrationJobs = pgTable(
+  'migration_jobs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    propertyId: uuid('property_id')
+      .notNull()
+      .references(() => properties.id),
+    /** External project reference (Remy migration project id or manual run). */
+    projectRef: varchar('project_ref', { length: 120 }).notNull(),
+    entity: migrationEntityEnum('entity').notNull(),
+    status: migrationJobStatusEnum('status').notNull().default('pending'),
+    /** Source rows staged for processing. */
+    rows: jsonb('rows').notNull(),
+    totalRows: integer('total_rows').notNull(),
+    /** Checkpoint cursor — index of the next unprocessed row. */
+    processedRows: integer('processed_rows').notNull().default(0),
+    createdCount: integer('created_count').notNull().default(0),
+    /** Skipped because the legacy id was already imported (idempotent re-run). */
+    skippedCount: integer('skipped_count').notNull().default(0),
+    failedCount: integer('failed_count').notNull().default(0),
+    /** Row-level errors: [{ index, legacyId?, error }]. */
+    errors: jsonb('errors').notNull().default([]),
+    dryRun: varchar('dry_run', { length: 5 }).notNull().default('false'),
+    attempts: integer('attempts').notNull().default(0),
+    lastError: text('last_error'),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    propertyStatusIdx: index('migration_jobs_property_status_idx').on(t.propertyId, t.status),
+    projectIdx: index('migration_jobs_project_ref_idx').on(t.propertyId, t.projectRef),
+  }),
+);
+
+/**
+ * Legacy identity map — the linchpin of idempotent migration. One row per
+ * imported entity instance: (property, project, entity, legacy id) → HAIP uuid.
+ * Reservation/folio steps resolve their references through this table, and
+ * re-runs skip already-mapped rows instead of duplicating them.
+ */
+export const migrationLegacyIdMap = pgTable(
+  'migration_legacy_id_map',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    propertyId: uuid('property_id')
+      .notNull()
+      .references(() => properties.id),
+    projectRef: varchar('project_ref', { length: 120 }).notNull(),
+    entity: migrationEntityEnum('entity').notNull(),
+    legacyId: varchar('legacy_id', { length: 255 }).notNull(),
+    haipId: uuid('haip_id').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: uniqueIndex('migration_legacy_id_map_unique').on(
+      t.propertyId,
+      t.projectRef,
+      t.entity,
+      t.legacyId,
+    ),
+    lookupIdx: index('migration_legacy_id_map_lookup_idx').on(
+      t.propertyId,
+      t.projectRef,
+      t.entity,
+      t.haipId,
+    ),
+  }),
+);
+
+/**
+ * Source-PMS credentials for API-pull connectors (TEL-70). Ciphertext only —
+ * app-level AES-256-GCM; plaintext never leaves the migration service.
+ */
+export const migrationSourceCredentials = pgTable(
+  'migration_source_credentials',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    propertyId: uuid('property_id')
+      .notNull()
+      .references(() => properties.id),
+    sourcePms: varchar('source_pms', { length: 60 }).notNull(),
+    /** AES-256-GCM payload: v1.<kid>.<b64 iv>.<b64 tag>.<b64 ciphertext>. */
+    ciphertext: text('ciphertext').notNull(),
+    /** Identifies which key encrypted this row (rotation seam). */
+    keyId: varchar('key_id', { length: 40 }).notNull(),
+    createdBy: varchar('created_by', { length: 255 }),
+    rotatedAt: timestamp('rotated_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    uniq: uniqueIndex('migration_source_credentials_unique').on(t.propertyId, t.sourcePms),
+  }),
+);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Foundation for the **Automated Migration from PMS' to Haip Cloud** project ([Linear TEL-76 plan](https://linear.app/telivity/project/automated-migration-from-pms-to-haip-cloud-3c41690aae7f)). This is the engine Remy will drive — durable, resumable, idempotent batch imports that replace today's synchronous in-request loops.

Implements **TEL-67** (migration engine) and **TEL-70** (credential vault).

## What's new

### Migration jobs — `POST /api/v1/migration/jobs`
One job = one entity batch inside a wider migration project (`projectRef`). Rows are staged on the job row and processed in 200-row chunks by a BullMQ worker (queue `haip-migration-jobs`, Redis-backed, mirrors the webhook-delivery pattern). `processedRows` is the checkpoint cursor — a crash/restart resumes from the last committed chunk.

- **Idempotent re-runs**: every row carries `legacyId`; completion is recorded in `migration_legacy_id_map` and re-runs **skip** instead of duplicating (double-approve / re-upload becomes a safe no-op).
- **Legacy-id references**: reference fields (`roomTypeId`, `ratePlanId`, `guestId`, `reservationId`) accept `{ "legacyId": "..." }` and resolve through the id map — callers never need HAIP UUIDs.
- **dry-run**: validate without writing.
- **Per-row errors**: one bad row never aborts the batch.

### New importers
`guests`, `room-types`, `rooms` (new), `rate-plans`, `reservations`, `folio-balances` (new — opening balance as a single `adjustment` charge; **closed-period history is never replayed**).

### Credential vault — `POST /api/v1/migration/credentials`
Source-PMS API tokens stored **AES-256-GCM** at rest (`migration_source_credentials`), with a key-id rotation seam. Fails closed when `MIGRATION_CREDENTIAL_KEY` is unset. Plaintext never appears in responses/logs; read path is server-side only.

## Schema

New enums `migration_job_status` / `migration_entity` + tables `migration_jobs`, `migration_legacy_id_map`, `migration_source_credentials` (push-schema + `0019_pms_migration.sql`).

## Verification

- 15 new unit tests (`migration.service`, `migration-crypto.service`) — green.
- Full suite: **1395 passed / 1 skipped**; typecheck clean; lint 0 errors.
- Live smoke on dev API + Postgres + Redis: guests job (2 created / 1 row-error), idempotent re-run (0 created / 2 skipped), rooms via legacy room-type ref, folio opening balance, credential store→ciphertext-at-rest→delete.

## Notes for reviewers

- Multi-tenancy: `propertyId` is a required, UUID-validated param on every route and scopes every query (per CLAUDE.md).
- Remy-side project/runner + the Mews pack land in follow-up issues (TEL-68/69) against the `remy` repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4abbf08-f413-456e-89ca-a3ee265b0841?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4abbf08-f413-456e-89ca-a3ee265b0841&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

