### PR TITLE
feat(ical): allow revenue_manager to read a feed's imported blocks

### DIFF
--- a/apps/api/src/modules/ical/ical.controller.ts
+++ b/apps/api/src/modules/ical/ical.controller.ts
@@ -116,7 +116,7 @@ export class IcalController {
   }
 
   @Get('feeds/:id/blocks')
-  @Roles('admin')
+  @Roles('admin', 'revenue_manager')
   @ApiOperation({ summary: 'List imported busy blocks for a feed' })
   @ApiQuery({ name: 'propertyId', required: true })
   listBlocks(


### PR DESCRIPTION
`#318` relaxed listing, reading and syncing iCal feeds to `revenue_manager`, but `GET /ical/feeds/:id/blocks` was missed — so an integration can list the feeds and trigger a sync, and then cannot see what that sync imported.

Reading the blocks is no more privileged than reading the feed beside it: they're the busy dates a sync just fetched, not credentials. Without this, any consumer that reconciles imported channel availability against its own calendar has to hold `admin` purely to read.

One line, same role list as its neighbours.
