### PR TITLE
feat(integrations): link one service account across multiple properties (#344)

### DIFF
--- a/docs/integrations/service-principal.md
+++ b/docs/integrations/service-principal.md
@@ -81,6 +81,21 @@ Profiles:
 
 Re-running the command is **idempotent** (same `keycloakSub` updates name; ensures role assignment).
 
+### Multi-property principals
+
+One Keycloak service account can operate on several properties: the JWT `property_ids` claim is multivalued, and `PermissionsGuard` resolves grants per request `propertyId` via `user_roles`. Link the same `keycloakSub` on each property — either run `integration:link` once per property, or pass a comma-separated list:
+
+```bash
+pnpm integration:link -- \
+  --property-id a0000001-0000-4000-a000-000000000001,b0000002-0000-4000-b000-000000000002 \
+  --keycloak-sub <sub-from-jwt> \
+  --label booking-pipeline \
+  --profile custom \
+  --permissions reservations.read,reservations.write,folios.read
+```
+
+`users.propertyId` on the local row is the principal's **home** property (set on the first link). It is not a constraint — additional properties are linked only through `user_roles`.
+
 ## 4. Verify
 
 ```bash

--- a/packages/database/src/integration-principal.link.spec.ts
+++ b/packages/database/src/integration-principal.link.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * DB integration tests for multi-property integration:link.
+ * Requires Postgres (CI sets DATABASE_URL to haip_test).
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import postgres from 'postgres';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import * as schema from './schema/index.js';
+import { postgresOptionsFromEnv } from './postgres-options.js';
+import { linkIntegrationPrincipal } from './integration-principal.js';
+
+const DATABASE_URL =
+  process.env['DATABASE_URL'] ?? 'postgresql://haip:haip@localhost:5432/haip_test';
+
+const PROP_A = 'f3440001-0000-4000-a000-000000000001';
+const PROP_B = 'f3440002-0000-4000-a000-000000000002';
+const KEYCLOAK_SUB = 'f3440003-0000-4000-a000-000000000003';
+const LABEL = 'multi-prop-test';
+
+describe('linkIntegrationPrincipal multi-property', () => {
+  const client = postgres(DATABASE_URL, postgresOptionsFromEnv());
+  const db = drizzle(client, { schema });
+
+  beforeAll(async () => {
+    for (const [id, code] of [
+      [PROP_A, 'F344A'],
+      [PROP_B, 'F344B'],
+    ] as const) {
+      const [existing] = await db
+        .select({ id: schema.properties.id })
+        .from(schema.properties)
+        .where(eq(schema.properties.id, id))
+        .limit(1);
+      if (!existing) {
+        await db.insert(schema.properties).values({
+          id,
+          name: `Issue 344 test ${code}`,
+          code,
+          countryCode: 'US',
+          timezone: 'America/New_York',
+          currencyCode: 'USD',
+          totalRooms: 10,
+        });
+      }
+    }
+  });
+
+  afterAll(async () => {
+    const email = `svc-multi-prop-test@integrations.local`;
+    const [user] = await db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.email, email))
+      .limit(1);
+    if (user) {
+      await db.delete(schema.userRoles).where(eq(schema.userRoles.userId, user.id));
+      await db.delete(schema.users).where(eq(schema.users.id, user.id));
+    }
+    await client.end();
+  });
+
+  it('links the same keycloakSub on a second property without moving home propertyId', async () => {
+    const first = await linkIntegrationPrincipal(db, {
+      propertyId: PROP_A,
+      keycloakSub: KEYCLOAK_SUB,
+      label: LABEL,
+      profile: 'inventory',
+    });
+
+    const second = await linkIntegrationPrincipal(db, {
+      propertyId: PROP_B,
+      keycloakSub: KEYCLOAK_SUB,
+      label: LABEL,
+      profile: 'inventory',
+    });
+
+    expect(second.userId).toBe(first.userId);
+    expect(second.userCreated).toBe(false);
+    expect(second.assignmentCreated).toBe(true);
+
+    const [user] = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.id, first.userId))
+      .limit(1);
+    expect(user?.propertyId).toBe(PROP_A);
+
+    const assignments = await db
+      .select({ propertyId: schema.userRoles.propertyId })
+      .from(schema.userRoles)
+      .where(eq(schema.userRoles.userId, first.userId));
+    const linkedProperties = assignments.map((a) => a.propertyId).sort();
+    expect(linkedProperties).toEqual([PROP_A, PROP_B].sort());
+  });
+});

--- a/packages/database/src/integration-principal.ts
+++ b/packages/database/src/integration-principal.ts
@@ -257,11 +257,9 @@ export async function linkIntegrationPrincipal(
 
   if (bySub) {
     userId = bySub.id;
-    if (bySub.propertyId !== propertyId) {
-      throw new Error(
-        `User linked to keycloakSub ${keycloakSub} belongs to another property (${bySub.propertyId})`,
-      );
-    }
+    // users.propertyId is the principal's home property (set on first link).
+    // Additional properties are linked via user_roles; PermissionsGuard resolves
+    // grants per request propertyId, matching the multivalued JWT property_ids claim.
     await (db as any)
       .update(users)
       .set({ name, updatedAt: new Date() })
@@ -278,10 +276,22 @@ export async function linkIntegrationPrincipal(
 
     if (emailRow) {
       userId = emailRow.id;
-      await (db as any)
-        .update(users)
-        .set({ keycloakSub, name, propertyId, status: 'active', updatedAt: new Date() })
-        .where(eq(users.id, userId));
+      const patch: {
+        keycloakSub: string;
+        name: string;
+        status: 'active';
+        updatedAt: Date;
+        propertyId?: string;
+      } = {
+        keycloakSub,
+        name,
+        status: 'active',
+        updatedAt: new Date(),
+      };
+      if (!emailRow.keycloakSub) {
+        patch.propertyId = propertyId;
+      }
+      await (db as any).update(users).set(patch).where(eq(users.id, userId));
     } else {
       const [user] = await (db as any)
         .insert(users)

--- a/packages/database/src/link-integration-principal.ts
+++ b/packages/database/src/link-integration-principal.ts
@@ -39,19 +39,32 @@ function parseArgs(argv: string[]) {
   return { args, positional };
 }
 
+function parsePropertyIds(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
 async function main() {
   const { args } = parseArgs(process.argv.slice(2));
 
-  const propertyId = args['property_id'];
+  const propertyIdRaw = args['property_id'];
   const keycloakSub = args['keycloak_sub'];
   const label = args['label'];
   const profileRaw = args['profile'] ?? 'inventory';
   const permissionsRaw = args['permissions'];
 
-  if (!propertyId || !keycloakSub || !label) {
+  if (!propertyIdRaw || !keycloakSub || !label) {
     console.error(
-      'Usage: pnpm integration:link -- --property-id <uuid> --keycloak-sub <uuid> --label <name> --profile inventory|reservations|custom [--permissions key1,key2]',
+      'Usage: pnpm integration:link -- --property-id <uuid>[,uuid...] --keycloak-sub <uuid> --label <name> --profile inventory|reservations|custom [--permissions key1,key2]',
     );
+    process.exit(1);
+  }
+
+  const propertyIds = parsePropertyIds(propertyIdRaw);
+  if (propertyIds.length === 0) {
+    console.error('At least one --property-id is required');
     process.exit(1);
   }
 
@@ -74,22 +87,24 @@ async function main() {
   const db = drizzle(client, { schema });
 
   try {
-    const result = await linkIntegrationPrincipal(db, {
-      propertyId,
-      keycloakSub,
-      label,
-      profile,
-      permissions,
-    });
+    for (const propertyId of propertyIds) {
+      const result = await linkIntegrationPrincipal(db, {
+        propertyId,
+        keycloakSub,
+        label,
+        profile,
+        permissions,
+      });
 
-    console.log('Integration principal linked:');
-    console.log(`  userId:     ${result.userId}`);
-    console.log(`  email:      ${result.email}`);
-    console.log(`  roleKey:    ${result.roleKey}`);
-    console.log(`  roleId:     ${result.roleId}`);
-    console.log(`  userCreated: ${result.userCreated}`);
-    console.log(`  roleCreated: ${result.roleCreated}`);
-    console.log(`  assignmentCreated: ${result.assignmentCreated}`);
+      console.log(`Integration principal linked (property ${propertyId}):`);
+      console.log(`  userId:     ${result.userId}`);
+      console.log(`  email:      ${result.email}`);
+      console.log(`  roleKey:    ${result.roleKey}`);
+      console.log(`  roleId:     ${result.roleId}`);
+      console.log(`  userCreated: ${result.userCreated}`);
+      console.log(`  roleCreated: ${result.roleCreated}`);
+      console.log(`  assignmentCreated: ${result.assignmentCreated}`);
+    }
   } catch (err) {
     console.error(err instanceof Error ? err.message : err);
     process.exit(1);

--- a/packages/database/src/migrations/0021_user_roles_per_property.sql
+++ b/packages/database/src/migrations/0021_user_roles_per_property.sql
@@ -1,0 +1,8 @@
+-- user_roles must be unique per property. The old unique index (user_id, role_id)
+-- blocked assigning the same system role to one integration principal across
+-- multiple properties — the shape JWT property_ids + per-property grants require.
+
+DROP INDEX IF EXISTS user_roles_user_role_unique;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_roles_user_role_unique
+  ON user_roles (user_id, role_id, property_id);

--- a/packages/database/src/push-schema.ts
+++ b/packages/database/src/push-schema.ts
@@ -1079,6 +1079,7 @@ async function main() {
       permission_key varchar(100) NOT NULL,
       created_at timestamptz NOT NULL DEFAULT now()
     )`,
+    `DROP INDEX IF EXISTS role_permissions_role_perm_unique`,
     `CREATE UNIQUE INDEX IF NOT EXISTS role_permissions_role_perm_unique ON role_permissions (property_id, role_id, permission_key)`,
     `CREATE TABLE IF NOT EXISTS user_roles (
       id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1087,7 +1088,8 @@ async function main() {
       role_id uuid NOT NULL REFERENCES roles(id),
       created_at timestamptz NOT NULL DEFAULT now()
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS user_roles_user_role_unique ON user_roles (user_id, role_id)`,
+    `DROP INDEX IF EXISTS user_roles_user_role_unique`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS user_roles_user_role_unique ON user_roles (user_id, role_id, property_id)`,
     `CREATE INDEX IF NOT EXISTS user_roles_user_idx ON user_roles (user_id)`,
     // Booking Engine — publishable keys + per-property config (guest-facing direct booking)
     `CREATE TABLE IF NOT EXISTS booking_engine_credentials (

--- a/packages/database/src/schema/rbac.ts
+++ b/packages/database/src/schema/rbac.ts
@@ -118,7 +118,11 @@ export const userRoles = pgTable(
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
-    userRoleUnique: uniqueIndex('user_roles_user_role_unique').on(t.userId, t.roleId),
+    userRoleUnique: uniqueIndex('user_roles_user_role_unique').on(
+      t.userId,
+      t.roleId,
+      t.propertyId,
+    ),
     userIdx: index('user_roles_user_idx').on(t.userId),
   }),
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements option (1) from #344 — the same Keycloak `sub` can be linked on multiple properties without operator SQL.

## Changes

- **`linkIntegrationPrincipal`**: remove the throw when an existing `keycloakSub` belongs to a different `users.propertyId`. `users.propertyId` is the principal's **home** property (set on first link only); additional properties are linked via `user_roles`.
- **CLI**: `--property-id` accepts a comma-separated list to link several properties in one invocation.
- **Schema**: `user_roles` unique index is now `(user_id, role_id, property_id)` so the same system integration role (`integration_inventory`, etc.) can be assigned per property.
- **`push-schema`**: idempotent `DROP INDEX` before recreating `role_permissions` and `user_roles` unique indexes (fixes DBs that still had the pre-#0016 `(role_id, permission_key)` index).
- **Docs**: multi-property section in `docs/integrations/service-principal.md`.
- **Test**: `integration-principal.link.spec.ts` — same `keycloakSub` on two properties keeps home `propertyId` and creates both `user_roles` rows.

## Why the index change matters

`PermissionsGuard` already resolves `getEffectivePermissions(userId, requestPropertyId)` via `user_roles.property_id`. The old `(user_id, role_id)` unique index blocked the second property assignment for built-in profiles even after removing the throw.

Closes #344.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7c49f5f-5787-421b-a6b2-ce3bb0374a4f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7c49f5f-5787-421b-a6b2-ce3bb0374a4f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

