### PR TITLE
feat(db): support transaction-pooling poolers (pgbouncer / RDS Proxy / Supabase)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,10 @@ DATABASE_URL=postgresql://haip:haip@localhost:5432/haip
 # (pgbouncer, RDS Proxy, Supabase). Disables named prepared statements, which
 # cannot work when each query may land on a different backend connection.
 # DATABASE_POOLER_MODE=transaction
-# Set to `no-verify` for a pooler that terminates TLS with a private or
-# self-signed certificate: TLS on, certificate chain not verified.
+# WARNING: `no-verify` disables TLS certificate verification (MITM risk on the
+# DB connection). Prefer a real CA or sslrootcert when possible. Only use this
+# for a pooler that terminates TLS with a private/self-signed certificate and
+# you accept that tradeoff: TLS on, certificate chain not verified.
 # DATABASE_SSL=no-verify
 
 # Redis

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@
 
 # Database
 DATABASE_URL=postgresql://haip:haip@localhost:5432/haip
+# Set to `transaction` when connecting through a transaction-pooling pooler
+# (pgbouncer, RDS Proxy, Supabase). Disables named prepared statements, which
+# cannot work when each query may land on a different backend connection.
+# DATABASE_POOLER_MODE=transaction
+# Set to `no-verify` for a pooler that terminates TLS with a private or
+# self-signed certificate: TLS on, certificate chain not verified.
+# DATABASE_SSL=no-verify
 
 # Redis
 REDIS_URL=redis://localhost:6379

--- a/.env.production.example
+++ b/.env.production.example
@@ -9,6 +9,13 @@
 # ── Database (REQUIRED) ───────────────────────────────────────────────────────
 # Default matches docker-compose postgres service (user/password/db: haip).
 DATABASE_URL=postgresql://haip:haip@postgres:5432/haip
+# Set to `transaction` when connecting through a transaction-pooling pooler
+# (pgbouncer, RDS Proxy, Supabase). Disables named prepared statements, which
+# cannot work when each query may land on a different backend connection.
+# DATABASE_POOLER_MODE=transaction
+# Set to `no-verify` for a pooler that terminates TLS with a private or
+# self-signed certificate: TLS on, certificate chain not verified.
+# DATABASE_SSL=no-verify
 
 # ── Redis (REQUIRED) ──────────────────────────────────────────────────────────
 REDIS_URL=redis://redis:6379

--- a/.env.production.example
+++ b/.env.production.example
@@ -13,8 +13,10 @@ DATABASE_URL=postgresql://haip:haip@postgres:5432/haip
 # (pgbouncer, RDS Proxy, Supabase). Disables named prepared statements, which
 # cannot work when each query may land on a different backend connection.
 # DATABASE_POOLER_MODE=transaction
-# Set to `no-verify` for a pooler that terminates TLS with a private or
-# self-signed certificate: TLS on, certificate chain not verified.
+# WARNING: `no-verify` disables TLS certificate verification (MITM risk on the
+# DB connection). Prefer a real CA or sslrootcert when possible. Only use this
+# for a pooler that terminates TLS with a private/self-signed certificate and
+# you accept that tradeoff: TLS on, certificate chain not verified.
 # DATABASE_SSL=no-verify
 
 # ── Redis (REQUIRED) ──────────────────────────────────────────────────────────

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -17,7 +17,21 @@ export const DRIZZLE = Symbol('DRIZZLE');
           'DATABASE_URL',
           'postgresql://haip:haip@localhost:5432/haip',
         );
-        const client = postgres(url);
+        // Transaction-pooling poolers (pgbouncer, RDS Proxy, Supabase pooler) cannot
+        // support postgres.js's default named prepared statements: the statement is
+        // prepared on one backend connection and executed on another. Setting
+        // DATABASE_POOLER_MODE=transaction disables them; direct connections keep the
+        // default, where prepared statements are a real win.
+        const prepare =
+          config.get<string>('DATABASE_POOLER_MODE', '') !== 'transaction';
+        // DATABASE_SSL=no-verify: TLS on, chain unverified — for poolers that
+        // terminate TLS with a private or self-signed certificate. sslmode in the
+        // connection URL is not honoured consistently across postgres.js versions,
+        // so this is explicit rather than a URL parameter.
+        const sslEnv = config.get<string>('DATABASE_SSL', '');
+        const ssl =
+          sslEnv === 'no-verify' ? { rejectUnauthorized: false } : undefined;
+        const client = postgres(url, { prepare, ...(ssl ? { ssl } : {}) });
         return drizzle(client, { schema });
       },
     },

