### PR TITLE
fix(test): make the ciphertext-tamper test deterministic

### DIFF
--- a/apps/api/src/common/crypto/credential-encryption.spec.ts
+++ b/apps/api/src/common/crypto/credential-encryption.spec.ts
@@ -48,7 +48,13 @@ describe('credential-encryption', () => {
   it('fails closed when ciphertext is tampered', () => {
     const keyRing = loadMigrationCredentialKeyRingFromEnv(env());
     const blob = encryptCredentialPlaintext('sensitive', keyRing, env());
-    const tampered = { ...blob, ciphertext: blob.ciphertext.replace(/a/g, 'b') };
+    // Deterministic tamper: change the first hex DIGIT to a different value.
+    // Two dead ends this avoids, both no-ops that decode to identical bytes:
+    //   - replace(/a/g,'b') does nothing when the ciphertext contains no 'a'
+    //   - flipping to uppercase 'A' does nothing when the digit was 'a' ('A'==='a' as hex)
+    // '0'<->'1' are distinct nibble values, both valid hex, so the bytes always change.
+    const first = blob.ciphertext[0];
+    const tampered = { ...blob, ciphertext: (first === '0' ? '1' : '0') + blob.ciphertext.slice(1) };
     expect(() => decryptCredentialPlaintext(tampered, keyRing)).toThrow(CredentialEncryptionError);
   });
 


### PR DESCRIPTION
\`credential-encryption.spec.ts\` › "fails closed when ciphertext is tampered" is probabilistically flaky: it tampers with \`blob.ciphertext.replace(/a/g, 'b')\`, and whenever the random ciphertext contains no \`a\`, the replacement is a no-op — the blob arrives untampered, decryption **rightly** succeeds, and the test fails claiming fail-closed is broken.

Hit tonight in our CI: \`1 failed | 1411 passed\` on a branch touching none of this code, with the identical tree passing minutes earlier.

Fix: flip the first character to a guaranteed-different one. Same intent, zero probability.

(The auth-tag test above it is already deterministic — \`'0'.repeat(...)\` can collide with an all-zero tag only with negligible probability, so left alone.)