### PR TITLE
feat(integrations): allow settings.manage for custom integration principals

### DIFF
--- a/packages/database/src/integration-principal.ts
+++ b/packages/database/src/integration-principal.ts
@@ -46,6 +46,11 @@ export const INTEGRATION_CUSTOM_PERMISSION_ALLOWLIST: readonly string[] = [
   'rateplans.manage',
   'reports.view',
   'nightaudit.run',
+  // Channel/iCal feed CRUD and property config are settings.manage routes
+  // (ical.controller.ts, property.controller.ts, import.controller.ts). An
+  // integration that syncs OTA calendars needs it, and without it here such
+  // a principal cannot be expressed with --profile custom at all.
+  'settings.manage',
 ];
 
 export interface LinkIntegrationPrincipalInput {


### PR DESCRIPTION
`--profile custom` can't express an integration that manages iCal feeds, because `settings.manage` isn't in `INTEGRATION_CUSTOM_PERMISSION_ALLOWLIST`.

It gates OTA/channel calendar CRUD (`ical.controller.ts`), property config (`property.controller.ts`) and imports (`import.controller.ts`) — all squarely integration territory. Syncing a Booking.com calendar is close to the canonical server-to-server case, and today the only ways to grant it are operator SQL or a role built outside `integration:link`, which is exactly what #341 set out to replace.

Concretely, ours is a booking-pipeline integration holding `reservations.read/write`, `guests.write`, `rateplans.read/manage`, `folios.read/manage` and `settings.manage`. Every key except the last is already on the allowlist, so it's one key away from being expressible.

One line, and it doesn't widen any built-in profile — `custom` remains explicit and opt-in.
