### PR TITLE
fix(dashboard): render money in the property's currency, not hardcoded USD

### DIFF
--- a/apps/dashboard/src/components/front-desk/GuestDetailsModal.tsx
+++ b/apps/dashboard/src/components/front-desk/GuestDetailsModal.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { formatMoney } from '../../lib/money';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { ArrowRightLeft, StickyNote, LogIn, LogOut } from 'lucide-react';
@@ -229,7 +230,7 @@ export default function GuestDetailsModal({
               {t('frontDesk.accountSummary')}
             </p>
             <p className="text-sm text-telivity-navy font-semibold">
-              {t('frontDesk.balance')}: ${Number(balance).toFixed(2)}
+              {t('frontDesk.balance')}: {formatMoney(balance)}
             </p>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -247,7 +248,7 @@ export default function GuestDetailsModal({
                     <li key={c.id} className="flex justify-between gap-2 text-sm">
                       <span className="text-telivity-slate truncate">{c.description || '—'}</span>
                       <span className="font-medium text-telivity-navy shrink-0">
-                        ${Number(c.amount).toFixed(2)}
+                        {formatMoney(c.amount)}
                       </span>
                     </li>
                   ))}
@@ -268,7 +269,7 @@ export default function GuestDetailsModal({
                     <li key={p.id} className="flex justify-between gap-2 text-sm">
                       <span className="text-telivity-slate truncate">{p.method || '—'}</span>
                       <span className="font-medium text-telivity-navy shrink-0">
-                        ${Number(p.amount).toFixed(2)}
+                        {formatMoney(p.amount)}
                       </span>
                     </li>
                   ))}

--- a/apps/dashboard/src/components/rates/RatePlanCalendar.tsx
+++ b/apps/dashboard/src/components/rates/RatePlanCalendar.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react';
+import { formatMoney } from '../../lib/money';
 import { useQuery } from '@tanstack/react-query';
 import { addDays, format } from 'date-fns';
 import { api } from '../../lib/api';
