### PR TITLE
fix(front-desk): the tape chart hides guests who are already in-house

### DIFF
--- a/apps/dashboard/src/pages/Reservations.tsx
+++ b/apps/dashboard/src/pages/Reservations.tsx
@@ -820,7 +820,16 @@ function AvailabilityCalendar() {
   const { data: resData } = useQuery({
     queryKey: ['reservations', 'calendar', propertyId, format(startDate, 'yyyy-MM-dd')],
     queryFn: () => api.get('/v1/reservations', {
-      params: { propertyId, arrivalDateFrom: format(startDate, 'yyyy-MM-dd'), arrivalDateTo: format(addDays(startDate, 13), 'yyyy-MM-dd') },
+      // OVERLAP, not arrival-within. Filtering on arrivalDateFrom asks "who
+      // arrives during this fortnight", which silently omits every guest who
+      // arrived before it and is still in the hotel — the people most likely to
+      // be looked up on a tape chart. A stay overlaps the window when it
+      // arrives before the window ends AND departs after it starts.
+      params: {
+        propertyId,
+        arrivalDateTo: format(addDays(startDate, 13), 'yyyy-MM-dd'),
+        departureDateFrom: format(startDate, 'yyyy-MM-dd'),
+      },
     }).then((r) => r.data),
     enabled: !!propertyId,
   });


### PR DESCRIPTION
The fortnight view queries `arrivalDateFrom` / `arrivalDateTo`, which asks *who arrives during this window*. That silently omits every guest who arrived **before** it and is still in the hotel — on a tape chart, the people most likely to be looked up.

A guest who checked in yesterday for a week disappears from today's view. Nothing errors; the row is simply absent.

A stay overlaps the window when it **arrives before the window ends and departs after it starts**, so the filter becomes `arrivalDateTo` + `departureDateFrom`. Both are already accepted by `ListReservationsDto` — only the dashboard was asking the narrower question.

Same endpoint, same window, same rendering; one filter corrected.
