### PR TITLE
fix(auth): search-availability is a query, gate it on reservations.read

### DIFF
--- a/apps/api/src/modules/auth/legacy-role-controllers-migration.spec.ts
+++ b/apps/api/src/modules/auth/legacy-role-controllers-migration.spec.ts
@@ -72,7 +72,7 @@ function permsOf(target: Function) {
 
 describe('legacy @Roles() controllers migrated to @RequirePermissions()', () => {
   it.each([
-    [ReservationController.prototype.searchAvailability, 'reservations.write'],
+    [ReservationController.prototype.searchAvailability, 'reservations.read'],
     [GuestController.prototype.createGuest, 'guests.write'],
     [GuestController.prototype.updateGuest, 'guests.write'],
     [GuestController.prototype.deleteGuest, 'guests.write'],

--- a/apps/api/src/modules/reservation/reservation.controller.ts
+++ b/apps/api/src/modules/reservation/reservation.controller.ts
@@ -54,7 +54,12 @@ export class ReservationController {
   // --- Action routes BEFORE :id to avoid conflicts ---
 
   @Post('search-availability')
-  @RequirePermissions('reservations.write')
+  // A QUERY, not a mutation. POST only because it takes a body; it
+  // reads availability and changes nothing. Gating it on
+  // reservations.write locks out every read-only caller -- notably a
+  // server integration holding reservations.read, which is exactly the
+  // shape integration_reservations describes.
+  @RequirePermissions('reservations.read')
   @ApiOperation({ summary: 'Search room availability for a date range' })
   @ApiResponse({ status: 200, description: 'Availability results' })
   searchAvailability(@Body() dto: SearchAvailabilityDto) {


### PR DESCRIPTION
`search-availability` is a **query** — it reads availability and changes nothing. It's a `POST` only because it takes a body. #340 migrated it off `@Roles()` onto `@RequirePermissions('reservations.write')` along with the 22 genuinely-write routes in the same controller.

That locks out every read-only caller. Concretely, in our deployment: a server integration account holding `reservations.read` — exactly the shape the new `integration_reservations` principal from #341 describes — started getting 403s on every availability lookup, which is the public booking page and every staff quote. Staff using the dashboard were unaffected, because their roles hold both keys, so it looked fine from the inside.

#340's own commit message explains the rule that produced it, and I think this route is where that rule mis-fires:

> the only permission key held by the whole set is then the read-only key even on a POST/PATCH/DELETE route, and using it would be a false economy — exact grantee-set match, wrong semantics

Agreed as a default. The exception is a route whose **verb is not its semantics**: here the read-only key isn't a false economy, it's the accurate one. Nothing about serving an availability search requires write access.

This changes the guard to `reservations.read` and updates the expectation in `legacy-role-controllers-migration.spec.ts`.

Worth noting the interaction with #341: `integration_reservations` grants both `reservations.read` and `reservations.write`, so a principal using that role is unaffected either way. But a narrower, genuinely read-only integration — the natural one for a public booking front end — cannot reach availability at all while this is a write.