--- a/apps/api/src/database/database.module.ts
+++ b/apps/api/src/database/database.module.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from '@telivityhaip/database';
+import { postgresOptionsFromEnv } from '@telivityhaip/database';
 
 export const DRIZZLE = Symbol('DRIZZLE');
 
@@ -17,21 +18,13 @@ export const DRIZZLE = Symbol('DRIZZLE');
           'DATABASE_URL',
           'postgresql://haip:haip@localhost:5432/haip',
         );
-        // Transaction-pooling poolers (pgbouncer, RDS Proxy, Supabase pooler) cannot
-        // support postgres.js's default named prepared statements: the statement is
-        // prepared on one backend connection and executed on another. Setting
-        // DATABASE_POOLER_MODE=transaction disables them; direct connections keep the
-        // default, where prepared statements are a real win.
-        const prepare =
-          config.get<string>('DATABASE_POOLER_MODE', '') !== 'transaction';
-        // DATABASE_SSL=no-verify: TLS on, chain unverified — for poolers that
-        // terminate TLS with a private or self-signed certificate. sslmode in the
-        // connection URL is not honoured consistently across postgres.js versions,
-        // so this is explicit rather than a URL parameter.
-        const sslEnv = config.get<string>('DATABASE_SSL', '');
-        const ssl =
-          sslEnv === 'no-verify' ? { rejectUnauthorized: false } : undefined;
-        const client = postgres(url, { prepare, ...(ssl ? { ssl } : {}) });
+        const client = postgres(
+          url,
+          postgresOptionsFromEnv({
+            DATABASE_POOLER_MODE: config.get<string>('DATABASE_POOLER_MODE'),
+            DATABASE_SSL: config.get<string>('DATABASE_SSL'),
+          }),
+        );
         return drizzle(client, { schema });
       },
     },

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,1 +1,6 @@
 export * from './schema/index.js';
+export {
+  postgresOptionsFromEnv,
+  type PostgresOptionsFromEnv,
+  type PostgresPoolerEnv,
+} from './postgres-options.js';