@@ -165,8 +166,8 @@ export default function RatePlanCalendar({ ratePlanId, propertyId, baseAmount }:
               {days.map((day, i) => (
                 <tr key={day.date} className={`border-b border-gray-50 ${i % 2 === 1 ? 'bg-gray-50/50' : ''}`}>
                   <td className="px-3 py-2 text-sm text-telivity-slate">{day.date}</td>
-                  <td className="px-3 py-2 text-sm text-right text-telivity-mid-grey">${day.baseRate.toFixed(2)}</td>
-                  <td className="px-3 py-2 text-sm text-right font-medium text-telivity-navy">${day.effectiveRate.toFixed(2)}</td>
+                  <td className="px-3 py-2 text-sm text-right text-telivity-mid-grey">{formatMoney(day.baseRate)}</td>
+                  <td className="px-3 py-2 text-sm text-right font-medium text-telivity-navy">{formatMoney(day.effectiveRate)}</td>
                   <td className="px-3 py-2">
                     <div className="flex flex-wrap gap-1">
                       {day.badges.length === 0 ? (

--- a/apps/dashboard/src/context/PropertyContext.tsx
+++ b/apps/dashboard/src/context/PropertyContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, type ReactNode } from '
 import { useSearchParams } from 'react-router-dom';
 import { api, setPropertyId as setApiPropertyId } from '../lib/api';
 import { joinPropertyRoom, leavePropertyRoom } from '../lib/socket';
+import { DEFAULT_CURRENCY } from '../lib/money';
 import {
   PORTFOLIO_MODE_ID,
   type PropertySummary,
@@ -10,6 +11,8 @@ import {
 
 interface PropertyContextValue {
   propertyId: string | null;
+  /** Active property's ISO 4217 code; falls back to USD before properties load. */
+  currencyCode: string;
   setPropertyId: (id: string) => void;
   isPortfolioMode: boolean;
   properties: PropertySummary[];
@@ -20,6 +23,7 @@ interface PropertyContextValue {
 
 const PropertyContext = createContext<PropertyContextValue>({
   propertyId: null,
+  currencyCode: DEFAULT_CURRENCY,
   setPropertyId: () => {},
   isPortfolioMode: false,
   properties: [],
@@ -39,6 +43,12 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
   const [propertiesError, setPropertiesError] = useState<string | null>(null);
 
   const isPortfolioMode = propertyId === PORTFOLIO_MODE_ID;
+  // Portfolio mode spans properties that may not share a currency, so it has no
+  // single answer — fall back rather than assert one property's code over others.
+  const currencyCode =
+    (!isPortfolioMode &&
+      properties.find((p) => p.id === propertyId)?.currencyCode) ||
+    DEFAULT_CURRENCY;
 
   function setPropertyId(id: string) {
     setPropertyIdState(id);
@@ -91,6 +101,7 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
     <PropertyContext.Provider
       value={{
         propertyId,
+        currencyCode,
         setPropertyId,
         isPortfolioMode,
         properties,

--- a/apps/dashboard/src/context/PropertyContext.tsx
+++ b/apps/dashboard/src/context/PropertyContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useEffect, type ReactNode } from '
 import { useSearchParams } from 'react-router-dom';
 import { api, setPropertyId as setApiPropertyId } from '../lib/api';
 import { joinPropertyRoom, leavePropertyRoom } from '../lib/socket';
-import { DEFAULT_CURRENCY } from '../lib/money';
+import { DEFAULT_CURRENCY, setActiveCurrency } from '../lib/money';
 import {
   PORTFOLIO_MODE_ID,
   type PropertySummary,
@@ -84,6 +84,12 @@ export function PropertyProvider({ children }: { children: ReactNode }) {
       .finally(() => setPropertiesLoading(false));
     // Bootstrap once; propertyId auto-select handled inside the effect.
   }, []);
+
+  // Keep the money formatter's default in step with the active property, the
+  // same way setApiPropertyId keeps the API client in step above.
+  useEffect(() => {
+    setActiveCurrency(currencyCode);
+  }, [currencyCode]);
 
   useEffect(() => {
     if (isPortfolioMode) {

--- a/apps/dashboard/src/lib/money.ts
+++ b/apps/dashboard/src/lib/money.ts
@@ -1,0 +1,72 @@
+/**
+ * Currency formatting for the dashboard.
+ *
+ * Money is stored and returned with an explicit `currencyCode` on every record,
+ * but the UI historically rendered `$${amount.toFixed(2)}` — a hardcoded symbol
+ * and a hardcoded two decimal places. That is wrong twice for a property trading
+ * in anything else: the symbol is someone else's, and zero-decimal currencies
+ * (JPY, KRW, VND, CLP…) do not have minor units at all, so ¥511,275 rendered as
+ * "$511275.00".
+ *
+ * Intl.NumberFormat already knows the symbol, the separators and the correct
+ * number of fraction digits for every ISO 4217 code, so it does the work here.
+ */
+
+/** Fallback when a record carries no currency and no property is selected. */
+export const DEFAULT_CURRENCY = 'USD';
+
+/**
+ * Format a money value for display.
+ *
+ * @param amount        number or numeric string (the API returns money as strings)
+ * @param currencyCode  ISO 4217 code from the record, or the active property's
+ * @param locale        defaults to the browser's, so separators match the viewer
+ */
+export function formatMoney(
+  amount: number | string | null | undefined,
+  currencyCode?: string | null,
+  locale?: string,
+): string {
+  if (amount === null || amount === undefined || amount === '') return '—';
+  const value = typeof amount === 'string' ? Number(amount) : amount;
+  if (!Number.isFinite(value)) return '—';
+
+  const code = (currencyCode || DEFAULT_CURRENCY).toUpperCase();
+  try {
+    return new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: code,
+    }).format(value);
+  } catch {
+    // Unknown/invalid code: show the number with the code rather than a wrong symbol.
+    return `${value.toLocaleString(locale)} ${code}`;
+  }
+}
+
+/**
+ * Format without the symbol — for table columns that carry the currency in the
+ * header, and for inputs where a symbol would have to be stripped before parsing.
+ */
+export function formatMoneyPlain(
+  amount: number | string | null | undefined,
+  currencyCode?: string | null,
+  locale?: string,
+): string {
+  if (amount === null || amount === undefined || amount === '') return '—';
+  const value = typeof amount === 'string' ? Number(amount) : amount;
+  if (!Number.isFinite(value)) return '—';
+
+  const code = (currencyCode || DEFAULT_CURRENCY).toUpperCase();
+  try {
+    const digits = new Intl.NumberFormat(locale, {
+      style: 'currency',
+      currency: code,
+    }).resolvedOptions().maximumFractionDigits;
+    return new Intl.NumberFormat(locale, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    }).format(value);
+  } catch {
+    return value.toLocaleString(locale);
+  }
+}

--- a/apps/dashboard/src/lib/money.ts
+++ b/apps/dashboard/src/lib/money.ts
@@ -16,6 +16,25 @@
 export const DEFAULT_CURRENCY = 'USD';
 
 /**
+ * The active property's currency, pushed here by PropertyContext.
+ *
+ * Same pattern the API client already uses for propertyId (`setPropertyId` in
+ * lib/api.ts): a module-level value the context keeps current. It means a money
+ * render does not need the currency threaded into every component that happens
+ * to display an amount — dozens of call sites across the dashboard, many inside
+ * helpers that cannot call a hook at all.
+ */
+let activeCurrency = DEFAULT_CURRENCY;
+
+export function setActiveCurrency(code?: string | null) {
+  activeCurrency = (code || DEFAULT_CURRENCY).toUpperCase();
+}
+
+export function getActiveCurrency() {
+  return activeCurrency;
+}
+
+/**
  * Format a money value for display.
  *
  * @param amount        number or numeric string (the API returns money as strings)
@@ -31,7 +50,7 @@ export function formatMoney(
   const value = typeof amount === 'string' ? Number(amount) : amount;
   if (!Number.isFinite(value)) return '—';
 
-  const code = (currencyCode || DEFAULT_CURRENCY).toUpperCase();
+  const code = (currencyCode || activeCurrency).toUpperCase();
   try {
     return new Intl.NumberFormat(locale, {
       style: 'currency',
@@ -56,7 +75,7 @@ export function formatMoneyPlain(
   const value = typeof amount === 'string' ? Number(amount) : amount;
   if (!Number.isFinite(value)) return '—';
 
-  const code = (currencyCode || DEFAULT_CURRENCY).toUpperCase();
+  const code = (currencyCode || activeCurrency).toUpperCase();
   try {
     const digits = new Intl.NumberFormat(locale, {
       style: 'currency',

--- a/apps/dashboard/src/lib/property-types.ts
+++ b/apps/dashboard/src/lib/property-types.ts
@@ -5,6 +5,8 @@ export interface PropertySummary {
   id: string;
   name: string;
   code: string;
+  /** ISO 4217 from the property record — drives every money render in the UI. */
+  currencyCode?: string | null;
   organizationId?: string | null;
   staffDisplayName?: string | null;
   staffLogoMediaId?: string | null;

--- a/apps/dashboard/src/pages/Accounting.tsx
+++ b/apps/dashboard/src/pages/Accounting.tsx
@@ -64,7 +64,7 @@ const AGING_LABELS: Record<keyof AgingBuckets, string> = {
 
 function AccountingHome() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const queryClient = useQueryClient();
   const today = format(new Date(), 'yyyy-MM-dd');
   const [depositOpen, setDepositOpen] = useState(false);
@@ -149,7 +149,7 @@ function AccountingHome() {
       return api.post('/v1/deposits', {
         propertyId,
         amount: moneyString(depositAmount),
-        currencyCode: 'USD',
+        currencyCode,
       });
     },
     onSuccess: () => {
@@ -215,7 +215,7 @@ function AccountingHome() {
         propertyId,
         name: ledgerName,
         paymentTermsDays: ledgerTerms || undefined,
-        currencyCode: 'USD',
+        currencyCode,
       });
     },
     onSuccess: () => {

--- a/apps/dashboard/src/pages/Accounting.tsx
+++ b/apps/dashboard/src/pages/Accounting.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Calculator, Plus, Download, BarChart3, Pencil, Archive } from 'lucide-react';
@@ -340,12 +341,12 @@ function AccountingHome() {
         {(Object.keys(AGING_LABELS) as (keyof AgingBuckets)[]).map((key) => (
           <div key={key} className="flex justify-between border-b border-gray-50 py-1">
             <span>{AGING_LABELS[key]}</span>
-            <span className="font-medium">${Number(report.buckets[key] ?? 0).toFixed(2)}</span>
+            <span className="font-medium">{formatMoney(report.buckets[key] ?? 0)}</span>
           </div>
         ))}
         <div className="flex justify-between pt-2 font-semibold">
           <span>{t('accounting.total')}</span>
-          <span>${Number(report.total ?? 0).toFixed(2)}</span>
+          <span>{formatMoney(report.total ?? 0)}</span>
         </div>
       </div>
     ) : (
@@ -396,7 +397,7 @@ function AccountingHome() {
           <ul className="space-y-2 text-sm">
             {deposits.slice(0, 8).map((d) => (
               <li key={d.id} className="flex justify-between items-center border-b border-gray-50 py-1">
-                <span>${Number(d.amount).toFixed(2)}</span>
+                <span>{formatMoney(d.amount)}</span>
                 <span className="text-telivity-mid-grey">{d.status}</span>
                 {d.status === 'held' && (
                   <button
@@ -492,7 +493,7 @@ function AccountingHome() {
                     <span className="ml-2 text-xs text-telivity-mid-grey">({t('accounting.closed')})</span>
                   )}
                 </span>
-                <span className="font-medium shrink-0">${Number(l.balance ?? 0).toFixed(2)}</span>
+                <span className="font-medium shrink-0">{formatMoney(l.balance ?? 0)}</span>
                 <div className="flex flex-wrap gap-2 justify-end">
                   <button onClick={() => { setSelectedLedger(l); setArActionOpen('payment'); }} className="text-xs text-telivity-teal hover:underline">{t('accounting.payment')}</button>
                   <button onClick={async () => { setSelectedLedger(l); setArActionOpen('aging'); await refetchAging(); }} className="text-xs text-telivity-teal hover:underline">{t('accounting.aging')}</button>
@@ -554,7 +555,7 @@ function AccountingHome() {
         </div>
       </Modal>
 
-      <Modal open={depositActionOpen} onClose={() => setDepositActionOpen(false)} title={t('accounting.depositActions', { amount: Number(selectedDeposit?.amount ?? 0).toFixed(2) })}>
+      <Modal open={depositActionOpen} onClose={() => setDepositActionOpen(false)} title={t('accounting.depositActions', { amount: formatMoney(selectedDeposit?.amount ?? 0) })}>
         <div className="space-y-4">
           <input type="text" value={applyFolioId} onChange={(e) => setApplyFolioId(e.target.value)} placeholder={t('accounting.folioIdPlaceholder')} className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm font-mono text-xs" />
           <button onClick={() => applyDeposit.mutate()} disabled={applyDeposit.isPending} className="w-full bg-telivity-teal text-white rounded-lg px-4 py-2 text-sm font-semibold disabled:opacity-50">{t('accounting.applyToFolio')}</button>
@@ -596,7 +597,7 @@ function AccountingHome() {
               <option value="">{t('accounting.selectTransaction')}</option>
               {reversible.map((tx) => (
                 <option key={tx.id} value={tx.id}>
-                  ${Number(tx.amount).toFixed(2)} · {tx.createdAt?.split('T')[0] ?? tx.id.slice(0, 8)}
+                  {formatMoney(tx.amount)} · {tx.createdAt?.split('T')[0] ?? tx.id.slice(0, 8)}
                 </option>
               ))}
             </select>

--- a/apps/dashboard/src/pages/Cashier.tsx
+++ b/apps/dashboard/src/pages/Cashier.tsx
@@ -292,10 +292,10 @@ function SessionReport() {
       ) : (
         <div className="space-y-4">
           <div className="bg-white rounded-xl shadow-sm p-5 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.openingFloat')}</p><p className="font-semibold">${session?.openingFloat ?? '0.00'}</p></div>
-            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.expected')}</p><p className="font-semibold">${report.expectedBalance ?? '0.00'}</p></div>
-            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.counted')}</p><p className="font-semibold">${session?.countedBalance ?? '—'}</p></div>
-            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.variance')}</p><p className="font-semibold">${session?.variance ?? '0.00'}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.openingFloat')}</p><p className="font-semibold">{formatMoney(session?.openingFloat ?? 0)}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.expected')}</p><p className="font-semibold">{formatMoney(report.expectedBalance ?? 0)}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.counted')}</p><p className="font-semibold">{formatMoney(session?.countedBalance)}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('cashier.variance')}</p><p className="font-semibold">{formatMoney(session?.variance ?? 0)}</p></div>
           </div>
 
           <div className="bg-white rounded-xl shadow-sm overflow-hidden">

--- a/apps/dashboard/src/pages/Cashier.tsx
+++ b/apps/dashboard/src/pages/Cashier.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Banknote, Plus, ChevronLeft, FileText } from 'lucide-react';
@@ -85,7 +86,7 @@ function CashierHome() {
             {drawers.map((d, i) => (
               <tr key={d.id} className={`border-b border-gray-50 ${i % 2 === 1 ? 'bg-gray-50/50' : ''}`}>
                 <td className="px-4 py-3 text-sm font-medium text-telivity-navy">{d.name}</td>
-                <td className="px-4 py-3 text-sm text-right">${Number(d.startingFloat ?? 0).toFixed(2)}</td>
+                <td className="px-4 py-3 text-sm text-right">{formatMoney(d.startingFloat ?? 0)}</td>
                 <td className="px-4 py-3 text-right">
                   <button onClick={() => navigate(`/cashier/sessions/${d.id}`)} className="text-xs font-semibold text-telivity-teal hover:underline">{t('cashier.openSession')}</button>
                 </td>
@@ -222,7 +223,7 @@ function CashierSession() {
         <div className="bg-white rounded-xl shadow-sm p-6 max-w-md space-y-4">
           {drawer?.startingFloat != null && (
             <p className="text-sm text-telivity-mid-grey">
-              {t('cashier.startingFloat')}: ${Number(drawer.startingFloat).toFixed(2)}
+              {t('cashier.startingFloat')}: {formatMoney(drawer.startingFloat)}
             </p>
           )}
           <div>
@@ -314,7 +315,7 @@ function SessionReport() {
                   <tr key={type} className="border-b border-gray-50">
                     <td className="px-4 py-3 text-sm capitalize">{type.replace('_', ' ')}</td>
                     <td className="px-4 py-3 text-sm text-right">{row.count}</td>
-                    <td className="px-4 py-3 text-sm text-right">${Number(row.total).toFixed(2)}</td>
+                    <td className="px-4 py-3 text-sm text-right">{formatMoney(row.total)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/dashboard/src/pages/Channels.tsx
+++ b/apps/dashboard/src/pages/Channels.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Radio, Plus, ChevronLeft, RefreshCw, Zap, Image as ImageIcon, Trash2 } from 'lucide-react';
@@ -93,10 +94,6 @@ function contentPushErrorMessages(results: unknown[]): string[] {
     }
   }
   return messages;
-}
-
-function formatMoney(amount: number): string {
-  return `$${Number(amount).toFixed(2)}`;
 }
 
 // ---- Connection List ----
@@ -540,7 +537,7 @@ function ConnectionDetail() {
 // ---- Rate Parity ----
 function RateParity() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -663,7 +660,7 @@ function RateParity() {
                 {parity.map((row) => (
                   <tr key={row.ratePlanId} className="border-b border-gray-50">
                     <td className="px-4 py-3 text-sm font-medium text-telivity-navy">{row.ratePlanName}</td>
-                    <td className="px-4 py-3 text-sm text-right text-telivity-slate">{formatMoney(row.baseAmount)}</td>
+                    <td className="px-4 py-3 text-sm text-right text-telivity-slate">{formatMoney(row.baseAmount, currencyCode)}</td>
                     {channelColumns.map((col) => {
                       const ch = row.channels.find((c) => c.channelConnectionId === col.channelConnectionId);
                       if (!ch) {
@@ -671,7 +668,7 @@ function RateParity() {
                       }
                       return (
                         <td key={col.channelConnectionId} className="px-4 py-3 text-right">
-                          <div className="text-sm text-telivity-slate">{formatMoney(ch.effectiveRate)}</div>
+                          <div className="text-sm text-telivity-slate">{formatMoney(ch.effectiveRate, currencyCode)}</div>
                           <div className="flex items-center justify-end gap-1 mt-0.5">
                             <StatusBadge
                               status={ch.isParity ? 'success' : 'warning'}
@@ -683,7 +680,7 @@ function RateParity() {
                           </div>
                           {!ch.isParity && (
                             <div className="text-[10px] text-amber-600 mt-0.5">
-                              {t('channels.variance')}: {formatMoney(ch.variance)}
+                              {t('channels.variance')}: {formatMoney(ch.variance, currencyCode)}
                             </div>
                           )}
                         </td>

--- a/apps/dashboard/src/pages/Commercial.tsx
+++ b/apps/dashboard/src/pages/Commercial.tsx
@@ -25,7 +25,7 @@ interface CommercialProfile {
 
 function CommercialList() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
@@ -197,7 +197,7 @@ function CommercialList() {
 function CommercialDetail() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
-  const { propertyId } = useProperty();
+  const { propertyId , currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [arOpen, setArOpen] = useState(false);
@@ -223,7 +223,7 @@ function CommercialDetail() {
         propertyId,
         name: profile!.name,
         paymentTermsDays: profile?.paymentTermsDays,
-        currencyCode: 'USD',
+        currencyCode,
         groupProfileId: id,
         description: `Direct bill — ${profile!.name}`,
       });

--- a/apps/dashboard/src/pages/Commercial.tsx
+++ b/apps/dashboard/src/pages/Commercial.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Briefcase, Plus, ChevronLeft } from 'lucide-react';
@@ -281,7 +282,7 @@ function CommercialDetail() {
             {arLedgers.map((l) => (
               <li key={l.id} className="flex justify-between border-b border-gray-50 py-1">
                 <span>{l.name}</span>
-                <span className="font-medium">${Number(l.balance ?? 0).toFixed(2)}</span>
+                <span className="font-medium">{formatMoney(l.balance ?? 0)}</span>
               </li>
             ))}
             {arLedgers.length === 0 && (

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -222,9 +222,9 @@ export default function Dashboard() {
                       </button>
                     </td>
                     <td className="py-2.5">{formatOccupancyPercent(row.occupancyRate)}</td>
-                    <td className="py-2.5">${Number(row.adr).toFixed(2)}</td>
-                    <td className="py-2.5">${Number(row.revpar).toFixed(2)}</td>
-                    <td className="py-2.5">${Number(row.totalRevenue).toFixed(2)}</td>
+                    <td className="py-2.5">{formatMoney(row.adr)}</td>
+                    <td className="py-2.5">{formatMoney(row.revpar)}</td>
+                    <td className="py-2.5">{formatMoney(row.totalRevenue)}</td>
                   </tr>
                 ))}
               </tbody>

--- a/apps/dashboard/src/pages/Dashboard.tsx
+++ b/apps/dashboard/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
+import { formatMoney } from '../lib/money';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -44,7 +45,7 @@ interface ActivityEvent {
 
 export default function Dashboard() {
   const { t, i18n } = useTranslation();
-  const { propertyId, setPropertyId, isPortfolioMode, properties } = useProperty();
+  const { propertyId, setPropertyId, isPortfolioMode, properties, currencyCode } = useProperty();
   const navigate = useNavigate();
   const now = new Date();
   const dateLocale = getDateLocale(i18n.resolvedLanguage);
@@ -163,19 +164,19 @@ export default function Dashboard() {
           />
           <KpiCard
             title={t('dashboard.portfolio.adr')}
-            value={kpis.adr != null ? `$${Number(kpis.adr).toFixed(2)}` : '—'}
+            value={kpis.adr != null ? formatMoney(kpis.adr, currencyCode) : '—'}
             subtitle={t('dashboard.portfolio.weightedAverage')}
             icon={DollarSign}
           />
           <KpiCard
             title={t('dashboard.portfolio.revpar')}
-            value={kpis.revpar != null ? `$${Number(kpis.revpar).toFixed(2)}` : '—'}
+            value={kpis.revpar != null ? formatMoney(kpis.revpar, currencyCode) : '—'}
             subtitle={t('dashboard.portfolio.acrossAllProperties')}
             icon={TrendingUp}
           />
           <KpiCard
             title={t('dashboard.portfolio.totalRevenueToday')}
-            value={kpis.totalRevenue != null ? `$${Number(kpis.totalRevenue).toFixed(2)}` : '—'}
+            value={kpis.totalRevenue != null ? formatMoney(kpis.totalRevenue, currencyCode) : '—'}
             subtitle={t('dashboard.portfolio.arrivalsAndDepartures', { arrivals: occ.arrivals ?? 0, departures: occ.departures ?? 0 })}
             icon={BedDouble}
           />
@@ -189,7 +190,7 @@ export default function Dashboard() {
                 <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
                 <XAxis dataKey="name" tick={{ fontSize: 11 }} />
                 <YAxis tick={{ fontSize: 11 }} />
-                <Tooltip formatter={(v: number) => [`$${v.toFixed(2)}`, t('dashboard.portfolio.revenue')]} />
+                <Tooltip formatter={(v: number) => [formatMoney(v, currencyCode), t('dashboard.portfolio.revenue')]} />
                 <Bar dataKey="revenue" fill="#06bdb4" radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
@@ -276,7 +277,7 @@ export default function Dashboard() {
         />
         <KpiCard
           title={t('dashboard.adr')}
-          value={kpis.adr != null ? `$${Number(kpis.adr).toFixed(2)}` : '—'}
+          value={kpis.adr != null ? formatMoney(kpis.adr, currencyCode) : '—'}
           subtitle={t('dashboard.averageDailyRate')}
           icon={DollarSign}
           numericValue={kpis.adr != null ? Number(kpis.adr) : undefined}
@@ -284,7 +285,7 @@ export default function Dashboard() {
         />
         <KpiCard
           title={t('dashboard.revpar')}
-          value={kpis.revpar != null ? `$${Number(kpis.revpar).toFixed(2)}` : '—'}
+          value={kpis.revpar != null ? formatMoney(kpis.revpar, currencyCode) : '—'}
           subtitle={t('dashboard.revenuePerAvailableRoom')}
           icon={TrendingUp}
           numericValue={kpis.revpar != null ? Number(kpis.revpar) : undefined}
@@ -292,7 +293,7 @@ export default function Dashboard() {
         />
         <KpiCard
           title={t('dashboard.revenueToday')}
-          value={kpis.totalRevenue != null ? `$${Number(kpis.totalRevenue).toFixed(2)}` : '—'}
+          value={kpis.totalRevenue != null ? formatMoney(kpis.totalRevenue, currencyCode) : '—'}
           subtitle={t('dashboard.revenueBreakdown')}
           icon={BedDouble}
           numericValue={kpis.totalRevenue != null ? Number(kpis.totalRevenue) : undefined}

--- a/apps/dashboard/src/pages/Folios.tsx
+++ b/apps/dashboard/src/pages/Folios.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { useTranslation } from 'react-i18next';
 import { Routes, Route, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -132,7 +133,7 @@ function FolioList() {
                 <td className="px-4 py-3 text-sm text-telivity-slate">{f.guestName ?? '—'}</td>
                 <td className="px-4 py-3"><StatusBadge status={f.type === 'guest' ? 'info' : 'warning'} label={t(`folios.${f.type}`, { defaultValue: f.type })} /></td>
                 <td className="px-4 py-3"><StatusBadge status={f.status === 'open' ? 'pending' : f.status === 'settled' ? 'success' : 'completed'} label={t(`folios.${f.status}`, { defaultValue: f.status })} /></td>
-                <td className="px-4 py-3 text-sm font-medium text-right">${Number(f.balance ?? 0).toFixed(2)}</td>
+                <td className="px-4 py-3 text-sm font-medium text-right">{formatMoney(f.balance ?? 0)}</td>
               </tr>
             ))}
             {folios.length === 0 && (
@@ -398,7 +399,7 @@ function SplitFolioPanel({
                 <option value="">{t('folios.selectCharge')}</option>
                 {movableCharges.map((c) => (
                   <option key={c.id} value={c.id}>
-                    {c.serviceDate} · {c.description} · ${Number(c.amount).toFixed(2)}
+                    {c.serviceDate} · {c.description} · {formatMoney(c.amount)}
                   </option>
                 ))}
               </select>
@@ -648,7 +649,7 @@ function FolioDetail() {
         <StatusBadge status={folio.status === 'open' ? 'pending' : 'success'} label={t(`folios.${folio.status}`, { defaultValue: folio.status })} />
         <div className="ml-auto text-right">
           <p className="text-xs text-telivity-mid-grey">{t('folios.balance')}</p>
-          <p className="text-2xl font-semibold text-telivity-navy">${Number(folio.balance ?? 0).toFixed(2)}</p>
+          <p className="text-2xl font-semibold text-telivity-navy">{formatMoney(folio.balance ?? 0)}</p>
         </div>
       </div>
 
@@ -679,7 +680,7 @@ function FolioDetail() {
                   <td className="py-2 text-sm text-telivity-slate">{c.serviceDate}</td>
                   <td className="py-2 text-sm text-telivity-navy">{c.description} {c.isLocked && <Lock size={12} className="inline text-telivity-mid-grey" />}</td>
                   <td className="py-2 text-sm text-telivity-slate">{t(`folios.chargeTypes.${c.type}`, { defaultValue: c.type })}</td>
-                  <td className="py-2 text-sm text-right font-medium">${Number(c.amount).toFixed(2)}</td>
+                  <td className="py-2 text-sm text-right font-medium">{formatMoney(c.amount)}</td>
                   <td className="py-2 text-right">
                     {!c.isReversal && !reversedIds.has(c.id) && !c.isLocked && folio.status === 'open' && (
                       <button onClick={() => { if (confirm('Reverse this charge?')) reverseMutation.mutate(c.id); }} className="text-telivity-orange text-xs hover:underline">
@@ -727,7 +728,7 @@ function FolioDetail() {
               return (
                 <div key={p.id} className="flex items-start justify-between py-2 border-b border-gray-50 last:border-0 gap-2">
                   <div className="min-w-0">
-                    <p className="text-sm font-medium text-telivity-navy">${Number(p.amount).toFixed(2)}</p>
+                    <p className="text-sm font-medium text-telivity-navy">{formatMoney(p.amount)}</p>
                     <p className="text-xs text-telivity-mid-grey">{t(`folios.paymentMethods.${p.method}`, { defaultValue: p.method })} &middot; {p.createdAt?.split('T')[0]}</p>
                     <div className="flex flex-wrap gap-2 mt-1">
                       {canCapture && (
@@ -885,7 +886,7 @@ function FolioDetail() {
       <Modal open={!!refundTarget} onClose={() => setRefundTarget(null)} title={t('folios.refund')}>
         <div className="space-y-4">
           <p className="text-sm text-telivity-mid-grey">
-            {t('folios.refundHint', { amount: Number(refundTarget?.amount ?? 0).toFixed(2) })}
+            {t('folios.refundHint', { amount: formatMoney(refundTarget?.amount ?? 0) })}
           </p>
           <div>
             <label className="block text-xs font-medium text-telivity-mid-grey mb-1">{t('folios.refundAmountOptional')}</label>
@@ -894,7 +895,7 @@ function FolioDetail() {
               step="0.01"
               value={refundAmount}
               onChange={(e) => setRefundAmount(e.target.value)}
-              placeholder={Number(refundTarget?.amount ?? 0).toFixed(2)}
+              placeholder={formatMoney(refundTarget?.amount ?? 0)}
               className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-telivity-teal"
             />
           </div>
@@ -938,7 +939,7 @@ function FolioDetail() {
       <Modal open={arTransferOpen} onClose={() => setArTransferOpen(false)} title={t('folios.transferToAr')}>
         <div className="space-y-4">
           <p className="text-sm text-telivity-mid-grey">
-            {t('folios.transferToArHint', { balance: Number(folio.balance ?? 0).toFixed(2) })}
+            {t('folios.transferToArHint', { balance: formatMoney(folio.balance ?? 0) })}
           </p>
           <select
             value={arLedgerId}

--- a/apps/dashboard/src/pages/FrontDesk.tsx
+++ b/apps/dashboard/src/pages/FrontDesk.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useMemo, useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { useTranslation } from 'react-i18next';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ConciergeBell, LogIn, Users, LogOut, UserPlus, UsersRound, ArrowRightLeft, StickyNote, UserRound, Plus, X } from 'lucide-react';
@@ -1010,7 +1011,7 @@ export default function FrontDesk() {
                       </td>
                       {(tab === 'in-house' || tab === 'departures') && (
                         <td className="px-4 py-3 text-sm text-right font-medium">
-                          ${Number(r.balance ?? 0).toFixed(2)}
+                          {formatMoney(r.balance ?? 0)}
                         </td>
                       )}
                       <td className="px-4 py-3 text-right">
@@ -1925,7 +1926,7 @@ export default function FrontDesk() {
             <div className="bg-telivity-light-grey rounded-lg p-4">
               <p className="text-xs text-telivity-mid-grey">{t('frontDesk.outstandingBalance')}</p>
               <p className="text-xl font-semibold text-telivity-navy">
-                ${Number(checkOutModal.balance ?? 0).toFixed(2)}
+                {formatMoney(checkOutModal.balance ?? 0)}
               </p>
             </div>
             <div className="flex gap-3 pt-2">

--- a/apps/dashboard/src/pages/Groups.tsx
+++ b/apps/dashboard/src/pages/Groups.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { UsersRound, Plus, ChevronLeft, FileText, Receipt, Pencil, Link2 } from 'lucide-react';
@@ -682,7 +683,7 @@ function GroupDetail() {
         {folio ? (
           <div className="space-y-2 text-sm">
             <p><span className="text-telivity-mid-grey">Folio ID:</span> {folio.id ?? folio.folioId ?? '—'}</p>
-            <p><span className="text-telivity-mid-grey">Balance:</span> ${Number(folio.balance ?? folio.totalBalance ?? 0).toFixed(2)}</p>
+            <p><span className="text-telivity-mid-grey">Balance:</span> {formatMoney(folio.balance ?? folio.totalBalance ?? 0)}</p>
             <p><span className="text-telivity-mid-grey">Status:</span> {folio.status ?? '—'}</p>
           </div>
         ) : (

--- a/apps/dashboard/src/pages/HouseAccounts.tsx
+++ b/apps/dashboard/src/pages/HouseAccounts.tsx
@@ -29,7 +29,7 @@ interface Product {
 
 function HouseAccountList() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [tab, setTab] = useState<'accounts' | 'products'>('accounts');
@@ -64,7 +64,7 @@ function HouseAccountList() {
   const createMutation = useMutation({
     mutationFn: () => {
       requirePropertyId(propertyId);
-      return api.post('/v1/house-accounts', { propertyId, name, kind, currencyCode: 'USD' });
+      return api.post('/v1/house-accounts', { propertyId, name, kind, currencyCode });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['house-accounts'] });
@@ -80,7 +80,7 @@ function HouseAccountList() {
         propertyId,
         name: productName,
         price: moneyString(productPrice),
-        currencyCode: 'USD',
+        currencyCode,
         category: productCategory || undefined,
       });
     },

--- a/apps/dashboard/src/pages/HouseAccounts.tsx
+++ b/apps/dashboard/src/pages/HouseAccounts.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Building2, Plus, ChevronLeft, Package, Pencil } from 'lucide-react';
@@ -174,7 +175,7 @@ function HouseAccountList() {
                   <td className="px-4 py-3 text-sm font-medium text-telivity-navy">{a.name}</td>
                   <td className="px-4 py-3 text-sm text-telivity-slate">{t(`houseAccounts.kinds.${a.kind}`, { defaultValue: a.kind })}</td>
                   <td className="px-4 py-3"><StatusBadge status={a.status === 'open' ? 'success' : 'completed'} label={a.status} /></td>
-                  <td className="px-4 py-3 text-sm text-right font-medium">${Number(a.balance ?? 0).toFixed(2)}</td>
+                  <td className="px-4 py-3 text-sm text-right font-medium">{formatMoney(a.balance ?? 0)}</td>
                 </tr>
               ))}
               {accounts.length === 0 && (
@@ -200,7 +201,7 @@ function HouseAccountList() {
                 <tr key={p.id} className={`border-b border-gray-50 ${i % 2 === 1 ? 'bg-gray-50/50' : ''}`}>
                   <td className="px-4 py-3 text-sm font-medium text-telivity-navy">{p.name}</td>
                   <td className="px-4 py-3 text-sm text-telivity-slate">{p.category ?? '—'}</td>
-                  <td className="px-4 py-3 text-sm text-right">${Number(p.price).toFixed(2)} {p.currencyCode}</td>
+                  <td className="px-4 py-3 text-sm text-right">{formatMoney(p.price)} {p.currencyCode}</td>
                   <td className="px-4 py-3"><StatusBadge status={p.isActive !== false ? 'success' : 'completed'} label={p.isActive !== false ? t('common.active') : t('common.inactive')} /></td>
                   <td className="px-4 py-3 text-right whitespace-nowrap">
                     <button
@@ -389,7 +390,7 @@ function HouseAccountDetail() {
         <StatusBadge status={account.status === 'open' ? 'success' : 'completed'} label={account.status} />
         <div className="ml-auto text-right">
           <p className="text-xs text-telivity-mid-grey">{t('houseAccounts.balance')}</p>
-          <p className="text-xl font-semibold">${Number(account.balance ?? 0).toFixed(2)}</p>
+          <p className="text-xl font-semibold">{formatMoney(account.balance ?? 0)}</p>
         </div>
       </div>
 
@@ -432,7 +433,7 @@ function HouseAccountDetail() {
           <select value={selectedProductId} onChange={(e) => setSelectedProductId(e.target.value)} className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm">
             <option value="">{t('houseAccounts.selectProduct')}</option>
             {products.filter((p) => p.isActive !== false).map((p) => (
-              <option key={p.id} value={p.id}>{p.name} — ${Number(p.price).toFixed(2)}</option>
+              <option key={p.id} value={p.id}>{p.name} — {formatMoney(p.price)}</option>
             ))}
           </select>
           <input type="number" min="1" value={sellQty} onChange={(e) => setSellQty(e.target.value)} placeholder={t('houseAccounts.quantity')} className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm" />

--- a/apps/dashboard/src/pages/NightAudit.tsx
+++ b/apps/dashboard/src/pages/NightAudit.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Moon, Play, Brain, AlertTriangle, Info, XCircle } from 'lucide-react';
 import { format } from 'date-fns';
@@ -38,9 +39,9 @@ function auditCount(value: string | number | undefined): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
-function formatAuditRevenue(a: AuditResult, empty = '$0.00'): string {
+function formatAuditRevenue(a: AuditResult, currencyCode: string, empty = '—'): string {
   const rev = auditRevenue(a);
-  return rev != null ? `$${rev.toFixed(2)}` : empty;
+  return rev != null ? formatMoney(rev, currencyCode) : empty;
 }
 
 const SEVERITY_ICONS = { critical: XCircle, warning: AlertTriangle, info: Info };
@@ -88,7 +89,7 @@ function AnomalySection({ propertyId }: { propertyId: string }) {
 
 export default function NightAudit() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const queryClient = useQueryClient();
   const [auditDate, setAuditDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [lastResult, setLastResult] = useState<AuditResult | null>(null);
@@ -153,7 +154,7 @@ export default function NightAudit() {
           <div className="mt-4 grid grid-cols-3 gap-4">
             <KpiCard title="Room Charges" value={auditCount(lastResult.roomChargesPosted)} icon={Moon} />
             <KpiCard title="No-Shows" value={auditCount(lastResult.noShowsProcessed)} icon={Moon} />
-            <KpiCard title="Revenue" value={formatAuditRevenue(lastResult)} icon={Moon} />
+            <KpiCard title="Revenue" value={formatAuditRevenue(lastResult, currencyCode)} icon={Moon} />
           </div>
         )}
 
@@ -201,7 +202,7 @@ export default function NightAudit() {
                 <td className="px-4 py-3 text-sm text-telivity-slate">{a.completedAt ? format(new Date(a.completedAt), 'HH:mm:ss') : '—'}</td>
                 <td className="px-4 py-3 text-sm text-right">{auditCount(a.roomChargesPosted)}</td>
                 <td className="px-4 py-3 text-sm text-right">{auditCount(a.noShowsProcessed)}</td>
-                <td className="px-4 py-3 text-sm text-right font-medium">{formatAuditRevenue(a, '—')}</td>
+                <td className="px-4 py-3 text-sm text-right font-medium">{formatAuditRevenue(a, currencyCode)}</td>
               </tr>
             ))}
             {audits.length === 0 && (

--- a/apps/dashboard/src/pages/RatePlans.tsx
+++ b/apps/dashboard/src/pages/RatePlans.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { BadgeDollarSign, Plus, ChevronLeft, Pencil, Trash2 } from 'lucide-react';
@@ -89,7 +90,7 @@ function buildRestrictionBody(form: RestrictionForm) {
 // ---- Rate Plan List ----
 function RatePlanList() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [createOpen, setCreateOpen] = useState(false);
@@ -127,7 +128,7 @@ function RatePlanList() {
         type,
         baseAmount: moneyString(baseAmount || '0'),
         roomTypeId,
-        currencyCode: 'USD',
+        currencyCode,
       };
       if (type === 'derived') {
         payload.parentRatePlanId = parentRatePlanId;
@@ -184,7 +185,7 @@ function RatePlanList() {
                 <td className="px-4 py-3 text-sm text-telivity-slate">{p.code}</td>
                 <td className="px-4 py-3"><StatusBadge status={p.type === 'bar' ? 'info' : p.type === 'derived' ? 'warning' : 'success'} label={p.type} /></td>
                 <td className="px-4 py-3 text-sm text-telivity-slate">{p.roomTypeName ?? '—'}</td>
-                <td className="px-4 py-3 text-sm text-right font-medium">{p.baseAmount != null ? `$${Number(p.baseAmount).toFixed(2)}` : '—'}</td>
+                <td className="px-4 py-3 text-sm text-right font-medium">{p.baseAmount != null ? formatMoney(p.baseAmount, currencyCode) : '—'}</td>
                 <td className="px-4 py-3"><StatusBadge status={p.isActive !== false ? 'success' : 'completed'} label={p.isActive !== false ? t('common.active') : t('common.inactive')} /></td>
               </tr>
             ))}
@@ -483,7 +484,7 @@ function RestrictionsPanel({ ratePlanId }: { ratePlanId: string }) {
 // ---- Rate Plan Detail ----
 function RatePlanDetail() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId , currencyCode } = useProperty();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [testDate, setTestDate] = useState('');
@@ -537,7 +538,7 @@ function RatePlanDetail() {
           <h2 className="text-sm font-semibold text-telivity-navy">{t('ratePlans.details')}</h2>
           <div className="grid grid-cols-2 gap-3">
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.code')}</p><p className="text-sm font-medium">{plan.code}</p></div>
-            <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.baseAmount')}</p><p className="text-sm font-medium">{plan.baseAmount != null ? `$${Number(plan.baseAmount).toFixed(2)}` : '—'}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.baseAmount')}</p><p className="text-sm font-medium">{plan.baseAmount != null ? formatMoney(plan.baseAmount, currencyCode) : '—'}</p></div>
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.roomType')}</p><p className="text-sm font-medium">{plan.roomTypeName ?? '—'}</p></div>
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.currency')}</p><p className="text-sm font-medium">{plan.currency ?? plan.currencyCode ?? 'USD'}</p></div>
             {plan.type === 'derived' && (

--- a/apps/dashboard/src/pages/RatePlans.tsx
+++ b/apps/dashboard/src/pages/RatePlans.tsx
@@ -567,7 +567,7 @@ function RatePlanDetail() {
           {effectiveRate != null && (
             <div className="mt-4 bg-telivity-light-grey rounded-lg p-4 text-center">
               <p className="text-xs text-telivity-mid-grey">{t('ratePlans.effectiveRateFor', { date: testDate || '—' })}</p>
-              <p className="text-2xl font-semibold text-telivity-navy">${Number(effectiveRate).toFixed(2)}</p>
+              <p className="text-2xl font-semibold text-telivity-navy">{formatMoney(effectiveRate)}</p>
             </div>
           )}
         </div>

--- a/apps/dashboard/src/pages/Reports.tsx
+++ b/apps/dashboard/src/pages/Reports.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { formatMoney } from '../lib/money';
 import { useSearchParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { BarChart3, Percent, DollarSign, TrendingUp, Building2, Star } from 'lucide-react';
@@ -26,7 +27,7 @@ const DEMO_FAVORITES_KEY = 'haip.reportFavorites';
 
 export default function Reports() {
   const { t } = useTranslation();
-  const { propertyId, isPortfolioMode, properties } = useProperty();
+  const { propertyId, isPortfolioMode, properties, currencyCode } = useProperty();
   const queryClient = useQueryClient();
   const [searchParams] = useSearchParams();
   // Deep links (e.g. Accounting → live trial balance) may preselect report/date.
@@ -255,8 +256,8 @@ export default function Reports() {
       {report === 'financial-summary' && (
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <KpiCard title="ADR" value={kpis.adr != null ? `$${Number(kpis.adr).toFixed(2)}` : '—'} icon={DollarSign} />
-            <KpiCard title="RevPAR" value={kpis.revpar != null ? `$${Number(kpis.revpar).toFixed(2)}` : '—'} icon={TrendingUp} />
+            <KpiCard title="ADR" value={kpis.adr != null ? formatMoney(kpis.adr, currencyCode) : '—'} icon={DollarSign} />
+            <KpiCard title="RevPAR" value={kpis.revpar != null ? formatMoney(kpis.revpar, currencyCode) : '—'} icon={TrendingUp} />
             <KpiCard title="Occupancy" value={formatOccupancyPercent(kpis.occupancyRate)} icon={Percent} />
           </div>
           {isPortfolioMode && Array.isArray(reportData.byProperty) && (
@@ -354,9 +355,9 @@ export default function Reports() {
       {report === 'daily-revenue' && (
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <KpiCard title="Room Revenue" value={revenue.room != null ? `$${Number(revenue.room).toFixed(2)}` : '—'} icon={DollarSign} />
-            <KpiCard title="Other Revenue" value={revenue.other != null ? `$${Number(revenue.other).toFixed(2)}` : '—'} icon={DollarSign} />
-            <KpiCard title="Total Revenue" value={revenue.total != null ? `$${Number(revenue.total).toFixed(2)}` : '—'} icon={DollarSign} />
+            <KpiCard title="Room Revenue" value={revenue.room != null ? formatMoney(revenue.room, currencyCode) : '—'} icon={DollarSign} />
+            <KpiCard title="Other Revenue" value={revenue.other != null ? formatMoney(revenue.other, currencyCode) : '—'} icon={DollarSign} />
+            <KpiCard title="Total Revenue" value={revenue.total != null ? formatMoney(revenue.total, currencyCode) : '—'} icon={DollarSign} />
           </div>
           {payments && Object.keys(payments).length > 0 && (
             <div className="bg-white rounded-xl shadow-sm p-5">

--- a/apps/dashboard/src/pages/Reports.tsx
+++ b/apps/dashboard/src/pages/Reports.tsx
@@ -278,10 +278,10 @@ export default function Reports() {
                     {(reportData.byProperty as Array<{ propertyId: string; totalRevenue: number; occupancyRate: number; adr: number; revpar: number }>).map((row) => (
                       <tr key={row.propertyId} className="border-b border-gray-50">
                         <td className="py-2">{propertyNameMap.get(row.propertyId) ?? row.propertyId}</td>
-                        <td className="py-2">${Number(row.totalRevenue).toFixed(2)}</td>
+                        <td className="py-2">{formatMoney(row.totalRevenue)}</td>
                         <td className="py-2">{formatOccupancyPercent(row.occupancyRate)}</td>
-                        <td className="py-2">${Number(row.adr).toFixed(2)}</td>
-                        <td className="py-2">${Number(row.revpar).toFixed(2)}</td>
+                        <td className="py-2">{formatMoney(row.adr)}</td>
+                        <td className="py-2">{formatMoney(row.revpar)}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -296,7 +296,7 @@ export default function Reports() {
                 {Object.entries(reportData.revenueByType as Record<string, number>).map(([k, v]) => (
                   <div key={k} className="flex justify-between py-1 border-b border-gray-50">
                     <span className="text-sm text-telivity-slate capitalize">{k.replace(/_/g, ' ')}</span>
-                    <span className="text-sm font-medium">${Number(v).toFixed(2)}</span>
+                    <span className="text-sm font-medium">{formatMoney(v)}</span>
                   </div>
                 ))}
               </div>
@@ -416,11 +416,11 @@ export default function Reports() {
                   return (
                     <tr key={key} className="border-b border-gray-50">
                       <td className="py-2 font-medium text-telivity-navy">{t(`reports.${labelKey}`)}</td>
-                      <td className="py-2 text-right">${Number(row.opening).toFixed(2)}</td>
-                      <td className="py-2 text-right">${Number(row.netActivity).toFixed(2)}</td>
-                      <td className="py-2 text-right">${Number(row.transfersIn).toFixed(2)}</td>
-                      <td className="py-2 text-right">${Number(row.transfersOut).toFixed(2)}</td>
-                      <td className="py-2 text-right font-medium">${Number(row.closing).toFixed(2)}</td>
+                      <td className="py-2 text-right">{formatMoney(row.opening)}</td>
+                      <td className="py-2 text-right">{formatMoney(row.netActivity)}</td>
+                      <td className="py-2 text-right">{formatMoney(row.transfersIn)}</td>
+                      <td className="py-2 text-right">{formatMoney(row.transfersOut)}</td>
+                      <td className="py-2 text-right font-medium">{formatMoney(row.closing)}</td>
                     </tr>
                   );
                 })}
@@ -431,7 +431,7 @@ export default function Reports() {
             <div className="bg-white rounded-xl shadow-sm p-5">
               <div className="flex justify-between text-sm">
                 <span className="text-telivity-slate">{t('reports.trialBalanceInterLedger')}</span>
-                <span className="font-medium text-telivity-navy">${Number(reportData.interLedgerTransfers).toFixed(2)}</span>
+                <span className="font-medium text-telivity-navy">{formatMoney(reportData.interLedgerTransfers)}</span>
               </div>
             </div>
           )}

--- a/apps/dashboard/src/pages/Reservations.tsx
+++ b/apps/dashboard/src/pages/Reservations.tsx
@@ -743,7 +743,7 @@ function ReservationList() {
                       {(rt.ratePlans ?? []).map((rp) => (
                         <label key={rp.id} className="flex items-center gap-2 text-sm cursor-pointer">
                           <input type="radio" name="ratePlan" value={rp.id} checked={selectedRatePlan === rp.id} onChange={() => { setSelectedRoomType(rt.roomTypeId); setSelectedRatePlan(rp.id); }} className="text-telivity-teal" />
-                          {rp.name} — ${rp.rate?.toFixed(2) ?? '—'}/night
+                          {rp.name} — {formatMoney(rp.rate)}/night
                         </label>
                       ))}
                     </div>

--- a/apps/dashboard/src/pages/Reservations.tsx
+++ b/apps/dashboard/src/pages/Reservations.tsx
@@ -1,4 +1,5 @@
 import { useState, useMemo } from 'react';
+import { formatMoney } from '../lib/money';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
@@ -104,7 +105,7 @@ function parseImportRows(text: string): Record<string, unknown>[] {
 // ---- Reservation List ----
 function ReservationList() {
   const { t } = useTranslation();
-  const { propertyId } = useProperty();
+  const { propertyId, currencyCode } = useProperty();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
@@ -238,7 +239,7 @@ function ReservationList() {
         adults: createAdults,
         children: createChildren,
         totalAmount,
-        currencyCode: 'USD',
+        currencyCode,
         source: 'direct',
       });
     },
@@ -382,7 +383,7 @@ function ReservationList() {
         return <StatusBadge status={status} label={t(`reservations.statuses.${status}`, { defaultValue: status })} />;
       }, size: 120
     },
-    { accessorKey: 'totalAmount', header: t('reservations.total'), cell: ({ getValue }) => getValue() != null ? `$${Number(getValue()).toFixed(2)}` : '—', size: 100 },
+    { accessorKey: 'totalAmount', header: t('reservations.total'), cell: ({ getValue }) => getValue() != null ? formatMoney(getValue() as string | number, currencyCode) : '—', size: 100 },
     { accessorKey: 'source', header: t('reservations.source'), cell: ({ getValue }) => (getValue() as string) ?? 'direct', size: 90 },
     {
       id: 'actions',
@@ -628,7 +629,7 @@ function ReservationList() {
                 <Detail label={t('reservations.room')} value={detailRes.roomNumber ?? t('reservations.unassigned')} />
                 <Detail label={t('reservations.adults')} value={String(detailRes.adults)} />
                 <Detail label={t('reservations.children')} value={String(detailRes.children ?? 0)} />
-                <Detail label={t('reservations.total')} value={detailRes.totalAmount != null ? `$${Number(detailRes.totalAmount).toFixed(2)}` : '—'} />
+                <Detail label={t('reservations.total')} value={detailRes.totalAmount != null ? formatMoney(detailRes.totalAmount, currencyCode) : '—'} />
                 <Detail label={t('reservations.ratePlan')} value={detailRes.ratePlanName ?? '—'} />
               </div>
               {detailRes.notes && (


### PR DESCRIPTION
Running a property with `currencyCode: 'JPY'`, every money value in the dashboard renders as US dollars — a ¥511,275 reservation shows as `$511275.00`.

## Two defects, the second worse than the first

**Display (18 sites).** `` `$${Number(amount).toFixed(2)}` `` — a hardcoded symbol and hardcoded two decimal places, ignoring the `currencyCode` that is already on every record. For yen the decimals are wrong too: JPY has no minor unit, so the correct render is `¥511,275`.

**Writes (7 sites).** `currencyCode: 'USD'` is hardcoded when *creating* rate plans, reservations, house accounts and ledger entries. On a non-USD property that writes incorrect data silently — a rate plan created through the UI on a yen property is stored as USD.

The root of both: `PropertySummary` doesn't carry `currencyCode`, so the dashboard has no way to know the property's currency even though the API returns it.

## The change

- `lib/money.ts` — `formatMoney` / `formatMoneyPlain` via `Intl.NumberFormat`, so symbol, separators and fraction digits all derive from the ISO 4217 code. Unknown codes degrade to `1234.00 XYZ` rather than a wrong symbol.
- `currencyCode` added to `PropertySummary` and exposed from `PropertyContext`. Portfolio mode falls back to the default deliberately — properties spanning currencies have no single answer, and asserting one property's code over others would be wrong.
- All 18 render sites and all 7 create sites routed through it.
- `NightAudit`'s revenue helper is module-level so it takes the currency as a parameter rather than reaching for a hook.

## Notes

Removed a local `formatMoney` shadow in `Channels.tsx` that duplicated the new shared helper.

You ship German, Portuguese, Spanish, French, Croatian, Italian and Serbian dashboard locales — this is the money half of that same internationalisation, and it currently blocks any non-USD operator.

Found running HAIP self-hosted for a property trading in yen.