### PR TITLE
fix(compose): bind datastore ports to loopback + harden probe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: haip
       POSTGRES_DB: haip
     ports:
-      - '5432:5432'
+      - '127.0.0.1:5432:5432'
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./keycloak/init-keycloak-db.sh:/docker-entrypoint-initdb.d/init-keycloak-db.sh:ro
@@ -23,7 +23,7 @@ services:
     image: redis:7-alpine
     container_name: haip-redis
     ports:
-      - '6379:6379'
+      - '127.0.0.1:6379:6379'
     volumes:
       - redis-data:/data
     healthcheck:
@@ -200,8 +200,8 @@ services:
       MINIO_ROOT_USER: haip
       MINIO_ROOT_PASSWORD: haip_secret
     ports:
-      - '9000:9000' # S3 API
-      - '9001:9001' # Web console
+      - '127.0.0.1:9000:9000' # S3 API
+      - '127.0.0.1:9001:9001' # Web console
     volumes:
       - minio-data:/data
 

--- a/ops/harden/cli/probes/local.mjs
+++ b/ops/harden/cli/probes/local.mjs
@@ -93,6 +93,34 @@ export async function runLocalFileProbes() {
     });
   }
 
+  // Datastores must not be published on all interfaces. Docker's published ports
+  // bypass host firewalls — ufw and firewalld rules sit behind Docker's own chain —
+  // so `- '5432:5432'` on a public host is an internet-reachable Postgres carrying
+  // this file's default credentials, even with a firewall correctly configured.
+  const baseCompose = path.join(root, 'docker-compose.yml');
+  if (fs.existsSync(baseCompose)) {
+    const composeText = fs.readFileSync(baseCompose, 'utf8');
+    const exposed = [];
+    for (const [svc, port] of [
+      ['postgres', 5432],
+      ['redis', 6379],
+      ['minio', 9000],
+    ]) {
+      // matches '5432:5432' but not '127.0.0.1:5432:5432'
+      if (new RegExp(`^\\s*-\\s*['"]${port}:${port}['"]`, 'm').test(composeText)) {
+        exposed.push(`${svc}:${port}`);
+      }
+    }
+    results.push({
+      id: 'compose:datastores-loopback',
+      ok: exposed.length === 0,
+      detail:
+        exposed.length === 0
+          ? 'datastore ports are bound to loopback or unpublished'
+          : `published on all interfaces: ${exposed.join(', ')} — bind to 127.0.0.1`,
+    });
+  }
+
   // Vignette pack present
   const vignetteDir = path.join(root, 'ops/harden/vignettes');
   let vignetteCount = 0;

--- a/ops/harden/cli/probes/local.mjs
+++ b/ops/harden/cli/probes/local.mjs
@@ -105,6 +105,7 @@ export async function runLocalFileProbes() {
       ['postgres', 5432],
       ['redis', 6379],
       ['minio', 9000],
+      ['minio', 9001],
     ]) {
       // matches '5432:5432' but not '127.0.0.1:5432:5432'
       if (new RegExp(`^\\s*-\\s*['"]${port}:${port}['"]`, 'm').test(composeText)) {


### PR DESCRIPTION
`docker-compose.yml` publishes Postgres on `5432:5432` and Redis on `6379:6379` — all interfaces — with the credentials set in the same file (`haip`/`haip`).

The reason this is worth more than a style nit: **Docker's published ports bypass host firewalls.** ufw and firewalld operate on chains that Docker's own rules sit in front of, so an operator who has correctly configured a firewall still ends up with an internet-reachable Postgres carrying default credentials the moment they run `docker compose up` on a public host. Following the quick start exactly is enough to get there.

## The change

Bind `postgres`, `redis` and `minio` to `127.0.0.1`. **The dev workflow is unaffected** — `psql`, a GUI client, and the MinIO console all still connect from the host exactly as before. Only external interfaces stop being served.

I've also added `compose:datastores-loopback` to `ops/harden/cli/probes/local.mjs`, since the harden pack is already the right home for "would this be safe on a public host" — this way a regression gets caught pre-go-live rather than by a port scan.

**Probe verified both directions** (I don't have Node locally, so I checked the pattern against both trees rather than claiming a test run): it flags all three services on the current file, and passes cleanly on the patched one. A check that has only ever passed isn't a check.

## Deliberately not changed — flagging rather than presuming

Keycloak under the `auth` profile publishes `8080` with `KEYCLOAK_ADMIN=admin` / `KEYCLOAK_ADMIN_PASSWORD=admin`. Same exposure shape, but changing it may cut across how you intend that profile to be used remotely. Happy to follow up separately if you'd like it treated the same way.

Found while running HAIP self-hosted with auth on — the harden pack made that path a lot smoother, so this is meant as a small addition to it rather than a criticism of it.