--- a/packages/database/src/postgres-options.ts
+++ b/packages/database/src/postgres-options.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared postgres.js options for HAIP database connections.
+ *
+ * Used by the API, seed, and push-schema so pooler/TLS behaviour cannot drift.
+ *
+ * - DATABASE_POOLER_MODE=transaction → prepare: false (required under
+ *   transaction-pooling poolers: pgbouncer, RDS Proxy, Supabase).
+ * - DATABASE_SSL=no-verify → TLS on, certificate chain not verified.
+ *   Prefer a real CA / sslrootcert when possible; no-verify is a MITM tradeoff.
+ */
+
+export type PostgresOptionsFromEnv = {
+  prepare: boolean;
+  ssl?: { rejectUnauthorized: false };
+};
+
+export type PostgresPoolerEnv = {
+  DATABASE_POOLER_MODE?: string | null;
+  DATABASE_SSL?: string | null;
+};
+
+export function postgresOptionsFromEnv(
+  env: PostgresPoolerEnv = process.env,
+): PostgresOptionsFromEnv {
+  const prepare = env.DATABASE_POOLER_MODE !== 'transaction';
+  if (env.DATABASE_SSL === 'no-verify') {
+    return { prepare, ssl: { rejectUnauthorized: false } };
+  }
+  return { prepare };
+}

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -12,7 +12,15 @@ const DATABASE_URL =
   process.env['DATABASE_URL'] ?? 'postgresql://haip:haip@localhost:5432/haip';
 
 async function main() {
-  const client = postgres(DATABASE_URL);
+  const client = postgres(DATABASE_URL, {
+    // Same pooler rules as apps/api database.module.ts: named prepared statements
+    // break under transaction pooling, and DATABASE_SSL=no-verify turns on TLS
+    // without chain verification for poolers using a private certificate.
+    prepare: process.env['DATABASE_POOLER_MODE'] !== 'transaction',
+    ...(process.env['DATABASE_SSL'] === 'no-verify'
+      ? { ssl: { rejectUnauthorized: false } }
+      : {}),
+  });
   const db = drizzle(client, { schema });
 
   // Create enums

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -7,20 +7,13 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { sql } from 'drizzle-orm';
 import * as schema from './schema/index.js';
 import { INTEGRATION_REGISTRY_SEED } from './schema/integration-registry-seed.js';
+import { postgresOptionsFromEnv } from './postgres-options.js';
 
 const DATABASE_URL =
   process.env['DATABASE_URL'] ?? 'postgresql://haip:haip@localhost:5432/haip';
 
 async function main() {
-  const client = postgres(DATABASE_URL, {
-    // Same pooler rules as apps/api database.module.ts: named prepared statements
-    // break under transaction pooling, and DATABASE_SSL=no-verify turns on TLS
-    // without chain verification for poolers using a private certificate.
-    prepare: process.env['DATABASE_POOLER_MODE'] !== 'transaction',
-    ...(process.env['DATABASE_SSL'] === 'no-verify'
-      ? { ssl: { rejectUnauthorized: false } }
-      : {}),
-  });
+  const client = postgres(DATABASE_URL, postgresOptionsFromEnv());
   const db = drizzle(client, { schema });
 
   // Create enums

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -60,7 +60,15 @@ function ts(d: number, hh = 0, mm = 0): Date {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const client = postgres(DATABASE_URL);
+  const client = postgres(DATABASE_URL, {
+    // Same pooler rules as apps/api database.module.ts: named prepared statements
+    // break under transaction pooling, and DATABASE_SSL=no-verify turns on TLS
+    // without chain verification for poolers using a private certificate.
+    prepare: process.env['DATABASE_POOLER_MODE'] !== 'transaction',
+    ...(process.env['DATABASE_SSL'] === 'no-verify'
+      ? { ssl: { rejectUnauthorized: false } }
+      : {}),
+  });
   const db = drizzle(client, { schema });
 
   // Idempotency check

--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -13,6 +13,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import { createHash } from 'node:crypto';
 import * as schema from './schema/index.js';
+import { postgresOptionsFromEnv } from './postgres-options.js';
 
 /**
  * Fixed publishable booking-engine key for the demo property. The raw value is
@@ -60,15 +61,7 @@ function ts(d: number, hh = 0, mm = 0): Date {
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const client = postgres(DATABASE_URL, {
-    // Same pooler rules as apps/api database.module.ts: named prepared statements
-    // break under transaction pooling, and DATABASE_SSL=no-verify turns on TLS
-    // without chain verification for poolers using a private certificate.
-    prepare: process.env['DATABASE_POOLER_MODE'] !== 'transaction',
-    ...(process.env['DATABASE_SSL'] === 'no-verify'
-      ? { ssl: { rejectUnauthorized: false } }
-      : {}),
-  });
+  const client = postgres(DATABASE_URL, postgresOptionsFromEnv());
   const db = drizzle(client, { schema });
 
   // Idempotency check


### PR DESCRIPTION
Running HAIP against Postgres through pgbouncer in transaction mode, the API dies on its second concurrent query. Two causes, both in how `postgres.js` is initialised.

**1. Named prepared statements.** postgres.js prepares by default. Under transaction pooling the statement is prepared on one backend connection and executed on another, which fails. The driver supports `prepare: false` for exactly this case, but there's no way to reach it from configuration today.

**2. TLS.** Poolers commonly terminate TLS with a private or self-signed certificate, and `sslmode` in the connection URL is not honoured consistently across postgres.js versions — so a URL parameter looks like it works and doesn't.

## The change

Two environment switches, both defaulting to current behaviour so nothing changes for direct connections:

- `DATABASE_POOLER_MODE=transaction` → `prepare: false`
- `DATABASE_SSL=no-verify` → `ssl: { rejectUnauthorized: false }`

Applied at all three connection sites (`apps/api` database module, `seed`, `push-schema`), since the init containers reach the database through the same pooler. Documented in `.env.example` and `.env.production.example`.

Direct connections keep prepared statements, which are a real win when you own the connection — the switch only opts out where the pooler makes them impossible.

## Testing

Verified against pgbouncer in transaction mode with a self-signed certificate: without these, `push-schema` exits on `PostgresError: SSL required` and the API fails on concurrent queries; with them, schema push and normal operation both succeed. `pnpm build && pnpm -r test` green.

Happy to split the TLS half into its own PR if you'd prefer them separate.