### PR TITLE
fix(dashboard): #327 removed the default currency, twelve call sites still invent one

### DIFF
--- a/apps/dashboard/src/components/front-desk/GuestDetailsModal.tsx
+++ b/apps/dashboard/src/components/front-desk/GuestDetailsModal.tsx
@@ -225,6 +225,7 @@ export default function GuestDetailsModal({
             roomTypeId={reservation.roomTypeId}
             ratePlanId={reservation.ratePlanId}
             totalAmount={reservation.totalAmount}
+            currencyCode={currencyCode}
           />
         </div>
 

--- a/apps/dashboard/src/components/reservations/ReservationPartyPanel.tsx
+++ b/apps/dashboard/src/components/reservations/ReservationPartyPanel.tsx
@@ -166,7 +166,7 @@ export default function ReservationPartyPanel({
   const splitMutation = useMutation({
     mutationFn: () => {
       requirePropertyId(propertyId);
-      requireCurrency(currencyCode);
+      requireCurrency(currencyCode ?? null);
       return api.post(
         `/v1/reservations/${reservationId}/split`,
         {

--- a/apps/dashboard/src/components/reservations/ReservationPartyPanel.tsx
+++ b/apps/dashboard/src/components/reservations/ReservationPartyPanel.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { UserPlus, Split, ArrowRightLeft, Trash2 } from 'lucide-react';
 import { api } from '../../lib/api';
-import { moneyString, requirePropertyId } from '../../lib/api-helpers';
+import { moneyString, requirePropertyId, requireCurrency } from '../../lib/api-helpers';
 import { useToast } from '../ui/Toast';
 import FindGuest from '../guests/FindGuest';
 import type { Guest } from '../../types/guest';
@@ -54,14 +54,14 @@ export default function ReservationPartyPanel({
   roomTypeId,
   ratePlanId,
   totalAmount,
-  currencyCode = 'USD',
+  currencyCode,
 }: {
   reservationId: string;
   propertyId: string;
   roomTypeId?: string;
   ratePlanId?: string;
   totalAmount?: string;
-  currencyCode?: string;
+  currencyCode?: string | null;
 }) {
   const { t } = useTranslation();
   const { toast } = useToast();
@@ -166,6 +166,7 @@ export default function ReservationPartyPanel({
   const splitMutation = useMutation({
     mutationFn: () => {
       requirePropertyId(propertyId);
+      requireCurrency(currencyCode);
       return api.post(
         `/v1/reservations/${reservationId}/split`,
         {

--- a/apps/dashboard/src/pages/Accounting.tsx
+++ b/apps/dashboard/src/pages/Accounting.tsx
@@ -279,10 +279,11 @@ function AccountingHome() {
   const recordArPayment = useMutation({
     mutationFn: () => {
       requirePropertyId(propertyId);
+      requireCurrency(selectedLedger?.currencyCode ?? null);
       return api.post(`/v1/ar/ledgers/${selectedLedger!.id}/payments`, {
         propertyId,
         amount: moneyString(arPaymentAmount),
-        currencyCode: selectedLedger?.currencyCode ?? 'USD',
+        currencyCode: selectedLedger?.currencyCode,
       });
     },
     onSuccess: () => {

--- a/apps/dashboard/src/pages/Folios.tsx
+++ b/apps/dashboard/src/pages/Folios.tsx
@@ -243,14 +243,17 @@ function SplitFolioPanel({
   });
 
   const createSplitFolio = useMutation({
-    mutationFn: () =>
-      api.post('/v1/folios', {
+    mutationFn: () => {
+      requirePropertyId(propertyId);
+      requireCurrency(folio.currencyCode ?? null);
+      return api.post('/v1/folios', {
         propertyId,
         reservationId,
         guestId: folio.guestId,
         type: 'guest',
-        currencyCode: folio.currencyCode ?? 'USD',
-      }),
+        currencyCode: folio.currencyCode,
+      });
+    },
     onSuccess: () => {
       refetchSiblings();
       setSplitOpen(false);
@@ -497,7 +500,7 @@ function FolioDetail() {
   const folio: Folio | null = folioData?.data ?? folioData ?? null;
   const charges: Charge[] = chargesData?.data ?? chargesData ?? [];
   const payments: Payment[] = paymentsData?.data ?? paymentsData ?? [];
-  const currencyCode = folio?.currencyCode ?? 'USD';
+  const currencyCode = folio?.currencyCode ?? null;
 
   const reversedIds = new Set(
     charges.filter((c) => c.isReversal && c.originalChargeId).map((c) => c.originalChargeId!),

--- a/apps/dashboard/src/pages/FrontDesk.tsx
+++ b/apps/dashboard/src/pages/FrontDesk.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { ConciergeBell, LogIn, Users, LogOut, UserPlus, UsersRound, ArrowRightLeft, StickyNote, UserRound, Plus, X } from 'lucide-react';
 import { addDays, differenceInCalendarDays, format, parseISO } from 'date-fns';
 import { api } from '../lib/api';
-import { moneyString, requirePropertyId } from '../lib/api-helpers';
+import { moneyString, requirePropertyId, requireCurrency } from '../lib/api-helpers';
 import { useProperty } from '../context/PropertyContext';
 import StatusBadge from '../components/ui/StatusBadge';
 import Modal from '../components/ui/Modal';
@@ -472,6 +472,7 @@ export default function FrontDesk() {
 
       const plans: any[] = Array.isArray(ratePlans) ? ratePlans : ratePlans?.data ?? [];
       const plan = plans.find((p) => p.id === wiRatePlanId);
+      requireCurrency(plan?.currencyCode ?? null);
       const nightly = Number(plan?.baseAmount ?? 0);
       const guestId = wiGuest.id;
       const resCreate = await api.post(
@@ -486,7 +487,7 @@ export default function FrontDesk() {
           adults: 1 + primaryAdditionalIds.length,
           source: 'walk_in',
           totalAmount: moneyString(nightly * wiNights),
-          currencyCode: plan?.currencyCode ?? 'USD',
+          currencyCode: plan?.currencyCode,
         },
         { skipErrorToast: true },
       );
@@ -518,6 +519,7 @@ export default function FrontDesk() {
       for (let i = 0; i < wiExtraRooms.length; i++) {
         const extra = wiExtraRooms[i];
         const planExtra = plans.find((p) => p.id === extra.ratePlanId);
+        requireCurrency(planExtra?.currencyCode ?? null);
         const nightlyExtra = Number(planExtra?.baseAmount ?? 0);
         const extraGuestIds = [extra.guest!.id, ...extraAdditionalIds[i]];
         // Occupants must be attached to the source (primary) reservation before they
@@ -539,7 +541,7 @@ export default function FrontDesk() {
             roomTypeId: extra.roomTypeId,
             ratePlanId: extra.ratePlanId,
             totalAmount: moneyString(nightlyExtra * wiNights),
-            currencyCode: planExtra?.currencyCode ?? 'USD',
+            currencyCode: planExtra?.currencyCode,
             roomId: extra.roomId,
             adults: extraGuestIds.length,
             overrideMaxOccupancy: extra.overrideOccupancy,

--- a/apps/dashboard/src/pages/HouseAccounts.tsx
+++ b/apps/dashboard/src/pages/HouseAccounts.tsx
@@ -65,6 +65,7 @@ function HouseAccountList() {
   const createMutation = useMutation({
     mutationFn: () => {
       requirePropertyId(propertyId);
+      requireCurrency(currencyCode);
       return api.post('/v1/house-accounts', { propertyId, name, kind, currencyCode });
     },
     onSuccess: () => {
@@ -321,7 +322,7 @@ function HouseAccountDetail() {
 
   const account: HouseAccount | null = data?.data ?? data ?? null;
   const products: Product[] = productsData?.data ?? productsData ?? [];
-  const currencyCode = account?.currencyCode ?? 'USD';
+  const currencyCode = account?.currencyCode ?? null;
 
   const postCharge = useMutation({
     mutationFn: () => {

--- a/apps/dashboard/src/pages/RatePlans.tsx
+++ b/apps/dashboard/src/pages/RatePlans.tsx
@@ -541,7 +541,7 @@ function RatePlanDetail() {
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.code')}</p><p className="text-sm font-medium">{plan.code}</p></div>
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.baseAmount')}</p><p className="text-sm font-medium">{plan.baseAmount != null ? formatMoney(plan.baseAmount, currencyCode) : '—'}</p></div>
             <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.roomType')}</p><p className="text-sm font-medium">{plan.roomTypeName ?? '—'}</p></div>
-            <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.currency')}</p><p className="text-sm font-medium">{plan.currency ?? plan.currencyCode ?? 'USD'}</p></div>
+            <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.currency')}</p><p className="text-sm font-medium">{plan.currency ?? plan.currencyCode ?? '—'}</p></div>
             {plan.type === 'derived' && (
               <>
                 <div><p className="text-xs text-telivity-mid-grey">{t('ratePlans.parentRatePlan')}</p><p className="text-sm font-medium font-mono">{plan.parentRatePlanId ?? '—'}</p></div>

--- a/apps/dashboard/src/pages/Reservations.tsx
+++ b/apps/dashboard/src/pages/Reservations.tsx
@@ -73,7 +73,7 @@ function parseImportRows(text: string): Record<string, unknown>[] {
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((line) => {
+    .map((line, index) => {
       const [
         guestId,
         arrivalDate,
@@ -86,6 +86,12 @@ function parseImportRows(text: string): Record<string, unknown>[] {
         adults,
         children,
       ] = line.split(',').map((s) => s.trim());
+      if (!currencyCode) {
+        // Was `currencyCode || 'USD'`. A missing column is not a USD booking —
+        // it is a row we cannot price, and importing it as dollars against a
+        // property trading in anything else writes a wrong number to a ledger.
+        throw new Error(`Row ${index + 1}: currencyCode is required`);
+      }
       const row: Record<string, unknown> = {
         guestId,
         arrivalDate,
@@ -93,7 +99,7 @@ function parseImportRows(text: string): Record<string, unknown>[] {
         roomTypeId,
         ratePlanId,
         totalAmount: totalAmount ? moneyString(totalAmount) : undefined,
-        currencyCode: currencyCode || 'USD',
+        currencyCode,
         source: source || 'direct',
       };
       if (adults) row.adults = Number(adults);
@@ -646,7 +652,7 @@ function ReservationList() {
                 totalAmount={
                   detailRes.totalAmount != null ? String(detailRes.totalAmount) : undefined
                 }
-                currencyCode={detailRes.currencyCode ?? 'USD'}
+                currencyCode={detailRes.currencyCode ?? null}
               />
               <ReservationOpsNotes reservationId={detailRes.id} propertyId={propertyId!} />
               <ReservationMessageCompose reservationId={detailRes.id} propertyId={propertyId!} />


### PR DESCRIPTION
## The problem

#327 removed `DEFAULT_CURRENCY` from `money.ts`, so an absent currency now renders plainly instead of as dollars. The formatter is honest — but **twelve call sites in the same app still substitute `'USD'`** when a record has no code, and seven of those are sent to the API and written to a ledger.

### The sharpest case: guards that cannot fire

```ts
const currencyCode = folio?.currencyCode ?? 'USD';   // Folios.tsx:500
...
requireCurrency(currencyCode);                       // :514, :535, :554
```

`requireCurrency` can never throw there — the value it checks was made non-null one line above. Three mutations read as guarded and are not, which is worse than no guard at all: a reviewer sees the call and stops looking. `HouseAccounts.tsx:324` has the identical shape in front of its charge and payment mutations.

### Writes that sent an invented currency

| Site | |
|---|---|
| `Folios.tsx:252` | split folio create — no guard of any kind |
| `FrontDesk.tsx:489` | walk-in reservation |
| `FrontDesk.tsx:542` | reservation split |
| `Accounting.tsx:285` | A/R payment — the exact case the `requireCurrency` docblock names |
| `Reservations.tsx:96` | CSV import, per row |
| `ReservationPartyPanel` | the `currencyCode` **prop defaulted to `'USD'`**, so the caller's own `?? 'USD'` was the second of two fallbacks |
| `HouseAccounts.tsx:68` | house-account create unguarded, while `createProduct` twelve lines below is guarded |

While wiring the panel prop I found a third instance: `GuestDetailsModal` already receives `currencyCode: string | null` and renders money with it, but never passed it to `ReservationPartyPanel` — so a split started from the front-desk guest modal took the panel's `'USD'` default. Now passed through.

## What each change does

- **Writes**: drop the `?? 'USD'`, guard with `requireCurrency`. A missing code fails loudly at the call site instead of quietly becoming dollars.
- **The two defanged derivations** become `?? null`. Both values also go to `formatMoney`, which #327 already taught to render a null currency plainly — so display stays correct and the guards can now actually fire.
- **CSV import** throws naming the row number rather than importing as USD. A missing column is not a dollar booking, it's a row we can't price.
- **`RatePlans.tsx:544`** displayed `'USD'` for a plan carrying no currency — a wrong fact on screen. Now an em dash, matching every other absent field beside it.

## Not included, deliberately

`Settings.tsx:76`/`:106` seed form state to `'USD'`. That's the screen whose job is to *set* the property currency, so a default there is a different question — though note `:106` means loading a property with no currency and saving any other field stamps it USD. Happy to follow up if you'd like that changed too.

## Risk

No behaviour change for any property that has a currency set, which is every property created through the UI. The change is entirely in what happens when one is missing: it stops instead of guessing.

---

*Context, since it's relevant to why we keep finding these: we run HAIP for a 9-room lodge trading in JPY, so a fabricated `USD` isn't hypothetical here — it's a wrong number on a real ledger. Same motivation as #301 and #327.*
