### PR TITLE
fix(compose): bind Keycloak to loopback + harden probe

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     volumes:
       - ./keycloak/haip-realm.json:/opt/keycloak/data/import/haip-realm.json:ro
     ports:
-      - '8080:8080'
+      - '127.0.0.1:8080:8080'
     depends_on:
       postgres:
         condition: service_healthy

--- a/ops/harden/cli/probes/local.mjs
+++ b/ops/harden/cli/probes/local.mjs
@@ -93,10 +93,11 @@ export async function runLocalFileProbes() {
     });
   }
 
-  // Datastores must not be published on all interfaces. Docker's published ports
-  // bypass host firewalls — ufw and firewalld rules sit behind Docker's own chain —
-  // so `- '5432:5432'` on a public host is an internet-reachable Postgres carrying
-  // this file's default credentials, even with a firewall correctly configured.
+  // Datastores and Keycloak must not be published on all interfaces. Docker's
+  // published ports bypass host firewalls — ufw and firewalld rules sit behind
+  // Docker's own chain — so `- '5432:5432'` / `- '8080:8080'` on a public host is
+  // internet-reachable with this file's default credentials, even with a firewall
+  // correctly configured. Flagged by Charles Pizzato in #300 for Keycloak.
   const baseCompose = path.join(root, 'docker-compose.yml');
   if (fs.existsSync(baseCompose)) {
     const composeText = fs.readFileSync(baseCompose, 'utf8');
@@ -106,6 +107,7 @@ export async function runLocalFileProbes() {
       ['redis', 6379],
       ['minio', 9000],
       ['minio', 9001],
+      ['keycloak', 8080],
     ]) {
       // matches '5432:5432' but not '127.0.0.1:5432:5432'
       if (new RegExp(`^\\s*-\\s*['"]${port}:${port}['"]`, 'm').test(composeText)) {
@@ -117,7 +119,7 @@ export async function runLocalFileProbes() {
       ok: exposed.length === 0,
       detail:
         exposed.length === 0
-          ? 'datastore ports are bound to loopback or unpublished'
+          ? 'datastore and Keycloak ports are bound to loopback or unpublished'
           : `published on all interfaces: ${exposed.join(', ')} — bind to 127.0.0.1`,
     });
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#300](https://github.com/TelivityAI/haip/pull/300) by @modernitconsultants , who correctly left Keycloak alone in that PR because the auth profile may be used remotely, while calling out the same exposure shape: Docker published ports bypass host firewalls, and Keycloak ships with `KEYCLOAK_ADMIN=admin` / `KEYCLOAK_ADMIN_PASSWORD=admin`.

This PR closes that gap:

1. Bind Keycloak in `docker-compose.yml` to `127.0.0.1:8080:8080`.
2. Extend `compose:datastores-loopback` in `ops/harden/cli/probes/local.mjs` to also flag Keycloak `:8080` on all interfaces.

Local Keycloak, dashboard, and booking auth (via `localhost:8080`) are unchanged. Anyone who relied on reaching Keycloak from another host must use a tunnel or an explicit publish override.

Credit for identifying the issue goes to Charles (#300).

## Test plan

- [ ] Confirm `docker-compose.yml` Keycloak ports line is `127.0.0.1:8080:8080`
- [ ] Confirm harden probe lists `keycloak`/`8080` and fails on all-interfaces / passes on loopback
- [ ] Local auth profile still reaches Keycloak at `http://localhost:8080`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96ffb07d-446a-4643-ab17-4cb9e72a50f4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96ffb07d-446a-4643-ab17-4cb9e72a50f4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

